### PR TITLE
Mas i196 expandseglist

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,10 @@
 {erl_opts, [warnings_as_errors,
 	    {platform_define, "^2[0-1]{1}", fsm_deprecated},
             {platform_define, "^1[7-8]{1}", old_rand},
+            {platform_define, "^17", no_log2},
             {platform_define, "^R", no_sync},
             {platform_define, "^R", old_rand},
+            {platform_define, "^R", no_log2},
             {platform_define, "^R", slow_test}]}.
 
 {xref_checks, [undefined_function_calls,undefined_functions]}.

--- a/src/leveled_math.erl
+++ b/src/leveled_math.erl
@@ -1,0 +1,38 @@
+%% Handle missing log2 prior to OTP18
+
+-module(leveled_math).
+
+%% API
+-export([
+         log2/1
+        ]).
+
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%%===================================================================
+%%% Use log2
+%%%===================================================================
+-ifndef(no_log2).
+
+log2(X) ->
+    math:log2(X).
+
+-else.
+%%%===================================================================
+%%% Old (r18) random style functions
+%%%===================================================================
+
+log2(X) ->
+    math:log(X) / 0.6931471805599453.
+
+-endif.
+
+
+-ifdef(TEST).
+
+log2_test() ->
+    ?assertMatch(8, round(log2(256))),
+    ?assertMatch(16, round(log2(65536))).
+
+-endif.

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -777,11 +777,11 @@ segment_expandsimple_test() ->
 
 
 timing_test() ->
-    timing_tester(10000, 4, small, large),
-    timing_tester(10000, 8, small, large),
-    timing_tester(10000, 4, medium, large),
-    timing_tester(10000, 4, small, medium),
-    timing_tester(100000, 4, small, large).
+    timing_tester(100000, 4, small, large),
+    timing_tester(100000, 8, small, large),
+    timing_tester(100000, 4, medium, large),
+    timing_tester(100000, 4, small, medium),
+    timing_tester(1000000, 4, small, large).
 
 
 timing_tester(KeyCount, SegCount, SmallSize, LargeSize) ->

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -413,7 +413,7 @@ adjust_segmentmatch_list(SegmentList, CompareSize, StoreSize) ->
     StoreSizeI = get_size(StoreSize),
     if CompareSizeI =< StoreSizeI ->
         ExpItems = StoreSizeI div CompareSizeI - 1,
-        ShiftFactor = trunc(math:log2(CompareSizeI * ?L2_CHUNKSIZE)),
+        ShiftFactor = round(leveled_math:log2(CompareSizeI * ?L2_CHUNKSIZE)),
         ExpList = 
             lists:map(fun(X) -> X bsl ShiftFactor end, lists:seq(1, ExpItems)),
         UpdSegmentList = 

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -777,11 +777,11 @@ segment_expandsimple_test() ->
 
 
 timing_test() ->
-    timing_tester(100000, 4, small, large),
-    timing_tester(100000, 8, small, large),
-    timing_tester(100000, 4, medium, large),
-    timing_tester(100000, 4, small, medium),
-    timing_tester(1000000, 4, small, large).
+    timing_tester(10000, 4, small, large),
+    timing_tester(10000, 8, small, large),
+    timing_tester(10000, 4, medium, large),
+    timing_tester(10000, 4, small, medium),
+    timing_tester(100000, 4, small, large).
 
 
 timing_tester(KeyCount, SegCount, SmallSize, LargeSize) ->

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -395,16 +395,16 @@ generate_segmentfilter_list(SegmentList, Size) ->
 %%
 %% Check with KeyCount=10000 SegCount=4 TreeSizes small large:
 %% adjust_segmentmatch_list check took 1.256 ms match_segment took 5.229 ms
-
+%%
 %% Check with KeyCount=10000 SegCount=8 TreeSizes small large:
 %% adjust_segmentmatch_list check took 2.065 ms match_segment took 8.637 ms
-
+%%
 %% Check with KeyCount=10000 SegCount=4 TreeSizes medium large:
 %% adjust_segmentmatch_list check took 0.453 ms match_segment took 4.843 ms
-
+%%
 %% Check with KeyCount=10000 SegCount=4 TreeSizes small medium:
 %% adjust_segmentmatch_list check took 0.451 ms match_segment took 5.528 ms
-
+%%
 %% Check with KeyCount=100000 SegCount=4 TreeSizes small large:
 %% adjust_segmentmatch_list check took 11.986 ms match_segment took 56.522 ms
 %%


### PR DESCRIPTION
Provides facilities to enhance leveled_tictac, and make it easier to fetch_clocks from a store hashed based on a `large` tree size, then the segments were found from comparing trees of a different size 