### PR TITLE
Mas i178 bookhead

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -58,6 +58,7 @@
         book_get/4,
         book_head/3,
         book_head/4,
+        book_headonly/4,
         book_snapshot/4,
         book_compactjournal/2,
         book_islastcompactionpending/1,
@@ -474,6 +475,7 @@ book_delete(Pid, Bucket, Key, IndexSpecs) ->
                                                     -> {ok, any()}|not_found.
 -spec book_head(pid(), key(), key(), leveled_codec:tag())
                                                     -> {ok, any()}|not_found.
+-spec book_headonly(pid(), key(), key(), key()) -> {ok, any()}|not_found.
 
 %% @doc - GET and HEAD requests
 %%
@@ -483,6 +485,10 @@ book_delete(Pid, Bucket, Key, IndexSpecs) ->
 %%
 %% GET requests first follow the path of a HEAD request, and if an object is
 %% found, then fetch the value from the Journal via the Inker.
+%% 
+%% to perform a head request in head_only mode with_lookup, book_headonly/4 
+%% should be used.  Not if head_only mode is false or no_lookup, then this
+%% request would not be supported
 
 
 book_get(Pid, Bucket, Key, Tag) ->
@@ -496,6 +502,9 @@ book_get(Pid, Bucket, Key) ->
 
 book_head(Pid, Bucket, Key) ->
     book_head(Pid, Bucket, Key, ?STD_TAG).
+
+book_headonly(Pid, Bucket, Key, SubKey) ->
+    gen_server:call(Pid, {head, Bucket, {Key, SubKey}, ?HEAD_TAG}, infinity).
 
 
 -spec book_returnfolder(pid(), tuple()) -> {async, fun()}.

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -1107,14 +1107,14 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
             % If we allow HEAD_TAG to be suubject to a lookup, then test this 
             % here
             {ok, Hash0} = 
-                leveled_bookie:book_head(Bookie1, 
-                                            SegmentID0, 
-                                            {Bucket0, Key0}, 
-                                            h),
+                leveled_bookie:book_headonly(Bookie1, 
+                                                SegmentID0, 
+                                                Bucket0, 
+                                                Key0),
             CheckHeadFun = 
                 fun({add, SegID, B, K, H}) ->
                     {ok, H} = 
-                        leveled_bookie:book_head(Bookie1, SegID, {B, K}, h)
+                        leveled_bookie:book_headonly(Bookie1, SegID, B, K)
                 end,
             lists:foreach(CheckHeadFun, ObjectSpecL);
         no_lookup ->
@@ -1122,7 +1122,12 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 leveled_bookie:book_head(Bookie1, 
                                             SegmentID0, 
                                             {Bucket0, Key0}, 
-                                            h)
+                                            h),
+            {unsupported_message, head} = 
+                leveled_bookie:book_headonly(Bookie1, 
+                                                SegmentID0, 
+                                                Bucket0, 
+                                                Key0)
     end,
 
 


### PR DESCRIPTION
This introduces the book_headonly/4 function, that allows for book_head call to be made in head_only mode, without breaking the dialyzer specs