### PR TITLE
Mas i103 coverage

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -453,7 +453,7 @@ gen_indexspec(Bucket, Key, IdxOp, IdxField, IdxTerm, SQN, TTL) ->
 %% Generate an additional index term representing the change, if the last
 %% modified date for the change is within the definition of recency.
 %%
-%% The objetc may have multiple last modified dates (siblings), and in this
+%% The object may have multiple last modified dates (siblings), and in this
 %% case index entries for all dates within the range are added.
 %%
 %% The index should entry auto-expire in the future (when it is no longer
@@ -907,5 +907,20 @@ genaaeidx_test() ->
                             buckets=[<<"Bucket0">>]},
     AAESpecsB2 = aae_indexspecs(AAE1, <<"Bucket0">>, Key, SQN, H, LastMods1),
     ?assertMatch(0, length(AAESpecsB2)).
+
+delayedupdate_aaeidx_test() ->
+    AAE = #recent_aae{filter=blacklist,
+                        buckets=[],
+                        limit_minutes=60,
+                        unit_minutes=5},
+    Bucket = <<"Bucket1">>,
+    Key = <<"Key1">>,
+    SQN = 1,
+    H = erlang:phash2(null),
+    {Mega, Sec, MSec} = os:timestamp(),
+    LastMods = [{Mega -1, Sec, MSec}],
+    AAESpecs = aae_indexspecs(AAE, Bucket, Key, SQN, H, LastMods),
+    ?assertMatch(0, length(AAESpecs)).
+
 
 -endif.

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -116,14 +116,24 @@
                     journal :: pid() | undefined,
                     compaction_perc :: float() | undefined}).
 
+-type iclerk_options() :: #iclerk_options{}.
 
 %%%============================================================================
 %%% API
 %%%============================================================================
 
+-spec clerk_new(iclerk_options()) -> {ok, pid()}.
+%% @doc
+%% Generate a new clerk
 clerk_new(InkerClerkOpts) ->
     gen_server:start(?MODULE, [InkerClerkOpts], []).
-    
+
+-spec clerk_compact(pid(), pid(), 
+                    fun(), fun(), fun(),  
+                    pid(), integer()) -> ok.
+%% @doc
+%% Trigger a compaction for this clerk if the threshold of data recovery has 
+%% been met
 clerk_compact(Pid, Checker, InitiateFun, CloseFun, FilterFun, Inker, TimeO) ->
     gen_server:cast(Pid,
                     {compact,
@@ -134,10 +144,18 @@ clerk_compact(Pid, Checker, InitiateFun, CloseFun, FilterFun, Inker, TimeO) ->
                     Inker,
                     TimeO}).
 
