### PR TITLE
Mas otp19 dialyzer

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -48,8 +48,8 @@
                         source_inker :: pid() | undefined,
                         reload_strategy = [] :: list(),
                         waste_retention_period :: integer() | undefined,
-                        compression_method :: lz4|native,
-                        compress_on_receipt :: boolean(),
+                        compression_method = native :: lz4|native,
+                        compress_on_receipt = false :: boolean(),
                         max_run_length}).
 
 -record(penciller_options,
@@ -60,7 +60,7 @@
                         bookies_mem :: tuple() | undefined,
                         source_penciller :: pid() | undefined,
                         snapshot_longrunning = true :: boolean(),
-                        compression_method :: lz4|native,
+                        compression_method = native :: lz4|native,
                         levelzero_cointoss = false :: boolean()}).
 
 -record(iclerk_options,
@@ -68,7 +68,7 @@
                          max_run_length :: integer() | undefined,
                          cdb_options = #cdb_options{} :: #cdb_options{},
                          waste_retention_period :: integer() | undefined,
-                         compression_method :: lz4|native,
+                         compression_method = native :: lz4|native,
                          reload_strategy = [] :: list()}).
 
 -record(recent_aae, {filter :: whitelist|blacklist,

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [warnings_as_errors,
-            {platform_define, "18", old_rand},
+            {platform_define, "^1[7-8]{1}", old_rand},
             {platform_define, "^R", old_rand},
             {platform_define, "^R", no_sync}]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,5 @@
 {erl_opts, [warnings_as_errors,
             {platform_define, "18", old_rand},
-            {platform_define, "17", old_rand},
             {platform_define, "^R", old_rand},
             {platform_define, "^R", no_sync}]}.
 

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -109,7 +109,7 @@
                 waste_retention_period :: integer() | undefined,
                 waste_path :: string() | undefined,
                 reload_strategy = ?DEFAULT_RELOAD_STRATEGY :: list(),
-                compression_method :: lz4|native}).
+                compression_method = native :: lz4|native}).
 
 -record(candidate, {low_sqn :: integer() | undefined,
                     filename :: string() | undefined,

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -136,8 +136,8 @@
                 clerk :: pid() | undefined,
                 compaction_pending = false :: boolean(),
                 is_snapshot = false :: boolean(),
-                compression_method :: lz4|native,
-                compress_on_receipt :: boolean(),
+                compression_method = native :: lz4|native,
+                compress_on_receipt = false :: boolean(),
                 source_inker :: pid() | undefined}).
 
 

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -50,7 +50,7 @@
 -record(state, {owner :: pid() | undefined,
                 root_path :: string() | undefined,
                 pending_deletions = dict:new(), % OTP 16 does not like type
-                compression_method :: lz4|native
+                compression_method = native :: lz4|native
                 }).
 
 %%%============================================================================

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -246,7 +246,7 @@
                 
                 head_timing :: tuple() | undefined,
                 
-                compression_method :: lz4|native}).
+                compression_method = native :: lz4|native}).
 
 -type penciller_options() :: #penciller_options{}.
 -type bookies_memory() :: {tuple()|empty_cache,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -140,7 +140,7 @@
                     filename,
                     yield_blockquery = false :: boolean(),
                     blockindex_cache,
-                    compression_method :: press_methods()}).
+                    compression_method = native :: press_methods()}).
 
 -type sst_state() :: #state{}.
 


### PR DESCRIPTION
Since High Sierra upgrade having a separate line for platform_define 17 caused issues.

OTP 19 seemingly matched against it.  OTP 18 had a redefine issue as it appeared to match against it as well.

Using this regex instead seems to work.  Why? Why was this not an issue before High Sierra?