### PR TITLE
Fix dialyzer warnings for newer erlang releases

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -51,12 +51,12 @@
                         max_run_length}).
 
 -record(penciller_options,
-                        {root_path :: string(),
-                        max_inmemory_tablesize :: integer(),
+                        {root_path :: string() | undefined,
+                        max_inmemory_tablesize :: integer() | undefined,
                         start_snapshot = false :: boolean(),
                         snapshot_query,
-                        bookies_mem :: tuple(),
-                        source_penciller :: pid(),
+                        bookies_mem :: tuple() | undefined,
+                        source_penciller :: pid() | undefined,
                         snapshot_longrunning = true :: boolean(),
                         levelzero_cointoss = false :: boolean()}).
 

--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -43,7 +43,7 @@
 -record(inker_options,
                         {cdb_max_size :: integer() | undefined,
                         root_path :: string() | undefined,
-                        cdb_options :: #cdb_options{},
+                        cdb_options :: #cdb_options{} | undefined,
                         start_snapshot = false :: boolean(),
                         source_inker :: pid() | undefined,
                         reload_strategy = [] :: list(),
@@ -106,4 +106,3 @@
           vclock,
           updatemetadata=dict:store(clean, true, dict:new()),
           updatevalue :: term()}).
- 

--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -34,11 +34,11 @@
                          filename :: string() | undefined}).
 
 -record(cdb_options,
-                        {max_size :: integer(),
-                        file_path :: string() | undefined,
-                        waste_path :: string() | undefined,
-                        binary_mode = false :: boolean(),
-                        sync_strategy = sync}).
+                        {max_size :: integer() | undefined,
+                         file_path :: string() | undefined,
+                         waste_path :: string() | undefined,
+                         binary_mode = false :: boolean(),
+                         sync_strategy = sync}).
 
 -record(inker_options,
                         {cdb_max_size :: integer() | undefined,
@@ -61,11 +61,11 @@
                         levelzero_cointoss = false :: boolean()}).
 
 -record(iclerk_options,
-                        {inker :: pid(),
-                        max_run_length :: integer(),
-                        cdb_options = #cdb_options{} :: #cdb_options{},
-                        waste_retention_period :: integer(),
-                        reload_strategy = [] :: list()}).
+                        {inker :: pid() | undefined,
+                         max_run_length :: integer() | undefined,
+                         cdb_options = #cdb_options{} :: #cdb_options{},
+                         waste_retention_period :: integer() | undefined,
+                         reload_strategy = [] :: list()}).
 
 -record(recent_aae, {filter :: whitelist|blacklist,
                         % the buckets list should either be a

--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -35,19 +35,19 @@
 
 -record(cdb_options,
                         {max_size :: integer(),
-                        file_path :: string(),
-                        waste_path :: string(),
+                        file_path :: string() | undefined,
+                        waste_path :: string() | undefined,
                         binary_mode = false :: boolean(),
                         sync_strategy = sync}).
 
 -record(inker_options,
-                        {cdb_max_size :: integer(),
-                        root_path :: string(),
+                        {cdb_max_size :: integer() | undefined,
+                        root_path :: string() | undefined,
                         cdb_options :: #cdb_options{},
                         start_snapshot = false :: boolean(),
-                        source_inker :: pid(),
+                        source_inker :: pid() | undefined,
                         reload_strategy = [] :: list(),
-                        waste_retention_period :: integer(),
+                        waste_retention_period :: integer() | undefined,
                         max_run_length}).
 
 -record(penciller_options,

--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -28,10 +28,10 @@
                         timestamp :: integer()}).                      
 
 -record(manifest_entry,
-                        {start_key :: tuple(),
-                        end_key :: tuple(),
-                        owner :: pid()|list(),
-                        filename :: string()}).
+                        {start_key :: tuple() | undefined,
+                         end_key :: tuple() | undefined,
+                         owner :: pid()|list(),
+                         filename :: string() | undefined}).
 
 -record(cdb_options,
                         {max_size :: integer(),

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -92,15 +92,15 @@
                         min_sqn = infinity :: integer()|infinity,
                         max_sqn = 0 :: integer()}).
 
--record(state, {inker :: pid(),
-                penciller :: pid(),
-                cache_size :: integer(),
-                recent_aae :: false|#recent_aae{},
+-record(state, {inker :: pid() | undefined,
+                penciller :: pid() | undefined,
+                cache_size :: integer() | undefined,
+                recent_aae :: false | #recent_aae{} | undefined,
                 ledger_cache = #ledger_cache{},
-                is_snapshot :: boolean(),
+                is_snapshot :: boolean() | undefined,
                 slow_offer = false :: boolean(),
-                put_timing :: tuple(),
-                get_timing :: tuple()}).
+                put_timing :: tuple() | undefined,
+                get_timing :: tuple() | undefined}).
 
 
 %%%============================================================================

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -99,17 +99,17 @@
 -define(DELETE_TIMEOUT, 10000).
 
 -record(state, {hashtree,
-                last_position :: integer(),
+                last_position :: integer() | undefined,
                 last_key = empty,
                 hash_index = {} :: tuple(),
-                filename :: string(),
-                handle :: file:fd(),
-                max_size :: integer(),
+                filename :: string() | undefined,
+                handle :: file:fd() | undefined,
+                max_size :: integer() | undefined,
                 binary_mode = false :: boolean(),
                 delete_point = 0 :: integer(),
-                inker :: pid(),
+                inker :: pid() | undefined,
                 deferred_delete = false :: boolean(),
-                waste_path :: string(),
+                waste_path :: string() | undefined,
                 sync_strategy = none}).
 
 -type cdb_options() :: #cdb_options{}.

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -104,17 +104,17 @@
 -define(DEFAULT_WASTE_RETENTION_PERIOD, 86400).
 -define(INTERVALS_PER_HOUR, 4).
 
--record(state, {inker :: pid(),
-                    max_run_length :: integer(),
-                    cdb_options,
-                    waste_retention_period :: integer(),
-                    waste_path :: string(),
-                    reload_strategy = ?DEFAULT_RELOAD_STRATEGY :: list()}).
+-record(state, {inker :: pid() | undefined,
+                max_run_length :: integer() | undefined,
+                cdb_options,
+                waste_retention_period :: integer() | undefined,
+                waste_path :: string() | undefined,
+                reload_strategy = ?DEFAULT_RELOAD_STRATEGY :: list()}).
 
--record(candidate, {low_sqn :: integer(),
-                    filename :: string(),
-                    journal :: pid(),
-                    compaction_perc :: float()}).
+-record(candidate, {low_sqn :: integer() | undefined,
+                    filename :: string() | undefined,
+                    journal :: pid() | undefined,
+                    compaction_perc :: float() | undefined}).
 
 
 %%%============================================================================

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -128,15 +128,15 @@
 -record(state, {manifest = [] :: list(),
 				manifest_sqn = 0 :: integer(),
                 journal_sqn = 0 :: integer(),
-                active_journaldb :: pid(),
+                active_journaldb :: pid() | undefined,
                 pending_removals = [] :: list(),
                 registered_snapshots = [] :: list(),
-                root_path :: string(),
-                cdb_options :: #cdb_options{},
-                clerk :: pid(),
+                root_path :: string() | undefined,
+                cdb_options :: #cdb_options{} | undefined,
+                clerk :: pid() | undefined,
                 compaction_pending = false :: boolean(),
                 is_snapshot = false :: boolean(),
-                source_inker :: pid()}).
+                source_inker :: pid() | undefined}).
 
 
 -type inker_options() :: #inker_options{}.

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -47,8 +47,8 @@
 -define(MAX_TIMEOUT, 2000).
 -define(MIN_TIMEOUT, 200).
 
