### PR TITLE
Remaining ledger snapshots log -> debug

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -66,7 +66,7 @@
     {"P0003",
         {debug, "Ledger snapshot ~w released"}},
     {"P0004",
-        {info, "Remaining ledger snapshots are ~w"}},
+        {debug, "Remaining ledger snapshots are ~w"}},
     {"P0005",
         {info, "Delete confirmed as file ~s is removed from Manifest"}},
     {"P0006",


### PR DESCRIPTION
This log under 2i load appears thousands of times per second.  Not
sustainable as an info log.  Will need to think about how to manage
this, but setting back to debug for now