### PR TITLE
Mas cdb hashtree refactor

### DIFF
--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -1330,12 +1330,12 @@ write_hash_tables(Indexes, HashTree, CurrPos) ->
     write_hash_tables(Indexes, HashTree, CurrPos, CurrPos, [], [], {0, 0, 0}).
 
 write_hash_tables([], _HashTree, _CurrPos, _BasePos, 
-                                            IndexList, HT_BinList, {T1, T2, T3}) ->
-    io:format("CDB99 ~w T1 ~w T2 ~w T3 ~w~n", [self(), T1, T2, T3]),
+                                        IndexList, HT_BinList, {T1, T2, T3}) ->
+    leveled_log:log("CDB14", [T1, T2, T3]),
     IL = lists:reverse(IndexList),
     {IL, list_to_binary(HT_BinList)};
 write_hash_tables([Index|Rest], HashTree, CurrPos, BasePos,
-                                            IndexList, HT_BinList, Timers) ->
+                                        IndexList, HT_BinList, Timers) ->
     SW1 = os:timestamp(),
     SlotMap = to_slotmap(HashTree, Index),
     T1 = timer:now_diff(os:timestamp(), SW1) + element(1, Timers),

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -258,7 +258,10 @@
     {"CDB12",
         {info, "HashTree written"}},
     {"CDB13",
-        {info, "Write options of ~w"}}
+        {info, "Write options of ~w"}},
+    {"CDB14",
+        {info, "Microsecond imings for hashtree build of "
+                ++ "to_list ~w sort ~w build ~w"}}
     
         ])).
 

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -260,9 +260,10 @@
     {"CDB13",
         {info, "Write options of ~w"}},
     {"CDB14",
-        {info, "Microsecond imings for hashtree build of "
-                ++ "to_list ~w sort ~w build ~w"}}
-    
+        {info, "Microsecond timings for hashtree build of "
+                ++ "to_list ~w sort ~w build ~w"}},
+    {"CDB15",
+        {info, "Cycle count of ~w in hashtable search higher than expected~n"}}
         ])).
 
 

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -263,7 +263,8 @@
         {info, "Microsecond timings for hashtree build of "
                 ++ "to_list ~w sort ~w build ~w"}},
     {"CDB15",
-        {info, "Cycle count of ~w in hashtable search higher than expected~n"}}
+        {info, "Cycle count of ~w in hashtable search higher than expected"
+                ++ " in search for hash ~w with result ~w"}}
         ])).
 
 


### PR DESCRIPTION
This has improved stability during hashtree recalculations, and also allowed for a general rise in throughput due to reduced CPU utilisations