### PR TITLE
Mas i134 compileflag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, [warnings_as_errors,
+	    {platform_define, "^2[0-1]{1}", fsm_deprecated},
             {platform_define, "^1[7-8]{1}", old_rand},
             {platform_define, "^R", old_rand},
             {platform_define, "^R", no_sync}]}.

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -46,6 +46,17 @@
 -behaviour(gen_fsm).
 -include("include/leveled.hrl").
 
+
+-ifdef(fsm_deprecated).
+-compile({nowarn_deprecated_function, 
+            [{gen_fsm, start, 3},
+                {gen_fsm, sync_send_event, 3},
+                {gen_fsm, sync_send_event, 2},
+                {gen_fsm, send_event, 2},
+                {gen_fsm, sync_send_all_state_event, 3},
+                {gen_fsm, send_all_state_event, 2}]}).
+-endif.
+
 -export([init/1,
             handle_sync_event/4,
             handle_event/3,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -62,6 +62,14 @@
 
 -behaviour(gen_fsm).
 
+-ifdef(fsm_deprecated).
+-compile({nowarn_deprecated_function, 
+            [{gen_fsm, start, 3},
+                {gen_fsm, sync_send_event, 3},
+                {gen_fsm, send_event, 2},
+                {gen_fsm, send_all_state_event, 2}]}).
+-endif.
+
 -include("include/leveled.hrl").
 
 -define(MAX_SLOTS, 256).


### PR DESCRIPTION
Use a compile flag just for OTP20/21 deprecation warnings, so can run R16 -> OTP20 (and potentially on to 21) without having to disable error_on_warnings