### PR TITLE
Tidy up unexported types

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -186,6 +186,7 @@
 -type head_timings() :: no_timing|#head_timings{}.
 -type timing_types() :: head|get|put|fold.
 
+
 -type open_options() :: 
     %% For full description of options see ../docs/STARTUP_OPTIONS.md
     [{root_path, string()|undefined} |
@@ -621,7 +622,7 @@ book_returnfolder(Pid, RunnerType) ->
                                      Start::IndexVal,
                                      End::IndexVal,
                                      ReturnTerms::boolean(),
-                                     TermRegex :: re:mp() | undefined.
+                                     TermRegex :: leveled_codec:regular_expression().
 
 book_indexfold(Pid, Constraint, FoldAccT, Range, TermHandling) ->
     RunnerType = 
@@ -730,7 +731,7 @@ book_keylist(Pid, Tag, Bucket, KeyRange, FoldAccT) ->
       StartKey :: Key,
       EndKey :: Key,
       Key :: term(),
-      TermRegex :: re:mp(),
+      TermRegex :: leveled_codec:regular_expression(),
       Runner :: fun(() -> Acc).
 book_keylist(Pid, Tag, Bucket, KeyRange, FoldAccT, TermRegex) ->
     RunnerType = {keylist, Tag, Bucket, KeyRange, FoldAccT, TermRegex},

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -134,6 +134,11 @@
         {index_specs(), infinity|integer()}. % {KeyChanges, TTL}
 -type maybe_lookup() ::
         lookup|no_lookup.
+-type regular_expression() ::
+        {re_pattern, term(), term(), term(), term()}|undefined. 
+    % first element must be re_pattern, but tuple may change legnth with
+    % versions
+
 
 
 -type segment_list() 
@@ -156,7 +161,8 @@
                 segment_list/0,
                 maybe_lookup/0,
                 last_moddate/0,
-                lastmod_range/0]).
+                lastmod_range/0,
+                regular_expression/0]).
 
 
 %%%============================================================================
@@ -801,7 +807,7 @@ get_metadata_from_siblings(<<ValLen:32/integer, Rest0/binary>>,
                                     MetaBin:MetaLen/binary>>,
                                     [LastMod|LastMods]).
 
--spec next_key(leveled_bookie:key()) -> leveled_bookie:key().
+-spec next_key(key()) -> key().
 %% @doc
 %% Get the next key to iterate from a given point
 next_key(Key) when is_binary(Key) ->

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -294,7 +294,7 @@
                             integer()}.
 -type pcl_state() :: #state{}.
 -type pcl_timings() :: no_timing|#pcl_timings{}.
--type levelzero_cacheentry() :: {pos_integer(), levled_tree:leveled_tree()}.
+-type levelzero_cacheentry() :: {pos_integer(), leveled_tree:leveled_tree()}.
 -type levelzero_cache() :: list(levelzero_cacheentry()).
 -type iterator_entry() 
     :: {pos_integer(), 

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -47,7 +47,6 @@
                     leveled_codec:ledger_key()|null}.
 -type fun_and_acc()
             :: {fun(), any()}.
--type term_regex() :: re:mp()|undefined.
 
 
 %%%============================================================================
@@ -147,7 +146,8 @@ index_query(SnapFun, {StartKey, EndKey, TermHandling}, FoldAccT) ->
     {async, Runner}.
 
 -spec bucketkey_query(fun(), leveled_codec:tag(), any(), 
-                        key_range(), fun_and_acc(), term_regex()) -> {async, fun()}.
+                        key_range(), fun_and_acc(),
+                        leveled_codec:regular_expression()) -> {async, fun()}.
 %% @doc
 %% Fold over all keys in `KeyRange' under tag (restricted to a given bucket)
 bucketkey_query(SnapFun, Tag, Bucket, 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1328,7 +1328,7 @@ take_max_lastmoddate(undefined, _LMDAcc) ->
 take_max_lastmoddate(LMD, LMDAcc) ->
     max(LMD, LMDAcc).
 
--spec generate_binary_slot(leveled_codec:lookup(),
+-spec generate_binary_slot(leveled_codec:maybe_lookup(),
                             list(leveled_codec:ledger_kv()),
                             press_method(),
                             boolean(),


### PR DESCRIPTION
also re:mp may not be exported in R16