### PR TITLE
Mas qi18 saferead

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -48,6 +48,7 @@
         code_change/3,
         book_start/1,
         book_start/4,
+        book_plainstart/1,
         book_put/5,
         book_put/6,
         book_tempput/7,
@@ -355,6 +356,14 @@ book_start(RootPath, LedgerCacheSize, JournalSize, SyncStrategy) ->
 
 book_start(Opts) ->
     gen_server:start_link(?MODULE, [set_defaults(Opts)], []).
+
+
+-spec book_plainstart(list(tuple())) -> {ok, pid()}.
+
+%% @doc
+%% Start used in tests to start without linking
+book_plainstart(Opts) ->
+    gen_server:start(?MODULE, [set_defaults(Opts)], []).
 
 
 -spec book_tempput(pid(), key(), key(), any(), 

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -364,7 +364,7 @@
                     ++ "with totals of cycle_count=~w "
                     ++ "fetch_time=~w index_time=~w"}},
     {"CDB20",
-        {error, "Error ~w caught when safe reading a file to length ~w"}}
+        {warn, "Error ~w caught when safe reading a file to length ~w"}}
         ]).
 
 


### PR DESCRIPTION
This PR adds some tests around openin/closing CDB files and resolves a bug where by the same cdb file is opened and re-opened as a writer following data corruption.

The log CDB20 is reduced from error to warn, as the process will continue.