### PR TITLE
Mas cdbcrc i31

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -581,11 +581,26 @@ corrupted_inker_tag_test() ->
 %% Test below proved that the overhead of performing hashes was trivial
 %% Maybe 5 microseconds per hash
 
-%hashperf_test() ->
-%    OL = lists:map(fun(_X) -> crypto:rand_bytes(8192) end, lists:seq(1, 10000)),
-%    SW = os:timestamp(),
-%    _HL = lists:map(fun(Obj) -> erlang:phash2(Obj) end, OL),
-%    io:format(user, "10000 object hashes in ~w microseconds~n",
-%                [timer:now_diff(os:timestamp(), SW)]).
+hashperf_test() ->
+    OL = lists:map(fun(_X) -> crypto:rand_bytes(8192) end, lists:seq(1, 1000)),
+    SW = os:timestamp(),
+    _HL = lists:map(fun(Obj) -> erlang:phash2(Obj) end, OL),
+    io:format(user, "1000 object hashes in ~w microseconds~n",
+                [timer:now_diff(os:timestamp(), SW)]).
+
+magichashperf_test() ->
+    KeyFun =
+        fun(X) ->
+            K = {o, "Bucket", "Key" ++ integer_to_list(X), null},
+            {K, X}
+        end,
+    KL = lists:map(KeyFun, lists:seq(1, 1000)),
+    {TimeMH, _HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
+    io:format(user, "1000 keys magic hashed in ~w microseconds~n", [TimeMH]),
+    {TimePH, _Hl2} = timer:tc(lists, map, [fun(K) -> erlang:phash2(K) end, KL]),
+    io:format(user, "1000 keys phash2 hashed in ~w microseconds~n", [TimePH]),
+    {TimeMH2, _HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
+    io:format(user, "1000 keys magic hashed in ~w microseconds~n", [TimeMH2]).
+
 
 -endif.

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -433,8 +433,7 @@ riak_extract_metadata(ObjBin, Size) ->
 %% <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
 %%%     VclockBin/binary, SibCount:32/integer, SibsBin/binary>>.
 
-riak_metadata_to_binary(Vclock, SibData) ->
-    VclockBin = term_to_binary(Vclock),
+riak_metadata_to_binary(VclockBin, SibData) ->
     VclockLen = byte_size(VclockBin),
     % <<?MAGIC:8/integer, ?V1_VERS:8/integer, VclockLen:32/integer,
     %         VclockBin:VclockLen/binary, SibData:32/integer>>.
@@ -455,7 +454,7 @@ riak_metadata_from_binary(V1Binary) ->
             SC when is_integer(SC) ->
                 get_metadata_from_siblings(SibsBin, SibCount, [])
         end,
-    {binary_to_term(VclockBin), SibMetaBinList}.
+    {VclockBin, SibMetaBinList}.
 
 % Fixes the value length for each sibling to be zero, and so includes no value
 slimbin_content(MetaBin) ->

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -46,7 +46,7 @@ simple_put_fetch_head_delete(_Config) ->
     ok = leveled_bookie:book_put(Bookie2, "Bucket1", "Key2", "Value2",
                                     [{add, "Index1", "Term1"}]),
     {ok, "Value2"} = leveled_bookie:book_get(Bookie2, "Bucket1", "Key2"),
-    {ok, {62888926, 56}} = leveled_bookie:book_head(Bookie2,
+    {ok, {62888926, 60}} = leveled_bookie:book_head(Bookie2,
                                                     "Bucket1",
                                                     "Key2"),
     testutil:check_formissingobject(Bookie2, "Bucket1", "Key2"),


### PR DESCRIPTION
This change stops the attempt to compress the object using term_to_binary, and uses an accumulating binary instead - compressing with zlib during compaction.

This reduces the CPU load.  ct tests now run much faster, with about a 3% improvement in volume tests.

Some though needs to be given in the future making compression at PUT time a configurable option.

Nothing has been changed for issue 34 - the CRC is still inbuilt within the CDB process.