### PR TITLE
Mas sstbinarytrim i42

### DIFF
--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1111,15 +1111,6 @@ form_slot(KVList1, KVList2, _LI, no_lookup, ?NOLOOK_SLOTSIZE, Slot, FK) ->
     {KVList1, KVList2, {no_lookup, lists:reverse(Slot)}, FK};
 form_slot(KVList1, KVList2, {IsBasement, TS}, lookup, Size, Slot, FK) ->
     case {key_dominates(KVList1, KVList2, {IsBasement, TS}), FK} of
-        {{{next_key, TopKV}, Rem1, Rem2}, null} ->
-            {TopK, _TopV} = TopKV,
-            form_slot(Rem1,
-                        Rem2,
-                        {IsBasement, TS},
-                        lookup,
-                        Size + 1,
-                        [TopKV|Slot],
-                        TopK);
         {{{next_key, TopKV}, Rem1, Rem2}, _} ->
             form_slot(Rem1,
                         Rem2,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -201,7 +201,12 @@ sst_getkvrange(Pid, StartKey, EndKey, ScanWidth) ->
                             infinity).
 
 sst_getslots(Pid, SlotList) ->
-    gen_fsm:sync_send_event(Pid, {get_slots, SlotList}, infinity).
+    SlotBins = gen_fsm:sync_send_event(Pid, {get_slots, SlotList}, infinity),
+    FetchFun =
+        fun({SlotBin, SK, EK}, Acc) ->
+            Acc ++ binaryslot_trimmedlist(SlotBin, SK, EK)
+        end,
+    lists:foldl(FetchFun, [], SlotBins).
 
 sst_getmaxsequencenumber(Pid) ->
     gen_fsm:sync_send_event(Pid, get_maxsequencenumber, infinity).
@@ -310,11 +315,7 @@ reader({get_kvrange, StartKey, EndKey, ScanWidth}, _From, State) ->
         State};
 reader({get_slots, SlotList}, _From, State) ->
     SlotBins = read_slots(State#state.handle, SlotList),
-    FetchFun =
-        fun({SlotBin, SK, EK}, Acc) ->
-            Acc ++ binaryslot_trimmedlist(SlotBin, SK, EK)
-        end,
-    {reply, lists:foldl(FetchFun, [], SlotBins), reader, State};
+    {reply, SlotBins, reader, State};
 reader(get_maxsequencenumber, _From, State) ->
     Summary = State#state.summary,
     {reply, Summary#summary.max_sqn, reader, State};
@@ -353,15 +354,7 @@ delete_pending({get_kvrange, StartKey, EndKey, ScanWidth}, _From, State) ->
         ?DELETE_TIMEOUT};
 delete_pending({get_slots, SlotList}, _From, State) ->
     SlotBins = read_slots(State#state.handle, SlotList),
-    FetchFun =
-        fun({SlotBin, SK, EK}, Acc) ->
-            Acc ++ binaryslot_trimmedlist(SlotBin, SK, EK)
-        end,
-    {reply, 
-        lists:foldl(FetchFun, [], SlotBins),
-        delete_pending,
-        State,
-        ?DELETE_TIMEOUT};
+    {reply, SlotBins, delete_pending, State, ?DELETE_TIMEOUT};
 delete_pending(close, _From, State) ->
     leveled_log:log("SST07", [State#state.filename]),
     ok = file:close(State#state.handle),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1656,7 +1656,24 @@ additional_range_test() ->
     % R8 = sst_getkvrange(P1, element(1, PastEKV), element(1, PastEKV), 2),
     % ?assertMatch([], R8).
     
-    
+
+simple_persisted_slotsize_test() ->
+    {RP, Filename} = {"../test/", "simple_slotsize_test"},
+    KVList0 = generate_randomkeys(1, ?SLOT_SIZE * 2, 1, 20),
+    KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?SLOT_SIZE),
+    [{FirstKey, _FV}|_Rest] = KVList1,
+    {LastKey, _LV} = lists:last(KVList1),
+    {ok, Pid, {FirstKey, LastKey}} = sst_new(RP,
+                                                Filename,
+                                                1,
+                                                KVList1,
+                                                length(KVList1)),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    ok = sst_close(Pid),
+    ok = file:delete(filename:join(RP, Filename ++ ".sst")).
 
 simple_persisted_test() ->
     {RP, Filename} = {"../test/", "simple_test"},


### PR DESCRIPTION
This combines two changes, which combined increase throughput under load by around 7%, and also reduce significantly average 2i query response times (under stress).

The first change is to handle the binary blocks that have been read off disk by the SST outside of the SST process -to avoid the copy thta would otherwise follow the conversion to terms.

The second change is to simplify greatly the code when trimming a set of 2i query results, and avoiding the unnecessray opening of some blocks.

With regards to the latter change, the habit of right trimming still seems dubious and may be better handled in penciller when folding.