### PR TITLE
Stopped unnecessary seek for last_key

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -297,7 +297,9 @@
         {info, "CDB scan from start ~w in file with end ~w and last_key ~w"}},
     {"CDB17",
         {info, "After ~w PUTs total write time is ~w total sync time is ~w "
-                ++ "and max write time is ~w and max sync time is ~w"}}
+                ++ "and max write time is ~w and max sync time is ~w"}},
+    {"CDB18",
+        {info, "Handled return and write of hashtable"}}
         ])).
 
 

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -77,7 +77,7 @@ many_put_fetch_head(_Config) ->
     testutil:check_forobject(Bookie1, TestObject),
     ok = leveled_bookie:book_close(Bookie1),
     StartOpts2 = [{root_path, RootPath},
-                    {max_journalsize, 1000000000},
+                    {max_journalsize, 500000000},
                     {max_pencillercachesize, 32000},
                     {sync_strategy, testutil:sync_strategy()}],
     {ok, Bookie2} = leveled_bookie:book_start(StartOpts2),


### PR DESCRIPTION
When rolling we already know the last_key - no need to seek for it on
startup.

The time it takes for this seek needs to be considered with regards to
startup time.  Can we do without knowing lastkey?