### PR TITLE
Full Riak Metadata

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -363,8 +363,8 @@ build_metadata_object(PrimaryKey, MD) ->
     {Tag, _Bucket, _Key, null} = PrimaryKey,
     case Tag of
         ?RIAK_TAG ->
-            {SibCount, Vclock, _Hash, _Size} = MD,
-            riak_metadata_to_binary(Vclock, SibCount);
+            {SibData, Vclock, _Hash, _Size} = MD,
+            riak_metadata_to_binary(Vclock, SibData);
         ?STD_TAG ->
             MD
     end.
@@ -373,24 +373,60 @@ build_metadata_object(PrimaryKey, MD) ->
 riak_extract_metadata(delete, Size) ->
     {delete, null, null, Size};
 riak_extract_metadata(ObjBin, Size) ->
-    {Vclock, SibCount} = riak_metadata_from_binary(ObjBin),
-    {SibCount, Vclock, erlang:phash2(ObjBin), Size}.
+    {Vclock, SibData} = riak_metadata_from_binary(ObjBin),
+    {SibData, Vclock, erlang:phash2(ObjBin), Size}.
 
 %% <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
 %%%     VclockBin/binary, SibCount:32/integer, SibsBin/binary>>.
 
-riak_metadata_to_binary(Vclock, SibCount) ->
+riak_metadata_to_binary(Vclock, SibData) ->
     VclockBin = term_to_binary(Vclock),
     VclockLen = byte_size(VclockBin),
+    % <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
+    %         VclockBin:VclockLen/binary, SibData:32/integer>>.
+    SibCount = length(SibData),
+    SibsBin = slimbin_contents(SibData),
     <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
-            VclockBin:VclockLen/binary, SibCount:32/integer>>.
+            VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>>.
     
 riak_metadata_from_binary(V1Binary) ->
     <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
             Rest/binary>> = V1Binary,
-    <<VclockBin:VclockLen/binary, SibCount:32/integer, _Rest/binary>> = Rest,
-    {binary_to_term(VclockBin), SibCount}.
-   
+    % Just grab the Sibling count and not the full metadata
+    % <<VclockBin:VclockLen/binary, SibCount:32/integer, _Rest/binary>> = Rest,
+    % {binary_to_term(VclockBin), SibCount}.
+    <<VclockBin:VclockLen/binary, SibCount:32/integer, SibsBin/binary>> = Rest,
+    SibMetaBinList =
+        case SibCount of
+            0 ->
+                [];
+            SC when is_integer(SC) ->
+                get_metadata_from_siblings(SibsBin, SibCount, [])
+        end,
+    {binary_to_term(VclockBin), SibMetaBinList}.
+
+% Fixes the value length for each sibling to be zero, and so includes no value
+slimbin_content(MetaBin) ->
+    MetaLen = byte_size(MetaBin),
+    <<0:32/integer,  MetaLen:32/integer, MetaBin:MetaLen/binary>>.
+
+slimbin_contents(SibMetaBinList) ->
+    F = fun(MetaBin, Acc) ->
+                <<Acc/binary, (slimbin_content(MetaBin))/binary>>
+        end,
+    lists:foldl(F, <<>>, SibMetaBinList).
+    
+get_metadata_from_siblings(<<>>, 0, SibMetaBinList) ->
+    SibMetaBinList;
+get_metadata_from_siblings(<<ValLen:32/integer, Rest0/binary>>,
+                            SibCount,
+                            SibMetaBinList) ->
+    <<_ValBin:ValLen/binary, MetaLen:32/integer, Rest1/binary>> = Rest0,
+    <<MetaBin:MetaLen/binary, Rest2/binary>> = Rest1,
+    get_metadata_from_siblings(Rest2,
+                                SibCount - 1,
+                                [MetaBin|SibMetaBinList]).
+
 
 
 

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -197,8 +197,8 @@
 -define(CURRENT_FILEX, "crr").
 -define(PENDING_FILEX, "pnd").
 -define(MEMTABLE, mem).