--record(state, {owner :: pid(),
-                root_path :: string(),
+-record(state, {owner :: pid() | undefined,
+                root_path :: string() | undefined,
                 pending_deletions = dict:new() % OTP 16 does not like type
                 }).
 

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -223,25 +223,25 @@
                 ledger_sqn = 0 :: integer(), % The highest SQN added to L0
                 root_path = "../test" :: string(),
                 
-                clerk :: pid(),
+                clerk :: pid() | undefined,
                 
                 levelzero_pending = false :: boolean(),
-                levelzero_constructor :: pid(),
+                levelzero_constructor :: pid() | undefined,
                 levelzero_cache = [] :: list(), % a list of trees
                 levelzero_size = 0 :: integer(),
-                levelzero_maxcachesize :: integer(),
+                levelzero_maxcachesize :: integer() | undefined,
                 levelzero_cointoss = false :: boolean(),
                 levelzero_index, % An array
                 
                 is_snapshot = false :: boolean(),
                 snapshot_fully_loaded = false :: boolean(),
-                source_penciller :: pid(),
-                levelzero_astree :: list(),
+                source_penciller :: pid() | undefined,
+                levelzero_astree :: list() | undefined,
                 
                 work_ongoing = false :: boolean(), % i.e. compaction work
                 work_backlog = false :: boolean(), % i.e. compaction work
                 
-                head_timing :: tuple()}).
+                head_timing :: tuple() | undefined}).
 
 -type penciller_options() :: #penciller_options{}.
 -type bookies_memory() :: {tuple()|empty_cache,
@@ -1269,9 +1269,7 @@ keyfolder({[{IMMKey, IMMVal}|NxIMMiterator], SSTiterator}, KeyRange,
 
 
 generate_randomkeys({Count, StartSQN}) ->
-    generate_randomkeys(Count, StartSQN, []);
-generate_randomkeys(Count) ->
-    generate_randomkeys(Count, 0, []).
+    generate_randomkeys(Count, StartSQN, []).
 
 generate_randomkeys(0, _SQN, Acc) ->
     lists:reverse(Acc);
@@ -1622,7 +1620,7 @@ foldwithimm_simple_test() ->
 create_file_test() ->
     {RP, Filename} = {"../test/", "new_file.sst"},
     ok = file:write_file(filename:join(RP, Filename), term_to_binary("hello")),
-    KVL = lists:usort(generate_randomkeys(10000)),
+    KVL = lists:usort(generate_randomkeys({10000, 0})),
     Tree = leveled_tree:from_orderedlist(KVL, ?CACHE_TYPE),
     FetchFun = fun(Slot) -> lists:nth(Slot, [Tree]) end,
     {ok,

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -61,7 +61,7 @@
                         % an array of lists or trees representing the manifest
                     manifest_sqn = 0 :: integer(),
                         % The current manifest SQN
-                    snapshots :: list(),
+                    snapshots :: list() | undefined,
                         % A list of snaphots (i.e. clones)
                     min_snapshot_sqn = 0 :: integer(),
                         % The smallest snapshot manifest SQN in the snapshot

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -117,7 +117,7 @@
 
 -record(summary,    {first_key :: tuple(),
                         last_key :: tuple(),
-                        index :: tuple(), 
+                     index :: tuple() | undefined,
                         size :: integer(),
                         max_sqn :: integer()}).
 
@@ -129,9 +129,9 @@
 %% extra copying.  Files at the top of the tree yield, those lower down don't.
 
 -record(state,      {summary,
-                        handle :: file:fd(),
-                        sst_timings :: tuple(),
-                        penciller :: pid(),
+                     handle :: file:fd() | undefined,
+                     sst_timings :: tuple() | undefined,
+                     penciller :: pid() | undefined,
                         root_path,
                         filename,
                         yield_blockquery = false :: boolean(),


### PR DESCRIPTION
With recent releases, dialyzers behavior for records changed slightly. While fields used to get an implicit `| undefined` as their type this now needs to be made explicit.

i.e. in R17 and below the following two lines are identical from dialyzers perspective
```erlang
-record(state, {value :: integer()}).
%%% resulted in the type:
-record(state, {value :: integer() | undefined}).
```

in R18 and upwards they are not.

This PR adds the `| undefined` to all records that require them to prevent ~200 warnings when executing dialyzer w/ R19