### PR TITLE
Mas i185 emptyjournal

### DIFF
--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -157,7 +157,7 @@ clerk_trim(Pid, Inker, PersistedSQN) ->
 %% of the hastable in the CDB file - so that the file is not blocked during
 %% this calculation
 clerk_hashtablecalc(HashTree, StartPos, CDBpid) ->
-    {ok, Clerk} = gen_server:start(?MODULE, [#iclerk_options{}], []),
+    {ok, Clerk} = gen_server:start_link(?MODULE, [#iclerk_options{}], []),
     gen_server:cast(Clerk, {hashtable_calc, HashTree, StartPos, CDBpid}).
 
 -spec clerk_stop(pid()) -> ok.

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -163,7 +163,20 @@ small_load_with2i(_Config) ->
         {foldobjects_bybucket, ?RIAK_TAG, "Bucket", all, {SumIntFun, 0}, true},
     {async, Sum1} = leveled_bookie:book_returnfolder(Bookie1, BucketObjQ),
     Total1 = Sum1(),
-    true = Total1 > 100000, 
+    io:format("Total from summing all I is ~w~n", [Total1]),
+    SumFromObjLFun = 
+        fun(Obj, Acc) ->
+            {I, _Bin} = testutil:get_value_from_objectlistitem(Obj),
+            Acc + I
+        end,
+    ObjL1Total = 
+        lists:foldl(SumFromObjLFun, 0, ObjL1),
+    ChkList1Total = 
+        lists:foldl(SumFromObjLFun, 0, ChkList1),
+    io:format("Total in original object list ~w and from removed list ~w~n", 
+                [ObjL1Total, ChkList1Total]),
+
+    Total1 = ObjL1Total - ChkList1Total, 
     
     ok = leveled_bookie:book_close(Bookie1),
     

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -50,6 +50,7 @@
             foldkeysfun_returnbucket/3,
             sync_strategy/0,
             riak_object/4,
+            get_value_from_objectlistitem/1,
         numbered_key/1,
         fixed_bin_key/1]).
 
@@ -477,6 +478,10 @@ set_object(Bucket, Key, Value, IndexGen, Indexes2Remove) ->
                 contents=[Content],
                 vclock=generate_vclock()},
         Spec1}.
+
+get_value_from_objectlistitem({_Int, Obj, _Spc}) ->
+    [Content] = Obj#r_object.contents,
+    Content#r_content.value.
 
 update_some_objects(Bookie, ObjList, SampleSize) ->
     StartWatchA = os:timestamp(),


### PR DESCRIPTION
Prevent an empty journal from being rolled, and make sure any object can be added (even if it exceeds the maximum journal size).

[there is still an upper limit on the object size of 1GB - and it is assumed that no implementation should attempt to go any where near that]