--define(MAX_TABLESIZE, 16000). % This is less than max - but COIN_SIDECOUNT
--define(SUPER_MAX_TABLE_SIZE, 22000).
+-define(MAX_TABLESIZE, 28000). % This is less than max - but COIN_SIDECOUNT
+-define(SUPER_MAX_TABLE_SIZE, 40000).
 -define(PROMPT_WAIT_ONL0, 5).
 -define(WORKQUEUE_BACKLOG_TOLERANCE, 4).
 -define(COIN_SIDECOUNT, 5).

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -197,8 +197,8 @@
 -define(CURRENT_FILEX, "crr").
 -define(PENDING_FILEX, "pnd").
 -define(MEMTABLE, mem).
--define(MAX_TABLESIZE, 28000). % This is less than max - but COIN_SIDECOUNT
--define(SUPER_MAX_TABLE_SIZE, 40000).
+-define(MAX_TABLESIZE, 16000). % This is less than max - but COIN_SIDECOUNT
+-define(SUPER_MAX_TABLE_SIZE, 22000).
 -define(PROMPT_WAIT_ONL0, 5).
 -define(WORKQUEUE_BACKLOG_TOLERANCE, 4).
 -define(COIN_SIDECOUNT, 5).

--- a/src/leveled_sft.erl
+++ b/src/leveled_sft.erl
@@ -178,7 +178,7 @@
 -define(DWORD_SIZE, 8).
 -define(CURRENT_VERSION, {0,1}).
 -define(SLOT_COUNT, 256).
--define(SLOT_GROUPWRITE_COUNT, 64).
+-define(SLOT_GROUPWRITE_COUNT, 16).
 -define(BLOCK_SIZE, 32).
 -define(BLOCK_COUNT, 4).
 -define(FOOTERPOS_HEADERPOS, 2).

--- a/src/leveled_sft.erl
+++ b/src/leveled_sft.erl
@@ -178,7 +178,7 @@
 -define(DWORD_SIZE, 8).
 -define(CURRENT_VERSION, {0,1}).
 -define(SLOT_COUNT, 256).
--define(SLOT_GROUPWRITE_COUNT, 16).
+-define(SLOT_GROUPWRITE_COUNT, 64).
 -define(BLOCK_SIZE, 32).
 -define(BLOCK_COUNT, 4).
 -define(FOOTERPOS_HEADERPOS, 2).
@@ -188,7 +188,7 @@
 -define(COMPRESSION_LEVEL, 1).
 -define(HEADER_LEN, 56).
 -define(ITERATOR_SCANWIDTH, 1).
--define(MERGE_SCANWIDTH, 8).
+-define(MERGE_SCANWIDTH, 32).
 -define(BLOOM_WIDTH, 48).
 -define(DELETE_TIMEOUT, 10000).
 -define(MAX_KEYS, ?SLOT_COUNT * ?BLOCK_COUNT * ?BLOCK_SIZE).

--- a/src/leveled_sft.erl
+++ b/src/leveled_sft.erl
@@ -178,7 +178,7 @@
 -define(DWORD_SIZE, 8).
 -define(CURRENT_VERSION, {0,1}).
 -define(SLOT_COUNT, 256).
--define(SLOT_GROUPWRITE_COUNT, 64).
+-define(SLOT_GROUPWRITE_COUNT, 16).
 -define(BLOCK_SIZE, 32).
 -define(BLOCK_COUNT, 4).
 -define(FOOTERPOS_HEADERPOS, 2).
@@ -188,7 +188,7 @@
 -define(COMPRESSION_LEVEL, 1).
 -define(HEADER_LEN, 56).
 -define(ITERATOR_SCANWIDTH, 1).
--define(MERGE_SCANWIDTH, 32).
+-define(MERGE_SCANWIDTH, 8).
 -define(BLOOM_WIDTH, 48).
 -define(DELETE_TIMEOUT, 10000).
 -define(MAX_KEYS, ?SLOT_COUNT * ?BLOCK_COUNT * ?BLOCK_SIZE).


### PR DESCRIPTION
Originally this tested as a much worse case compared to having vector clocks alone.  However, this was due to a paging issue, the actual delta is marginal (perhaps 1-2%) assuming the extra memory doesn't push this over the tipping point of needing to page.

Given that this will allow for HEAD before PUT rather than GET before PUT, we will now assume that this change is worth it.