### PR TITLE
Resolve pclerk crash

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -168,7 +168,13 @@
         {info, "Saved manifest file"}},
     {"PC019",
         {debug, "After ~s level ~w is ~w"}},
-    
+    {"PC020",
+        {warn, "Empty prompt deletions at ManifestSQN=~w"}},
+    {"PC021",
+        {info, "Prompting deletions at ManifestSQN=~w"}},
+    {"PC022",
+        {info, "Storing reference to deletions at ManifestSQN=~w"}},
+        
     {"I0001",
         {info, "Unexpected failure to fetch value for Key=~w SQN=~w "
                 ++ "with reason ~w"}},


### PR DESCRIPTION
Need to add extra logging to understand why pclerk crashes in some
volume tests.

Penciller's Clerk <0.813.0> shutdown now complete for reason
{badarg,[{dict,fetch,[63,{dict,0,16,16,8,80,48,{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]},{{[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]}}}],[{file,[100,105,99,116,46,101,114,108]},{line,126}]},{leveled_pclerk,handle_cast,2,[{file,[115,114,99,47,108,101,118,101,108,101,100,95,112,99,108,101,114,107,46,101,114,108]},{line,96}]},{gen_server,handle_msg,5,[{file,[103,101,110,95,115,101,114,118,101,114,46,101,114,108]},{line,604}]},{proc_lib,init_p_do_apply,3,[{file,[112,114,111,99,95,108,105,98,46,101,114,108]},{line,239}]}]}

Should only be prompted after prompt deletions had bene updated.
Perhaps a race whereby somehow it is prompted again after it is emptied.