+-spec clerk_hashtablecalc(ets:tid(), integer(), pid()) -> ok.
+%% @doc
+%% Spawn a dedicated clerk for the process of calculating the binary view
+%% of the hastable in the CDB file - so that the file is not blocked during
+%% this calculation
 clerk_hashtablecalc(HashTree, StartPos, CDBpid) ->
     {ok, Clerk} = gen_server:start(?MODULE, [#iclerk_options{}], []),
     gen_server:cast(Clerk, {hashtable_calc, HashTree, StartPos, CDBpid}).
 
+-spec clerk_stop(pid()) -> ok.
+%% @doc
+%% Stop the clerk
 clerk_stop(Pid) ->
     gen_server:cast(Pid, stop).
 
@@ -240,6 +258,10 @@ code_change(_OldVsn, State, _Extra) ->
 %%% External functions
 %%%============================================================================
 
+-spec schedule_compaction(list(integer()), 
+                            integer(), 
+                            {integer(), integer(), integer()}) -> integer().
+%% @doc
 %% Schedule the next compaction event for this store.  Chooses a random
 %% interval, and then a random start time within the first third
 %% of the interval.
@@ -256,7 +278,6 @@ code_change(_OldVsn, State, _Extra) ->
 %%
 %% Current TS should be the outcome of os:timestamp()
 %%
-
 schedule_compaction(CompactionHours, RunsPerDay, CurrentTS) ->
     % We chedule the next interval by acting as if we were scheduing all
     % n intervals at random, but then only chose the next one.  After each
@@ -318,7 +339,12 @@ check_single_file(CDB, FilterFun, FilterServer, MaxSQN, SampleSize, BatchSize) -
     FN = leveled_cdb:cdb_filename(CDB),
     PositionList = leveled_cdb:cdb_getpositions(CDB, SampleSize),
     KeySizeList = fetch_inbatches(PositionList, BatchSize, CDB, []),
-    
+    Score = 
+        size_comparison_score(KeySizeList, FilterFun, FilterServer, MaxSQN),
+    leveled_log:log("IC004", [FN, Score]),
+    Score.
+
+size_comparison_score(KeySizeList, FilterFun, FilterServer, MaxSQN) ->
     FoldFunForSizeCompare =
         fun(KS, {ActSize, RplSize}) ->
             case KS of
@@ -333,20 +359,22 @@ check_single_file(CDB, FilterFun, FilterServer, MaxSQN, SampleSize, BatchSize) -
                             {ActSize, RplSize + Size - ?CRC_SIZE}
                     end;
                 _ ->
+                    % There is a key which is not in expected format
+                    % Not that the key-size list has been filtered for
+                    % errors by leveled_cdb - but this doesn't know the 
+                    % expected format of the key
                     {ActSize, RplSize}
             end
             end,
             
     R0 = lists:foldl(FoldFunForSizeCompare, {0, 0}, KeySizeList),
     {ActiveSize, ReplacedSize} = R0,
-    Score = case ActiveSize + ReplacedSize of
-                0 ->
-                    100.0;
-                _ ->
-                    100 * ActiveSize / (ActiveSize + ReplacedSize)
-            end,
-    leveled_log:log("IC004", [FN, Score]),
-    Score.
+    case ActiveSize + ReplacedSize of
+        0 ->
+            100.0;
+        _ ->
+            100 * ActiveSize / (ActiveSize + ReplacedSize)
+    end.
 
 scan_all_files(Manifest, FilterFun, FilterServer, MaxSQN) ->
     scan_all_files(Manifest, FilterFun, FilterServer, MaxSQN, []).
@@ -979,6 +1007,22 @@ compact_singlefile_totwosmallfiles_testto() ->
                     ManifestSlice),
     ok = leveled_cdb:cdb_deletepending(CDBr),
     ok = leveled_cdb:cdb_destroy(CDBr).
+
+size_score_test() ->
+    KeySizeList = 
+        [{{1, "INK", "Key1"}, 104},
+            {{2, "INK", "Key2"}, 124},
+            {{3, "INK", "Key3"}, 144},
+            {{4, "INK", "Key4"}, 154},
+            {{5, "INK", "Key5", "Subk1"}, 164},
+            {{6, "INK", "Key6"}, 174},
+            {{7, "INK", "Key7"}, 184}],
+    MaxSQN = 6,
+    CurrentList = ["Key1", "Key4", "Key5", "Key6"],
+    FilterFun = fun(L, K, _SQN) -> lists:member(K, L) end,
+    Score = size_comparison_score(KeySizeList, FilterFun, CurrentList, MaxSQN),
+    ?assertMatch(true, Score > 69.0),
+    ?assertMatch(true, Score < 70.0).
 
 coverage_cheat_test() ->
     {noreply, _State0} = handle_info(timeout, #state{}),

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -91,7 +91,7 @@
 
 -define(JOURNAL_FILEX, "cdb").
 -define(PENDING_FILEX, "pnd").
--define(SAMPLE_SIZE, 200).
+-define(SAMPLE_SIZE, 100).
 -define(BATCH_SIZE, 32).
 -define(BATCHES_TO_CHECK, 8).
 %% How many consecutive files to compact in one run

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -338,7 +338,7 @@ schedule_compaction(CompactionHours, RunsPerDay, CurrentTS) ->
 %% @doc
 %% Get a score for a single CDB file in the journal.  This will pull out a bunch 
 %% of keys and sizes at random in an efficient way (by scanning the hashtable
-%% then just picking the key and siz einformation of disk).
+%% then just picking the key and size information of disk).
 %% 
 %% The score should represent a percentage which is the size of the file by 
 %% comparison to the original file if compaction was to be run.  So if a file 

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -335,6 +335,17 @@ schedule_compaction(CompactionHours, RunsPerDay, CurrentTS) ->
 %%%============================================================================
 
 
+%% @doc
+%% Get a score for a single CDB file in the journal.  This will pull out a bunch 
+%% of keys and sizes at random in an efficient way (by scanning the hashtable
+%% then just picking the key and siz einformation of disk).
+%% 
+%% The score should represent a percentage which is the size of the file by 
+%% comparison to the original file if compaction was to be run.  So if a file 
+%% can be reduced in size by 30% the score will be 70%.
+%% 
+%% The score is based on a random sample - so will not be consistent between 
+%% calls.
 check_single_file(CDB, FilterFun, FilterServer, MaxSQN, SampleSize, BatchSize) ->
     FN = leveled_cdb:cdb_filename(CDB),
     PositionList = leveled_cdb:cdb_getpositions(CDB, SampleSize),

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -327,11 +327,7 @@
         {info, "After ~w PUTs total write time is ~w total sync time is ~w "
                 ++ "and max write time is ~w and max sync time is ~w"}},
     {"CDB18",
-        {info, "Handled return and write of hashtable"}},
-    {"CDB19",
-        {info, "Transferring filename ~s to waste ~s"}},
-    {"CDB20",
-        {info, "Deleting filename ~s as no waste retention period defined"}}
+        {info, "Handled return and write of hashtable"}}
         ]).
 
 


### PR DESCRIPTION
|------------------------|------------|

  |                module  |  coverage  |

  |------------------------|------------|

  |        leveled_bookie  |      100%  |

  |           leveled_cdb  |      100%  |

  |         leveled_codec  |      100%  |

  |        leveled_iclerk  |      100%  |

  |     leveled_imanifest  |      100%  |

  |         leveled_inker  |      100%  |

  |           leveled_log  |      100%  |

  |        leveled_pclerk  |      100%  |

  |     leveled_penciller  |      100%  |

  |     leveled_pmanifest  |      100%  |

  |          leveled_pmem  |      100%  |

  |          leveled_rand  |      100%  |

  |        leveled_runner  |      100%  |

  |           leveled_sst  |      100%  |

  |        leveled_tictac  |      100%  |

  |     leveled_tinybloom  |      100%  |

  |          leveled_tree  |      100%  |

  |------------------------|------------|

  |                 total  |      100%  |

  |------------------------|------------|

  coverage calculated from:

    /Users/martinsumner/dbroot/leveled/_build/test/cover/ct.coverdata

    /Users/martinsumner/dbroot/leveled/_build/test/cover/eunit.coverdata

Hopefully can maintain leveled going forward with 100% test coverage.  I don't have an automated CI at this stage - but intention is to insert a test coverage check into the pull process to confirm full test coverage is maintained