### PR TITLE
Mas pushmem i46

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1181,7 +1181,7 @@ maybepush_ledgercache(MaxCacheSize, Cache, Penciller) ->
     TimeToPush = maybe_withjitter(CacheSize, MaxCacheSize),
     if
         TimeToPush ->
-            CacheToLoad = {leveled_tree:from_orderedset(Tab, ?CACHE_TYPE),
+            CacheToLoad = {Tab,
                             Cache#ledger_cache.index,
                             Cache#ledger_cache.min_sqn,
                             Cache#ledger_cache.max_sqn},

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -465,7 +465,33 @@ corrupted_ledgerkey_test() ->
                                     true},
                                     [{?STD_TAG, retain}]),
     ?assertMatch(skip, TagStrat2).
+
+general_skip_strategy_test() ->
+    % Confirm that we will skip if the strategy says so
+    TagStrat1 = compact_inkerkvc({{1,
+                                        ?INKT_STND,
+                                        {?STD_TAG, "B1", "K1andSK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, skip}]),
+    ?assertMatch(skip, TagStrat1),
+    TagStrat2 = compact_inkerkvc({{1,
+                                        ?INKT_KEYD,
+                                        {?STD_TAG, "B1", "K1andSK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, skip}]),
+    ?assertMatch(skip, TagStrat2).
     
+corrupted_inker_tag_test() ->
+    % Confirm that we will skip on unknown inker tag
+    TagStrat1 = compact_inkerkvc({{1,
+                                        foo,
+                                        {?STD_TAG, "B1", "K1andSK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, retain}]),
+    ?assertMatch(skip, TagStrat1).
 
 %% Test below proved that the overhead of performing hashes was trivial
 %% Maybe 5 microseconds per hash

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -481,7 +481,28 @@ general_skip_strategy_test() ->
                                     {},
                                     true},
                                     [{?STD_TAG, skip}]),
-    ?assertMatch(skip, TagStrat2).
+    ?assertMatch(skip, TagStrat2),
+    TagStrat3 = compact_inkerkvc({{1,
+                                        ?INKT_KEYD,
+                                        {?IDX_TAG, "B1", "K1", "SK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, skip}]),
+    ?assertMatch(skip, TagStrat3),
+    TagStrat4 = compact_inkerkvc({{1,
+                                        ?INKT_KEYD,
+                                        {?IDX_TAG, "B1", "K1", "SK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, skip}, {?IDX_TAG, recalc}]),
+    ?assertMatch({recalc, null}, TagStrat4),
+    TagStrat5 = compact_inkerkvc({{1,
+                                        ?INKT_TOMB,
+                                        {?IDX_TAG, "B1", "K1", "SK"}},
+                                    {},
+                                    true},
+                                    [{?STD_TAG, skip}, {?IDX_TAG, recalc}]),
+    ?assertMatch(skip, TagStrat5).
     
 corrupted_inker_tag_test() ->
     % Confirm that we will skip on unknown inker tag

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -61,7 +61,8 @@
         generate_uuid/0,
         integer_now/0,
         riak_extract_metadata/2,
-        magic_hash/1]).         
+        magic_hash/1,
+        to_lookup/1]).         
 
 -define(V1_VERS, 1).
 -define(MAGIC, 53). % riak_kv -> riak_object
@@ -72,6 +73,14 @@
 %% Hash function contains mysterious constants, some explanation here as to
 %% what they are -
 %% http://stackoverflow.com/questions/10696223/reason-for-5381-number-in-djb-hash-function
+
+to_lookup(Key) ->
+    case element(1, Key) of
+        ?IDX_TAG ->
+            no_lookup;
+        _ ->
+            lookup
+    end.
 
 magic_hash({?RIAK_TAG, Bucket, Key, _SubKey}) ->
     magic_hash({Bucket, Key});

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -166,7 +166,8 @@
     {"PC015",
         {info, "File created"}},
     {"PC016",
-        {info, "Slow fetch from SFT ~w of ~w microseconds with result ~w"}},
+        {info, "Slow fetch from SFT ~w of ~w microseconds at level ~w "
+                    ++ "with result ~w"}},
     {"PC017",
         {info, "Notified clerk of manifest change"}},
     {"PC018",

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -267,7 +267,7 @@
     {"SST05",
         {warn, "Rename rogue filename ~s to ~s"}},
     {"SST06",
-        {info, "File ~s has been set for delete"}},
+        {debug, "File ~s has been set for delete"}},
     {"SST07",
         {info, "Exit called and now clearing ~s"}},
     {"SST08",

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -259,7 +259,7 @@
         {error, "False result returned from SST with filename ~s as "
                     ++ "slot ~w has failed crc check"}},
     {"SST03",
-        {info, "Opening SST file with filename ~s keys ~w slots ~w and"
+        {info, "Opening SST file with filename ~s slots ~w and"
                 ++ " max sqn ~w"}},
     {"SST04",
         {info, "Exit called for reason ~w on filename ~s"}},

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -853,7 +853,7 @@ fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
     L0Check = leveled_pmem:check_levelzero(Key, Hash, PosList, L0Cache),
     case L0Check of
         {false, not_found} ->
-            fetch(Key, Hash, Manifest, 0, fun timed_sst_get/3);
+            fetch(Key, Hash, Manifest, 0, fun timed_sst_get/4);
         {true, KV} ->
             {KV, 0}
     end.
@@ -865,7 +865,7 @@ fetch(Key, Hash, Manifest, Level, FetchFun) ->
         false ->
             fetch(Key, Hash, Manifest, Level + 1, FetchFun);
         FP ->
-            case FetchFun(FP, Key, Hash) of
+            case FetchFun(FP, Key, Hash, Level) of
                 not_present ->
                     fetch(Key, Hash, Manifest, Level + 1, FetchFun);
                 ObjectFound ->
@@ -873,21 +873,21 @@ fetch(Key, Hash, Manifest, Level, FetchFun) ->
             end
     end.
     
-timed_sst_get(PID, Key, Hash) ->
+timed_sst_get(PID, Key, Hash, Level) ->
     SW = os:timestamp(),
     R = leveled_sst:sst_get(PID, Key, Hash),
     T0 = timer:now_diff(os:timestamp(), SW),
-    log_slowfetch(T0, R, PID, ?SLOW_FETCH).
+    log_slowfetch(T0, R, PID, Level, ?SLOW_FETCH).
 
-log_slowfetch(T0, R, PID, FetchTolerance) ->
+log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     case {T0, R} of
         {T, R} when T < FetchTolerance ->
             R;
         {T, not_present} ->
-            leveled_log:log("PC016", [PID, T, not_present]),
+            leveled_log:log("PC016", [PID, T, Level, not_present]),
             not_present;
         {T, R} ->
-            leveled_log:log("PC016", [PID, T, found]),
+            leveled_log:log("PC016", [PID, T, Level, found]),
             R
     end.
 
@@ -1498,7 +1498,7 @@ create_file_test() ->
     ?assertMatch("hello", binary_to_term(Bin)).
 
 slow_fetch_test() ->
-    ?assertMatch(not_present, log_slowfetch(2, not_present, "fake", 1)).
+    ?assertMatch(not_present, log_slowfetch(2, not_present, "fake", 0, 1)).
 
 checkready(Pid) ->
     try

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -369,7 +369,6 @@ handle_call({push_mem, {PushedTree, PushedIdx, MinSQN, MaxSQN}},
                                         State#state.work_backlog]),
             {reply, returned, State};
         false ->
-            leveled_log:log("P0018", [ok, false, false]),
             gen_server:reply(From, ok),
             {noreply,
                 update_levelzero(State#state.levelzero_size,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -414,7 +414,6 @@ fetch(LedgerKey, Hash, State) ->
                                         State#state.blockindex_cache),
             case CachedBlockIdx of 
                 none ->
-                    io:format("Looking for key without cache~n"),
                     SlotBin = read_slot(State#state.handle, Slot),
                     {Result,
                         BlockLengths,
@@ -428,7 +427,6 @@ fetch(LedgerKey, Hash, State) ->
                         Slot#slot_index_value.slot_id,
                         State#state{blockindex_cache = BlockIndexCache}};
                 <<BlockLengths:20/binary, BlockIdx/binary>> ->
-                    io:format("Looking for key with cache~n"),
                     PosList = find_pos(BlockIdx, 
                                         double_hash(Hash, LedgerKey), 
                                         [], 
@@ -800,14 +798,11 @@ check_blocks([], _Handle, _Slot, _BlockLengths, _LedgerKey) ->
     not_present;
 check_blocks([Pos|Rest], Handle, Slot, BlockLengths, LedgerKey) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
-    io:format("Checking BlockNumber ~w in BlockPos ~w~n",
-                [BlockNumber, BlockPos]),
     BlockBin = read_block(Handle, Slot, BlockLengths, BlockNumber),
     BlockL = binary_to_term(BlockBin),
     {K, V} = lists:nth(BlockPos, BlockL),
     case K of 
         LedgerKey ->
-            io:format("Key mismatch in check_blocks~n"),
             {K, V};
         _ ->
             check_blocks(Rest, Handle, Slot, BlockLengths, LedgerKey)
@@ -816,7 +811,6 @@ check_blocks([Pos|Rest], Handle, Slot, BlockLengths, LedgerKey) ->
 
 read_block(Handle, Slot, BlockLengths, BlockID) ->
     {BlockPos, Offset, Length} = block_offsetandlength(BlockLengths, BlockID),
-    io:format("Reading offset ~w Length ~w~n", [Offset, Length]),
     {ok, BlockBin} = file:pread(Handle,
                                 Slot#slot_index_value.start_position
                                     + BlockPos
@@ -1058,7 +1052,6 @@ fetch_value([Pos|Rest], BlockLengths, Blocks, Key) ->
     {K, V} = lists:nth(BlockPos, BlockL),
     case K of 
         Key ->
-            io:format("Key mismatch in fetch_value~n"),
             {K, V};
         _ ->
             fetch_value(Rest, BlockLengths, Blocks, Key)

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1212,7 +1212,8 @@ form_slot(KVList1, KVList2, {IsBasement, TS}, no_lookup, Size, Slot, FK) ->
                         true ->
                             {KVList1,
                                 KVList2,
-                                {no_lookup, lists:reverse(Slot)}};
+                                {no_lookup, lists:reverse(Slot)},
+                                FK};
                         false ->
                             form_slot(Rem1,
                                         Rem2,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -71,7 +71,7 @@
 -define(COMPRESSION_LEVEL, 1).
 -define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_LEVEL}]).
 % -define(LEVEL_BLOOM_BITS, [{0, 8}, {1, 10}, {2, 8}, {default, 6}]).
--define(MERGE_SCANWIDTH, 4).
+-define(MERGE_SCANWIDTH, 8).
 -define(DISCARD_EXT, ".discarded").
 -define(DELETE_TIMEOUT, 10000).
 -define(TREE_TYPE, idxt).

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1334,6 +1334,18 @@ generate_indexkeys(Count, IndexList) ->
     generate_indexkeys(Count - 1, IndexList ++ Changes).
 
 
+form_slot_test() ->
+    % If a skip key happens, mustn't switch to loookup by accident as could be
+    % over the expected size
+    SkippingKV = {{o, "B1", "K9999", null}, {9999, tomb, 1234567, {}}},
+    Slot = [{{o, "B1", "K5", null}, {5, active, 99234567, {}}}],
+    R1 = form_slot([SkippingKV], [],
+                    {true, 99999999},
+                    no_lookup,
+                    ?SLOT_SIZE + 1,
+                    Slot),
+    ?assertMatch({[], [], {no_lookup, Slot}}, R1).
+
 indexed_list_test() ->
     io:format(user, "~nIndexed list timing test:~n", []),
     N = 150,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1703,11 +1703,14 @@ additional_range_test() ->
                                     2 * ?NOLOOK_SLOTSIZE + Gap + 1),
     R4 = sst_getkvrange(P1, element(1, GapSKV), element(1, PastEKV), 2),
     ?assertMatch(IK2, R4),
+    R5 = sst_getkvrange(P1, SK, element(1, PastEKV), 2),
+    IKAll = IK1 ++ IK2,
+    ?assertMatch(IKAll, R5),
     
     % Testing at a slot end
     Slot1EK = element(1, lists:last(IK1)),
-    R5 = sst_getkvrange(P1, SK, Slot1EK, 2),
-    ?assertMatch(IK1, R5).
+    R6 = sst_getkvrange(P1, SK, Slot1EK, 2),
+    ?assertMatch(IK1, R6).
     
     
 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1142,7 +1142,7 @@ merge_lists(KVList1, KVList2, LI, SlotList, SlotCount) ->
         KVRem2,
         Slot} = form_slot(KVList1, KVList2, LI, no_lookup, 0, []),
     case Slot of
-        [] ->
+        {_, []} ->
             merge_lists(KVRem1, KVRem2, LI, SlotList, SlotCount);
         _ ->
             merge_lists(KVRem1, KVRem2, LI, [Slot|SlotList], SlotCount + 1)
@@ -1345,6 +1345,18 @@ form_slot_test() ->
                     ?SLOT_SIZE + 1,
                     Slot),
     ?assertMatch({[], [], {no_lookup, Slot}}, R1).
+
+merge_tombstonelist_test() ->
+    % Merge lists wiht nothing but tombstones
+    SkippingKV1 = {{o, "B1", "K9995", null}, {9995, tomb, 1234567, {}}},
+    SkippingKV2 = {{o, "B1", "K9996", null}, {9996, tomb, 1234567, {}}},
+    SkippingKV3 = {{o, "B1", "K9997", null}, {9997, tomb, 1234567, {}}},
+    SkippingKV4 = {{o, "B1", "K9998", null}, {9998, tomb, 1234567, {}}},
+    SkippingKV5 = {{o, "B1", "K9999", null}, {9999, tomb, 1234567, {}}},
+    R = merge_lists([SkippingKV1, SkippingKV3, SkippingKV5],
+                        [SkippingKV2, SkippingKV4],
+                        {true, 9999999}),
+    ?assertMatch({[], [], []}, R).
 
 indexed_list_test() ->
     io:format(user, "~nIndexed list timing test:~n", []),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -68,7 +68,6 @@
 -define(SLOT_SIZE, 128). % This is not configurable
 -define(NOLOOK_MULT, 2). % How much bigger is a slot/block with no lookups 
 -define(NOLOOK_SLOTSIZE, ?SLOT_SIZE * ?NOLOOK_MULT).
--define(EMPTY_SLOTLIST, [{no_lookup, []}]).
 -define(COMPRESSION_LEVEL, 1).
 -define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_LEVEL}]).
 % -define(LEVEL_BLOOM_BITS, [{0, 8}, {1, 10}, {2, 8}, {default, 6}]).
@@ -161,7 +160,7 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN) ->
 sst_new(RootPath, Filename, KVL1, KVL2, IsBasement, Level, MaxSQN) ->
     {Rem1, Rem2, SlotList, FK} = merge_lists(KVL1, KVL2, {IsBasement, Level}),
     case SlotList of
-        ?EMPTY_SLOTLIST ->
+        [] ->
             empty;
         _ ->
             {ok, Pid} = gen_fsm:start(?MODULE, [], []),
@@ -1138,8 +1137,6 @@ merge_lists(KVList1, KVList2, LevelInfo) ->
 
 merge_lists(KVList1, KVList2, _LI, SlotList, FirstKey, ?MAX_SLOTS) ->
     {KVList1, KVList2, lists:reverse(SlotList), FirstKey};
-merge_lists([], [], _LI, [], null, _SlotCount) ->
-    {[], [], ?EMPTY_SLOTLIST, null};
 merge_lists([], [], _LI, SlotList, FirstKey, _SlotCount) ->
     {[], [], lists:reverse(SlotList), FirstKey};
 merge_lists(KVList1, KVList2, LI, SlotList, FirstKey, SlotCount) ->
@@ -1391,7 +1388,7 @@ merge_tombstonelist_test() ->
     R = merge_lists([SkippingKV1, SkippingKV3, SkippingKV5],
                         [SkippingKV2, SkippingKV4],
                         {true, 9999999}),
-    ?assertMatch({[], [], ?EMPTY_SLOTLIST, null}, R).
+    ?assertMatch({[], [], [], null}, R).
 
 indexed_list_test() ->
     io:format(user, "~nIndexed list timing test:~n", []),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -69,8 +69,7 @@
 -define(COMPRESSION_LEVEL, 1).
 -define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_LEVEL}]).
 % -define(LEVEL_BLOOM_BITS, [{0, 8}, {1, 10}, {2, 8}, {default, 6}]).
--define(MERGE_SCANWIDTH, 16).
--define(INDEX_MARKER_WIDTH, 16).
+-define(MERGE_SCANWIDTH, 4).
 -define(DISCARD_EXT, ".discarded").
 -define(DELETE_TIMEOUT, 10000).
 -define(TREE_TYPE, idxt).

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -161,7 +161,7 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN) ->
 sst_new(RootPath, Filename, KVL1, KVL2, IsBasement, Level, MaxSQN) ->
     {Rem1, Rem2, SlotList} = merge_lists(KVL1, KVL2, {IsBasement, Level}),
     case SlotList of
-        {_, []} ->
+        [{_, []}] ->
             empty;
         _ ->
             {ok, Pid} = gen_fsm:start(?MODULE, [], []),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1193,7 +1193,7 @@ form_slot(KVList1, KVList2, {IsBasement, TS}, no_lookup, Size, Slot) ->
                     end
             end;        
         {skipped_key, Rem1, Rem2} ->
-            form_slot(Rem1, Rem2, {IsBasement, TS}, lookup, Size, Slot)
+            form_slot(Rem1, Rem2, {IsBasement, TS}, no_lookup, Size, Slot)
     end.
 
 key_dominates(KL1, KL2, Level) ->

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -319,7 +319,7 @@ reader(get_maxsequencenumber, _From, State) ->
     Summary = State#state.summary,
     {reply, Summary#summary.max_sqn, reader, State};
 reader(print_timings, _From, State) ->
-    io:format(user, "Timings of ~w~n", [State#state.sst_timings]),
+    io:format(user, "~nTimings of ~w~n", [State#state.sst_timings]),
     {reply, ok, reader, State#state{sst_timings = undefined}};
 reader({set_for_delete, Penciller}, _From, State) ->
     leveled_log:log("SST06", [State#state.filename]),
@@ -1710,6 +1710,11 @@ additional_range_test() ->
     Slot1EK = element(1, lists:last(IK1)),
     R7 = sst_getkvrange(P1, SK, Slot1EK, 2),
     ?assertMatch(IK1, R7).
+    
+    % Testing beyond end (should never happen if manifest behaves)
+    % Test blows up anyway
+    % R8 = sst_getkvrange(P1, element(1, PastEKV), element(1, PastEKV), 2),
+    % ?assertMatch([], R8).
     
     
 


### PR DESCRIPTION
This is a combination of changes to help control the impact of constant merge activity driven by large numbers of 2i terms.

The primary alterations are:

Double the number of keys in a SST slot if none of the keys require a lookup (i.e. they are all index terms) - slow the pace of change
Try and build the SST files with less elrang term-based object copying (i.e pass binaries between processes)
Request specific blocks only when looking up objects in SST files (so whole slots are no longer lifted across from the page cache)