### PR TITLE
Mas i31 cdccrckey

### DIFF
--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -1175,7 +1175,7 @@ extract_key_value_check(Handle, Position, BinaryMode) ->
     {ok, _} = file:position(Handle, Position),
     case {BinaryMode, saferead_keyvalue(Handle)} of 
         {_, false} ->
-            {null, null, false};
+            {null, crc_wonky, false};
         {true, {Key, Value, _KeyL, _ValueL}} ->
             {Key, Value, true};
         {false, {Key, Value, _KeyL, _ValueL}} ->

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -2410,17 +2410,10 @@ safe_read_test() ->
                     % Sometimes corruption may yield a correct answer
                     % for example if Value Length is too big
                     %
-                    % This cna only happen with a corrupted value length at
+                    % This can only happen with a corrupted value length at
                     % the end of the file - which is just a peculiarity of 
                     % the test
-                    ?assertMatch(true, BadValueL > ValueL);
-                {_BadKey, Value, KeyL, ValueL} ->
-                    % Key is not CRC checked - so may be bit flipped to
-                    % something which is still passes through binary_to_term
-                    % Assumption is that the application should always 
-                    % ultimately know the key - and so will be able to check
-                    % against the Key it is trying for.
-                    ok
+                    ?assertMatch(true, BadValueL > ValueL)
             end,
             ok = file:close(Handle)
         end,

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -1183,6 +1183,9 @@ extract_key_value_check(Handle, Position, BinaryMode) ->
     end.
 
 
+-spec startup_scan_over_file(fle:io_device(), file:location()) 
+                                                -> {file:location(), any()}.
+%% @doc
 %% Scan through the file until there is a failure to crc check an input, and 
 %% at that point return the position and the key dictionary scanned so far
 startup_scan_over_file(Handle, Position) ->
@@ -1204,12 +1207,13 @@ startup_filter(Key, _ValueAsBin, Position, {Hashtree, _LastKey}, _ExtractFun) ->
     {loop, {put_hashtree(Key, Position, Hashtree), Key}}.
 
 
+-spec scan_over_file(file:io_device(), file:location(), fun(), any(), any())
+                                                -> {file:location(), any()}.
 %% Scan for key changes - scan over file returning applying FilterFun
 %% The FilterFun should accept as input:
 %% - Key, ValueBin, Position, Accumulator, Fun (to extract values from Binary)
 %% -> outputting a new Accumulator and a loop|stop instruction as a tuple
 %% i.e. {loop, Acc} or {stop, Acc}
-
 scan_over_file(Handle, Position, FilterFun, Output, LastKey) ->
     case saferead_keyvalue(Handle) of
         false ->

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -2086,7 +2086,7 @@ create_file_test() ->
                             _ ->
                                 ok
                         end end,
-                    [50, 50, 50, 50, 50]),
+                    [50, 100, 200, 400, 800]),
     {ok, SrcFN, StartKey, EndKey} = checkready(SP),
     io:format("StartKey ~w EndKey ~w~n", [StartKey, EndKey]),
     ?assertMatch({o, _, _, _}, StartKey),


### PR DESCRIPTION
Within the cdb files, make the crc check a joint check of both key and value - so that issues with corrupted keys don't bubble up.