### PR TITLE
Fix bad specs

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -88,7 +88,7 @@
 -type ledger_status() ::
         tomb|{active, non_neg_integer()|infinity}.
 -type ledger_key() :: 
-        {tag(), any(), any(), any()}.
+        {tag(), any(), any(), any()}|all.
 -type ledger_value() :: 
         {integer(), ledger_status(), segment_hash(), tuple()|null}.
 -type ledger_kv() ::
@@ -647,7 +647,7 @@ aae_indexspecs(AAE, Bucket, Key, SQN, H, LastMods) ->
     end.
 
 -spec parse_date(tuple(), integer(), integer(), integer()) ->
-                    no_index|{binary(), integer()}.
+                    no_index|{list(), integer()}.
 %% @doc
 %% Parse the last modified date and the AAE date configuration to return a
 %% binary to be used as the last modified date part of the index, and an

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -79,8 +79,9 @@
 
 -type manifest() :: #manifest{}.
 -type manifest_entry() :: #manifest_entry{}.
+-type manifest_owner() :: pid()|list().
 
--export_type([manifest/0, manifest_entry/0]).
+-export_type([manifest/0, manifest_entry/0, manifest_owner/0]).
 
 %%%============================================================================
 %%% API
@@ -324,7 +325,7 @@ get_manifest_sqn(Manifest) ->
     Manifest#manifest.manifest_sqn.
 
 -spec key_lookup(manifest(), integer(), leveled_codec:ledger_key()) 
-                                                    -> false|manifest_entry().
+                                                    -> false|manifest_owner().
 %% @doc
 %% For a given key find which manifest entry covers that key at that level,
 %% returning false if there is no covering manifest entry at that level.


### PR DESCRIPTION
There were some bad specs in '|' OR'd specs.  These were being falsely ignored in dialyzer until https://github.com/erlang/otp/pull/1722.

Running on OTP21 exposed these incomplete specs.