### PR TITLE
Debug excessive log

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -134,7 +134,7 @@
     {"P0036",
         {info, "Garbage collection on manifest removes key for filename ~s"}},
     {"P0037",
-        {info, "Merging of penciller L0 tree from size ~w complete"}},
+        {debug, "Merging of penciller L0 tree from size ~w complete"}},
         
     {"PC001",
         {info, "Penciller's clerk ~w started with owner ~w"}},


### PR DESCRIPTION
Logs excessively during 2i tests.  Set to debug for now, until can think
further about this