### PR TITLE
`recovr` is not a valid sync strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A new database can be started by running
 {ok, Bookie} = leveled_bookie:book_start(RootPath, LedgerCacheSize, JournalSize, SyncStrategy)   
 ```
 
-This will start a new Bookie.  It will start and look for existing data files, under the RootPath, and start empty if none exist.  A LedgerCacheSize of 2000, a JournalSize of 500000000 (500MB) and a SyncStrategy of recovr should work OK.
+This will start a new Bookie.  It will start and look for existing data files, under the RootPath, and start empty if none exist.  A LedgerCacheSize of `2000`, a JournalSize of `500000000` (500MB) and a SyncStrategy of `none` should work OK.
 
 The book_start method should respond once startup is complete.  The [leveled_bookie module](src/leveled_bookie.erl) includes the full API for external use of the store.
 


### PR DESCRIPTION
If you follow the instructions in `Running Leveled` the error:

    {error,{{badmatch,{error,{{{case_clause,recovr},

is shown. `none` seems to work fine.