### PR TITLE
Mas i11 backenddelete

### DIFF
--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -677,6 +677,7 @@ handle_call({fetch_keys,
                                 [State#state.levelzero_size],
                                 SW,
                                 0.01),
+    io:format("Fetch keys with segment_list of ~w~n", [SegmentList]),
     SetupFoldFun =
         fun(Level, Acc) ->
             Pointers = leveled_pmanifest:range_lookup(State#state.manifest,

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -677,7 +677,6 @@ handle_call({fetch_keys,
                                 [State#state.levelzero_size],
                                 SW,
                                 0.01),
-    io:format("Fetch keys with segment_list of ~w~n", [SegmentList]),
     SetupFoldFun =
         fun(Level, Acc) ->
             Pointers = leveled_pmanifest:range_lookup(State#state.manifest,

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -478,7 +478,7 @@ foldobjects(SnapFun, Tag, KeyRanges, FoldObjFun, DeferredFetch, SegmentList) ->
                 % initial accumulator
                 FoldObjFun;
             false ->
-                % no initial accumulatr passed, and so should be just a list
+                % no initial accumulator passed, and so should be just a list
                 {FoldObjFun, []}
         end,
     

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -403,6 +403,7 @@ sst_getslots(Pid, SlotList) ->
 %% false as a SegList to not filter
 sst_getfilteredslots(Pid, SlotList, SegList) ->
     SegL0 = tune_seglist(SegList),
+    io:format("Tuned seglist of ~w~n", [SegL0]),
     {SlotBins, PressMethod} = 
         gen_fsm:sync_send_event(Pid, {get_slots, SlotList, SegL0}, infinity),
     binaryslot_reader(SlotBins, PressMethod).

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -403,7 +403,6 @@ sst_getslots(Pid, SlotList) ->
 %% false as a SegList to not filter
 sst_getfilteredslots(Pid, SlotList, SegList) ->
     SegL0 = tune_seglist(SegList),
-    io:format("Tuned seglist of ~w~n", [SegL0]),
     {SlotBins, PressMethod} = 
         gen_fsm:sync_send_event(Pid, {get_slots, SlotList, SegL0}, infinity),
     binaryslot_reader(SlotBins, PressMethod).

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -369,6 +369,7 @@ sst_getkvrange(Pid, StartKey, EndKey, ScanWidth) ->
 %% leveled_tictac
 sst_getfilteredrange(Pid, StartKey, EndKey, ScanWidth, SegList) ->
     SegList0 = tune_seglist(SegList),
+    io:format("Using tuned seglist ~w~n", [SegList0]),
     case gen_fsm:sync_send_event(Pid,
                                     {get_kvrange, 
                                         StartKey, EndKey, 
@@ -1258,11 +1259,8 @@ generate_binary_slot(Lookup, KVL, PressMethod, BuildTimings0) ->
 % LedgerKey is false
 
 check_blocks([], _Handle, _StartPos, _BlockLengths, _PosBinLength,
-                _LedgerKeyToCheck, _PressMethod, Acc) when is_list(Acc) ->
-    lists:reverse(Acc);
-check_blocks([], _Handle, _StartPos, _BlockLengths, _PosBinLength,
                 _LedgerKeyToCheck, _PressMethod, Acc) ->
-    Acc; % Should be not_present only?
+    Acc;
 check_blocks([Pos|Rest], Handle, StartPos, BlockLengths, PosBinLength,
                 LedgerKeyToCheck, PressMethod, Acc) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
@@ -1280,10 +1278,8 @@ check_blocks([Pos|Rest], Handle, StartPos, BlockLengths, PosBinLength,
         _ ->
             case LedgerKeyToCheck of 
                 false ->
-                    check_blocks(Rest, Handle, StartPos, 
-                                    BlockLengths, PosBinLength, 
-                                    LedgerKeyToCheck, PressMethod, 
-                                    [{K, V}|Acc]);
+                    io:format("{K, V} found in block of ~w~n", [{K, V}]),
+                    Acc ++ [{K, V}];
                 _ ->
                     check_blocks(Rest, Handle, StartPos, 
                                     BlockLengths, PosBinLength, 
@@ -1386,8 +1382,11 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
                     % other keys
                     case find_pos(BlockIdx, SegList, [], 0) of 
                         [] ->
+                            io:format("Empty postion list for slot~n"),
                             Acc;
                         PositionList ->
+                            io:format("~w positions found for slot~n", 
+                                        [length(PositionList)]),
                             Acc ++ 
                                 check_blocks(PositionList, 
                                                 Handle, SP, 
@@ -1687,6 +1686,7 @@ find_pos(<<1:1/integer, PotentialHit:15/integer, T/binary>>,
                         HashList, PosList, Count) when is_list(HashList) ->
     case lists:member(PotentialHit, HashList) of 
         true ->
+            io:format("Found pos based on ~w~n", [PotentialHit]),
             find_pos(T, HashList, PosList ++ [Count], Count + 1);
         false ->
             find_pos(T, HashList, PosList, Count + 1)

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1364,6 +1364,7 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
             BL = ?BLOCK_LENGTHS_LENGTH,
             case array:get(ID - 1, BlockIndexCache) of
                 none ->
+                    io:format("BlockIndex cache not available for fetch_range~n"),
                     % If there is an attempt to use the seg list query and the
                     % index block cache isn't cached for any part this may be 
                     % slower as each slot will be read in turn
@@ -1378,6 +1379,7 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
                     % present without lifting the slot off disk. Also the 
                     % fact that we know position can be used to filter out 
                     % other keys
+                    io:format("BlockIndex cache used in fetch_range~n"),
                     case find_pos(BlockIdx, SegList, [], 0) of 
                         [] ->
                             Acc;

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -369,6 +369,7 @@ sst_getkvrange(Pid, StartKey, EndKey, ScanWidth) ->
 %% leveled_tictac
 sst_getfilteredrange(Pid, StartKey, EndKey, ScanWidth, SegList) ->
     SegList0 = tune_seglist(SegList),
+    io:format("Using tuned seglist ~w~n", [SegList0]),
     case gen_fsm:sync_send_event(Pid,
                                     {get_kvrange, 
                                         StartKey, EndKey, 
@@ -1364,7 +1365,6 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
             BL = ?BLOCK_LENGTHS_LENGTH,
             case array:get(ID - 1, BlockIndexCache) of
                 none ->
-                    io:format("BlockIndex cache not available for fetch_range~n"),
                     % If there is an attempt to use the seg list query and the
                     % index block cache isn't cached for any part this may be 
                     % slower as each slot will be read in turn
@@ -1379,7 +1379,6 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
                     % present without lifting the slot off disk. Also the 
                     % fact that we know position can be used to filter out 
                     % other keys
-                    io:format("BlockIndex cache used in fetch_range~n"),
                     case find_pos(BlockIdx, SegList, [], 0) of 
                         [] ->
                             Acc;
@@ -1683,6 +1682,7 @@ find_pos(<<1:1/integer, PotentialHit:15/integer, T/binary>>,
                         HashList, PosList, Count) when is_list(HashList) ->
     case lists:member(PotentialHit, HashList) of 
         true ->
+            io:format("Found pos based on ~w~n", [PotentialHit]),
             find_pos(T, HashList, PosList ++ [Count], Count + 1);
         false ->
             find_pos(T, HashList, PosList, Count + 1)

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1630,7 +1630,7 @@ tune_hash(SegHash) ->
 tune_seglist(SegList) ->
     case is_list(SegList) of 
         true ->
-            lists:map(fun tune_hash/1, SegList);
+            lists:usort(lists:map(fun tune_hash/1, SegList));
         false ->
             SegList
     end.

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1381,8 +1381,11 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
                     % other keys
                     case find_pos(BlockIdx, SegList, [], 0) of 
                         [] ->
+                            io:format("Empty postion list for slot~n"),
                             Acc;
                         PositionList ->
+                            io:format("~w positions found for slot~n", 
+                                        [length(PositionList)]),
                             Acc ++ 
                                 check_blocks(PositionList, 
                                                 Handle, SP, 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1278,6 +1278,7 @@ check_blocks([Pos|Rest], Handle, StartPos, BlockLengths, PosBinLength,
         _ ->
             case LedgerKeyToCheck of 
                 false ->
+                    io:format("{K, V} found in block of ~w~n", [{K, V}]),
                     Acc ++ [{K, V}];
                 _ ->
                     check_blocks(Rest, Handle, StartPos, 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -369,7 +369,6 @@ sst_getkvrange(Pid, StartKey, EndKey, ScanWidth) ->
 %% leveled_tictac
 sst_getfilteredrange(Pid, StartKey, EndKey, ScanWidth, SegList) ->
     SegList0 = tune_seglist(SegList),
-    io:format("Using tuned seglist ~w~n", [SegList0]),
     case gen_fsm:sync_send_event(Pid,
                                     {get_kvrange, 
                                         StartKey, EndKey, 
@@ -1259,8 +1258,11 @@ generate_binary_slot(Lookup, KVL, PressMethod, BuildTimings0) ->
 % LedgerKey is false
 
 check_blocks([], _Handle, _StartPos, _BlockLengths, _PosBinLength,
+                _LedgerKeyToCheck, _PressMethod, Acc) when is_list(Acc) ->
+    lists:reverse(Acc);
+check_blocks([], _Handle, _StartPos, _BlockLengths, _PosBinLength,
                 _LedgerKeyToCheck, _PressMethod, Acc) ->
-    Acc;
+    Acc; % Should be not_present only?
 check_blocks([Pos|Rest], Handle, StartPos, BlockLengths, PosBinLength,
                 LedgerKeyToCheck, PressMethod, Acc) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
@@ -1278,8 +1280,10 @@ check_blocks([Pos|Rest], Handle, StartPos, BlockLengths, PosBinLength,
         _ ->
             case LedgerKeyToCheck of 
                 false ->
-                    io:format("{K, V} found in block of ~w~n", [{K, V}]),
-                    Acc ++ [{K, V}];
+                    check_blocks(Rest, Handle, StartPos, 
+                                    BlockLengths, PosBinLength, 
+                                    LedgerKeyToCheck, PressMethod, 
+                                    [{K, V}|Acc]);
                 _ ->
                     check_blocks(Rest, Handle, StartPos, 
                                     BlockLengths, PosBinLength, 
@@ -1382,11 +1386,8 @@ read_slots(Handle, SlotList, {SegList, BlockIndexCache}, PressMethod) ->
                     % other keys
                     case find_pos(BlockIdx, SegList, [], 0) of 
                         [] ->
-                            io:format("Empty postion list for slot~n"),
                             Acc;
                         PositionList ->
-                            io:format("~w positions found for slot~n", 
-                                        [length(PositionList)]),
                             Acc ++ 
                                 check_blocks(PositionList, 
                                                 Handle, SP, 
@@ -1686,7 +1687,6 @@ find_pos(<<1:1/integer, PotentialHit:15/integer, T/binary>>,
                         HashList, PosList, Count) when is_list(HashList) ->
     case lists:member(PotentialHit, HashList) of 
         true ->
-            io:format("Found pos based on ~w~n", [PotentialHit]),
             find_pos(T, HashList, PosList ++ [Count], Count + 1);
         false ->
             find_pos(T, HashList, PosList, Count + 1)


### PR DESCRIPTION
An issue was spotted.  If we use a segment filter in a query, and there are multiple matches within a given slot - only the first match is returned.

Tests didn't detect this.  Now they do, and the issue is resolved.