### PR TITLE
Mas i162 isempty

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -162,6 +162,7 @@
 -type head_timings() :: no_timing|#head_timings{}.
 -type timing_types() :: head|get|put|fold.
 -type recent_aae() :: false|#recent_aae{}|undefined.
+-type key() :: binary()|integer()|string().
 -type open_options() :: 
     %% For full description of options see ../docs/STARTUP_OPTIONS.md
     [{root_path, string()|undefined} |
@@ -329,7 +330,7 @@ book_start(Opts) ->
     gen_server:start_link(?MODULE, [set_defaults(Opts)], []).
 
 
--spec book_tempput(pid(), any(), any(), any(), 
+-spec book_tempput(pid(), key(), key(), any(), 
                     leveled_codec:index_specs(), 
                     leveled_codec:tag(), integer()) -> ok|pause.
 
@@ -396,7 +397,7 @@ book_put(Pid, Bucket, Key, Object, IndexSpecs) ->
 book_put(Pid, Bucket, Key, Object, IndexSpecs, Tag) ->
     book_put(Pid, Bucket, Key, Object, IndexSpecs, Tag, infinity).
 
--spec book_put(pid(), any(), any(), any(), 
+-spec book_put(pid(), key(), key(), any(), 
                 leveled_codec:index_specs(), 
                 leveled_codec:tag(), infinity|integer()) -> ok|pause.
 
@@ -432,7 +433,7 @@ book_mput(Pid, ObjectSpecs) ->
 book_mput(Pid, ObjectSpecs, TTL) ->
     gen_server:call(Pid, {mput, ObjectSpecs, TTL}, infinity).
 
--spec book_delete(pid(), any(), any(), leveled_codec:index_specs()) 
+-spec book_delete(pid(), key(), key(), leveled_codec:index_specs()) 
                                                                 -> ok|pause.
 
 %% @doc 
@@ -444,9 +445,9 @@ book_delete(Pid, Bucket, Key, IndexSpecs) ->
     book_put(Pid, Bucket, Key, delete, IndexSpecs, ?STD_TAG).
 
 
--spec book_get(pid(), any(), any(), leveled_codec:tag()) 
+-spec book_get(pid(), key(), key(), leveled_codec:tag()) 
                                                     -> {ok, any()}|not_found.
--spec book_head(pid(), any(), any(), leveled_codec:tag())
+-spec book_head(pid(), key(), key(), leveled_codec:tag())
                                                     -> {ok, any()}|not_found.
 
 %% @doc - GET and HEAD requests

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -503,7 +503,7 @@ book_head(Pid, Bucket, Key) ->
 %% {bucket_stats, Bucket}  -> return a key count and total object size within
 %% a bucket
 %% {riakbucket_stats, Bucket} -> as above, but for buckets with the Riak Tag
-%% {binary_bucketlist, Tag, {FoldKeysFun, Acc}} -> if we assume buckets and
+%% {bucket_list, Tag, {FoldKeysFun, Acc}} -> if we assume buckets and
 %% keys are binaries, provides a fast bucket list function
 %% {index_query,
 %%        Constraint,
@@ -1200,14 +1200,14 @@ get_runner(State,
     leveled_runner:foldobjects_byindex(SnapFun, 
                                         {Tag, Bucket, Field, FromTerm, ToTerm},
                                         FoldObjectsFun);
-get_runner(State, {binary_bucketlist, Tag, FoldAccT}) ->
+get_runner(State, {bucket_list, Tag, FoldAccT}) ->
     {FoldBucketsFun, Acc} = FoldAccT,
     SnapFun = return_snapfun(State, ledger, no_lookup, false, false),
-    leveled_runner:binary_bucketlist(SnapFun, Tag, FoldBucketsFun, Acc);
+    leveled_runner:bucket_list(SnapFun, Tag, FoldBucketsFun, Acc);
 get_runner(State, {first_bucket, Tag, FoldAccT}) ->
     {FoldBucketsFun, Acc} = FoldAccT,
     SnapFun = return_snapfun(State, ledger, no_lookup, false, false),
-    leveled_runner:binary_bucketlist(SnapFun, Tag, FoldBucketsFun, Acc, 1);
+    leveled_runner:bucket_list(SnapFun, Tag, FoldBucketsFun, Acc, 1);
 %% Set of specific runners, primarily used as exmaples for tests
 get_runner(State, DeprecatedQuery) ->
     get_deprecatedrunner(State, DeprecatedQuery).

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -162,7 +162,7 @@
 -type head_timings() :: no_timing|#head_timings{}.
 -type timing_types() :: head|get|put|fold.
 -type recent_aae() :: false|#recent_aae{}|undefined.
--type key() :: binary()|integer()|string().
+-type key() :: binary()|string().
 -type open_options() :: 
     %% For full description of options see ../docs/STARTUP_OPTIONS.md
     [{root_path, string()|undefined} |
@@ -2175,8 +2175,8 @@ is_empty_headonly_test() ->
                                     {head_only, no_lookup}]),
     ?assertMatch(true, book_isempty(Bookie1, ?HEAD_TAG)),
     ObjSpecs = 
-        [{add, <<"B1">>, <<"K1">>, 1, 100},
-            {remove, <<"B1">>, <<"K1">>, 0, null}],
+        [{add, <<"B1">>, <<"K1">>, <<1:8/integer>>, 100},
+            {remove, <<"B1">>, <<"K1">>, <<0:8/integer>>, null}],
     ok = book_mput(Bookie1, ObjSpecs),
     ?assertMatch(false, book_isempty(Bookie1, ?HEAD_TAG)),
     ok = book_close(Bookie1).
@@ -2197,7 +2197,7 @@ foldkeys_headonly_tester(ObjectCount, BlockSize, BStr) ->
     GenObjSpecFun =
         fun(I) ->
             Key = I rem 6,
-            {add, BStr, <<Key:8/integer>>, I, erlang:phash2(I)}
+            {add, BStr, <<Key:8/integer>>, integer_to_list(I), I}
         end,
     ObjSpecs = lists:map(GenObjSpecFun, lists:seq(1, ObjectCount)),
     ObjSpecBlocks = 

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -163,6 +163,8 @@
 -type timing_types() :: head|get|put|fold.
 -type recent_aae() :: false|#recent_aae{}|undefined.
 -type key() :: binary()|string().
+    % Keys SHOULD be binary()
+    % string() support is a legacy of old tests
 -type open_options() :: 
     %% For full description of options see ../docs/STARTUP_OPTIONS.md
     [{root_path, string()|undefined} |
@@ -278,6 +280,8 @@
             % and are only compressed when they are first subject to compaction
             % Defaults to ?COMPRESSION_POINT
         ].
+
+-export_type([key/0]).
 
 
 %%%============================================================================

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -2183,12 +2183,12 @@ is_empty_headonly_test() ->
 
 
 foldkeys_headonly_test() ->
-    foldkeys_headonly_tester(5000, 25).
+    foldkeys_headonly_tester(5000, 25, "BucketStr"),
+    foldkeys_headonly_tester(2000, 25, <<"B0">>).
 
 
-foldkeys_headonly_tester(ObjectCount, BlockSize) ->
+foldkeys_headonly_tester(ObjectCount, BlockSize, BStr) ->
     RootPath = reset_filestructure(),
-    BStr = "BucketStr",
     
     {ok, Bookie1} = book_start([{root_path, RootPath},
                                     {max_journalsize, 1000000},

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -67,7 +67,8 @@
         riak_extract_metadata/2,
         segment_hash/1,
         to_lookup/1,
-        riak_metadata_to_binary/2]).         
+        riak_metadata_to_binary/2,
+        next_key/1]).         
 
 -define(V1_VERS, 1).
 -define(MAGIC, 53). % riak_kv -> riak_object
@@ -252,6 +253,8 @@ from_ledgerkey({?IDX_TAG, ?ALL_BUCKETS, {_IdxFld, IdxVal}, {Bucket, Key}}) ->
     {Bucket, Key, IdxVal};
 from_ledgerkey({?IDX_TAG, Bucket, {_IdxFld, IdxVal}, Key}) ->
     {Bucket, Key, IdxVal};
+from_ledgerkey({?HEAD_TAG, Bucket, Key, SubKey}) ->
+    {Bucket, {Key, SubKey}};
 from_ledgerkey({_Tag, Bucket, Key, _SubKey}) ->
     {Bucket, Key}.
 
@@ -834,6 +837,13 @@ get_metadata_from_siblings(<<ValLen:32/integer, Rest0/binary>>,
                                     MetaBin:MetaLen/binary>>,
                                     [LastMod|LastMods]).
 
+
+next_key(Key) when is_binary(Key) ->
+    <<Key/binary, 0>>;
+next_key(Key) when is_integer(Key) ->
+    Key + 1;
+next_key(Key) when is_list(Key) ->
+    Key ++ [0].
 
 
 

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -837,14 +837,13 @@ get_metadata_from_siblings(<<ValLen:32/integer, Rest0/binary>>,
                                     MetaBin:MetaLen/binary>>,
                                     [LastMod|LastMods]).
 
-
+-spec next_key(leveled_bookie:key()) -> leveled_bookie:key().
+%% @doc
+%% Get the next key to iterate from a given point
 next_key(Key) when is_binary(Key) ->
     <<Key/binary, 0>>;
-next_key(Key) when is_integer(Key) ->
-    Key + 1;
 next_key(Key) when is_list(Key) ->
     Key ++ [0].
-
 
 
 %%%============================================================================

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -40,8 +40,6 @@
         {info, "Bucket list finds no more results"}},
     {"B0009",
         {info, "Bucket list finds Bucket ~w"}},
-    {"B0010",
-        {info, "Bucket list finds non-binary Bucket ~w"}},
     {"B0011",
         {warn, "Call to destroy the store and so all files to be removed"}},
     {"B0013",

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -458,10 +458,7 @@ get_nextbucket(NextBucket, NextKey, Tag, LedgerSnapshot, BKList, {C, L}) ->
                                 leveled_codec:next_key(K)
                         end,
                     get_nextbucket(B, NK, Tag, LedgerSnapshot, BKList, {C, L})
-            end;
-        {NB, _V} ->
-            leveled_log:log("B0010",[NB]),
-            []
+            end
     end.
 
 

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -23,8 +23,8 @@
 
 -export([
             bucket_sizestats/3,
-            binary_bucketlist/4,
-            binary_bucketlist/5,
+            bucket_list/4,
+            bucket_list/5,
             index_query/3,
             bucketkey_query/4,
             bucketkey_query/5,
@@ -73,19 +73,20 @@ bucket_sizestats(SnapFun, Bucket, Tag) ->
         end,
     {async, Runner}.
 
--spec binary_bucketlist(fun(), leveled_codec:tag(), fun(), any()) 
+-spec bucket_list(fun(), leveled_codec:tag(), fun(), any()) 
                                                             -> {async, fun()}.
 %% @doc
-%% List buckets for tag, assuming bucket names are all binary type
-binary_bucketlist(SnapFun, Tag, FoldBucketsFun, InitAcc) ->
-    binary_bucketlist(SnapFun, Tag, FoldBucketsFun, InitAcc, -1).
+%% List buckets for tag, assuming bucket names are all either binary, ascii 
+%% strings or integers 
+bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc) ->
+    bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc, -1).
 
--spec binary_bucketlist(fun(), leveled_codec:tag(), fun(), any(), integer()) 
+-spec bucket_list(fun(), leveled_codec:tag(), fun(), any(), integer()) 
                                                     -> {async, fun()}.
 %% @doc
 %% set Max Buckets to -1 to list all buckets, otherwise will only return
 %% MaxBuckets (use 1 to confirm that there exists any bucket for a given Tag)
-binary_bucketlist(SnapFun, Tag, FoldBucketsFun, InitAcc, MaxBuckets) ->
+bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc, MaxBuckets) ->
     Runner = 
         fun() ->
             {ok, LedgerSnapshot, _JournalSnapshot} = SnapFun(),

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -778,7 +778,7 @@ is_empty_test(_Config) ->
     ok = testutil:book_riakput(Bookie1, TestObject3, TestSpec3),
     
     FoldBucketsFun = fun(B, Acc) -> sets:add_element(B, Acc) end,
-    BucketListQuery = {binary_bucketlist,
+    BucketListQuery = {bucket_list,
                         ?RIAK_TAG,
                         {FoldBucketsFun, sets:new()}},
     {async, BL} = leveled_bookie:book_returnfolder(Bookie1, BucketListQuery),

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -173,13 +173,13 @@ small_load_with2i(_Config) ->
     true = Total2 == Total1, 
     
     FoldBucketsFun = fun(B, Acc) -> sets:add_element(B, Acc) end,
-    % Should not find any buckets - as there is a non-binary bucket, and no
-    % binary ones
-    BucketListQuery = {binary_bucketlist,
+    % this should find Bucket and Bucket1 - as we can now find string-based 
+    % buckets using bucket_list - i.e. it isn't just binary buckets now
+    BucketListQuery = {bucket_list,
                         ?RIAK_TAG,
                         {FoldBucketsFun, sets:new()}},
     {async, BL} = leveled_bookie:book_returnfolder(Bookie2, BucketListQuery),
-    true = sets:size(BL()) == 0,
+    true = sets:size(BL()) == 2,
     
     ok = leveled_bookie:book_close(Bookie2),
     testutil:reset_filestructure().
@@ -394,7 +394,7 @@ query_count(_Config) ->
     testutil:check_forobject(Book4, TestObject),
     
     FoldBucketsFun = fun(B, Acc) -> sets:add_element(B, Acc) end,
-    BucketListQuery = {binary_bucketlist,
+    BucketListQuery = {bucket_list,
                         ?RIAK_TAG,
                         {FoldBucketsFun, sets:new()}},
     {async, BLF1} = leveled_bookie:book_returnfolder(Book4, BucketListQuery),


### PR DESCRIPTION
This branch attempts to better document `head_only` mode, and make its behaviour more consistent - for example is_empty should work.

Dialyzer spec checks now validate that Buckets, Keys and SubKeys are all either binaries or strings.  Integers are not supported as the type must be > than null - or unexpected issues may occur in folds.

Key folding queries should now work in `head_only`, but key folding function should be of the form:

``fun(B, {Key, SubKey}, Acc) -> Acc0``

`book_isempty` check should behave as expected with either binary or string-based bucket names, with the 'head` tag in `head_only` mode.