### PR TITLE
Change default compaction settings

### DIFF
--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -467,7 +467,7 @@ load_and_count_withdelete(_Config) ->
 space_clear_ondelete(_Config) ->
     RootPath = testutil:reset_filestructure(),
     StartOpts1 = [{root_path, RootPath},
-                    {max_journalsize, 20000000},
+                    {max_journalsize, 10000000},
                     {sync_strategy, testutil:sync_strategy()}],
     {ok, Book1} = leveled_bookie:book_start(StartOpts1),
     G2 = fun testutil:generate_compressibleobjects/2,
@@ -586,7 +586,7 @@ space_clear_ondelete(_Config) ->
     io:format("FNsD - Bookie has ~w ledger files " ++
                     "after second close~n", [length(FNsD_L)]),
     lists:foreach(fun(FN) -> 
-                        io:format("FNsD - Ledger file if ~s~n", [FN]) 
+                        io:format("FNsD - Ledger file is ~s~n", [FN]) 
                     end, 
                     FNsD_L),
     true = PointB_Journals < length(FNsA_J),


### PR DESCRIPTION
Need to allow specific settings to be passed into unit tests.

Also, too much journal compaction may lead to intermittent failures on
the basic_SUITE space_clear_on_delete test.  think this is because
there are less “deletes” to reload in on startup to trigger the cascade
down and clear up?