### PR TITLE
Mas i138 useblockindexonfetchrange

### DIFF
--- a/test/end_to_end/riak_SUITE.erl
+++ b/test/end_to_end/riak_SUITE.erl
@@ -84,6 +84,7 @@ crossbucket_aae(_Config) ->
     {ok, Bookie2A} = leveled_bookie:book_start(StartOpts2),
 
     test_segfilter_query(Bookie2A, CLs),
+    test_segfilter_query(Bookie2A, CLs),
 
     test_singledelta_stores(Bookie2A, Bookie3, small, {B1, K1}),
 


### PR DESCRIPTION
When a fetch range or fetch slots occurs on the SST file, and a seg list is passed, the index is now checked even if the block index is not in the cache.

Also the index used is then added to the cache to be used next time.

