### PR TITLE
Mas i189 tuplebuckets

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -181,7 +181,7 @@
 -type head_timings() :: no_timing|#head_timings{}.
 -type timing_types() :: head|get|put|fold.
 -type recent_aae() :: false|#recent_aae{}|undefined.
--type key() :: binary()|string().
+-type key() :: binary()|string()|{binary(), binary()}.
     % Keys SHOULD be binary()
     % string() support is a legacy of old tests
 -type open_options() :: 

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -843,7 +843,9 @@ get_metadata_from_siblings(<<ValLen:32/integer, Rest0/binary>>,
 next_key(Key) when is_binary(Key) ->
     <<Key/binary, 0>>;
 next_key(Key) when is_list(Key) ->
-    Key ++ [0].
+    Key ++ [0];
+next_key({Type, Bucket}) when is_binary(Type), is_binary(Bucket) ->
+    {Type, next_key(Bucket)}.
 
 
 %%%============================================================================


### PR DESCRIPTION
Buckets can now be tuples of two binaries - to support bucket types directly in Riak.