### PR TITLE
Correctly set array type

### DIFF
--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -213,7 +213,7 @@
                 levelzero_pending = false :: boolean(),
                 levelzero_constructor :: pid(),
                 levelzero_cache = [] :: list(), % a list of gb_trees
-                levelzero_index :: erlang:array(),
+                levelzero_index :: array:array(),
                 levelzero_size = 0 :: integer(),
                 levelzero_maxcachesize :: integer(),
                 


### PR DESCRIPTION
Otherwise cannot compile in both OTP 16 and 17