### PR TITLE
Mas kvi missinghead

### DIFF
--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -173,8 +173,7 @@
         pcl_start/1,
         pcl_pushmem/2,
         pcl_fetchlevelzero/2,
-        pcl_fetch/2,
-        pcl_fetch/3,
+        pcl_fetch/4,
         pcl_fetchkeys/5,
         pcl_fetchkeysbysegment/6,
         pcl_fetchnextkey/5,
@@ -362,20 +361,20 @@ pcl_fetch(Pid, Key) ->
     Hash = leveled_codec:segment_hash(Key),
     if
         Hash /= no_lookup ->
-            gen_server:call(Pid, {fetch, Key, Hash}, infinity)
+            gen_server:call(Pid, {fetch, Key, Hash, true}, infinity)
     end.
 
 -spec pcl_fetch(pid(), 
                 leveled_codec:ledger_key(), 
-                leveled_codec:segment_hash())
-                                    -> leveled_codec:ledger_kv()|not_present.
+                leveled_codec:segment_hash(),
+                boolean()) -> leveled_codec:ledger_kv()|not_present.
 %% @doc
 %% Fetch a key, return the first (highest SQN) occurrence of that Key along
 %% with  the value.
 %%
 %% Hash should be result of leveled_codec:segment_hash(Key)
-pcl_fetch(Pid, Key, Hash) ->
-    gen_server:call(Pid, {fetch, Key, Hash}, infinity).
+pcl_fetch(Pid, Key, Hash, UseL0Index) ->
+    gen_server:call(Pid, {fetch, Key, Hash, UseL0Index}, infinity).
 
 -spec pcl_fetchkeys(pid(), 
                     leveled_codec:ledger_key(), 
@@ -636,12 +635,19 @@ handle_call({push_mem, {LedgerTable, PushedIdx, MinSQN, MaxSQN}},
                                     State#state.levelzero_cache,
                                     State)}
     end;
-handle_call({fetch, Key, Hash}, _From, State) ->
+handle_call({fetch, Key, Hash, UseL0Index}, _From, State) ->
+    L0Idx = 
+        case UseL0Index of 
+            true ->
+                State#state.levelzero_index;
+            false ->
+                none
+        end,
     {R, UpdTimings} = timed_fetch_mem(Key,
                                         Hash,
                                         State#state.manifest,
                                         State#state.levelzero_cache,
-                                        State#state.levelzero_index,
+                                        L0Idx,
                                         State#state.timings),
     {UpdTimings0, CountDown} = 
         update_statetimings(UpdTimings, State#state.timings_countdown),
@@ -1233,11 +1239,14 @@ plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
     element(1, R).
 
 fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
-    PosList = leveled_pmem:check_index(Hash, L0Index),
+    PosList = 
+        case L0Index of
+            none ->
+                lists:seq(1, length(L0Cache));
+            _ ->
+                leveled_pmem:check_index(Hash, L0Index)
+        end,
     L0Check = leveled_pmem:check_levelzero(Key, Hash, PosList, L0Cache),
-    io:format(user, 
-                "fetch mem for Key ~w PosList ~w L0Check ~w Hash ~w~n", 
-                [Key, PosList, L0Check, Hash]),
     case L0Check of
         {false, not_found} ->
             fetch(Key, Hash, Manifest, 0, fun timed_sst_get/4);

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -1236,8 +1236,8 @@ fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
     PosList = leveled_pmem:check_index(Hash, L0Index),
     L0Check = leveled_pmem:check_levelzero(Key, Hash, PosList, L0Cache),
     io:format(user, 
-                "fetch mem for Key ~w PosList ~w L0Check ~w~n", 
-                [Key, PosList, L0Check]),
+                "fetch mem for Key ~w PosList ~w L0Check ~w Hash ~w~n", 
+                [Key, PosList, L0Check, Hash]),
     case L0Check of
         {false, not_found} ->
             fetch(Key, Hash, Manifest, 0, fun timed_sst_get/4);

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -1235,6 +1235,9 @@ plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
 fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
     PosList = leveled_pmem:check_index(Hash, L0Index),
     L0Check = leveled_pmem:check_levelzero(Key, Hash, PosList, L0Cache),
+    io:format(user, 
+                "fetch mem for Key ~w PosList ~w L0Check ~w~n", 
+                [Key, PosList, L0Check]),
     case L0Check of
         {false, not_found} ->
             fetch(Key, Hash, Manifest, 0, fun timed_sst_get/4);

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -44,7 +44,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 % -type index_array() :: array:array().
--type index_array() :: any(). % To live with OTP16
+-type index_array() :: any()|none. % To live with OTP16
 
 -export_type([index_array/0]).
 
@@ -214,20 +214,20 @@ split_hash({SegmentID, ExtraHash}) ->
 
 check_slotlist(Key, _Hash, CheckList, TreeList) ->
     SlotCheckFun =
-                fun(SlotToCheck, {Found, KV}) ->
-                    case Found of
-                        true ->
+        fun(SlotToCheck, {Found, KV}) ->
+            case Found of
+                true ->
+                    {Found, KV};
+                false ->
+                    CheckTree = lists:nth(SlotToCheck, TreeList),
+                    case leveled_tree:match(Key, CheckTree) of
+                        none ->
                             {Found, KV};
-                        false ->
-                            CheckTree = lists:nth(SlotToCheck, TreeList),
-                            case leveled_tree:match(Key, CheckTree) of
-                                none ->
-                                    {Found, KV};
-                                {value, Value} ->
-                                    {true, {Key, Value}}
-                            end
+                        {value, Value} ->
+                            {true, {Key, Value}}
                     end
-                    end,
+            end
+            end,
     lists:foldl(SlotCheckFun,
                     {false, not_found},
                     lists:reverse(CheckList)).

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -1108,7 +1108,13 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 leveled_bookie:book_head(Bookie1, 
                                             SegmentID0, 
                                             {Bucket0, Key0}, 
-                                            h);
+                                            h),
+            CheckHeadFun = 
+                fun({add, SegID, B, K, H}) ->
+                    {ok, H} = 
+                        leveled_bookie:book_head(Bookie1, SegID, {B, K}, h)
+                end,
+            lists:foreach(CheckHeadFun, ObjectSpecL);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 


### PR DESCRIPTION
When running leveled in head_only mode, there is no L0Index created for the penciler - bu the head request will still try an use this index if with_lookup used. 