### PR TITLE
Mas i209 rangeissue

### DIFF
--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1719,11 +1719,14 @@ read_slots(Handle, SlotList, {SegList, LowLastMod, BlockIndexCache},
                                                         PressMethod,
                                                         IdxModDate,
                                                         []),
+                                    % There is no range passed through to the
+                                    % binaryslot_reader, so this needs to
+                                    % filtered
                                     FilterFun =
                                         fun(KV) -> in_range(KV, SK, EK) end,
                                     Acc ++ lists:filter(FilterFun, KVL)
-                                        % Note check_blocks shouldreturn [] if
-                                        % PositionList is empty
+                                    % Note check_blocks shouldreturn [] if
+                                    % PositionList is empty
                             end
                     end
             end 
@@ -1733,6 +1736,8 @@ read_slots(Handle, SlotList, {SegList, LowLastMod, BlockIndexCache},
 
 -spec in_range(leveled_codec:ledger_kv(),
                 range_endpoint(), range_endpoint()) -> boolean().
+%% @doc
+%% Is the ledger key in the range.
 in_range({_LK, _LV}, all, all) ->
     true;
 in_range({LK, _LV}, all, EK) ->


### PR DESCRIPTION
When extracting a range of keys from a sst_file there were two primary paths:

1 - Extract the slot as a binary, and send that, along with a range to the reader which would extract the details and check the range

2 - If a segment list is provided to accelerate the query, extract individual KV pairs based on checking a segment list, and send that to the reader which would pass through those pairs straight to the iterator.

In the second way nothing was actually checking each key was in the range.  So if there existed a slot where  there were some keys in the range, but also some keys outside of the range which had a hash collision with the segment list - then the accumulator may receive individual results outside of the range.

The segment acceleration feature is only currently used by the proposed aae_fold feature in riak, and the error was detected in testing of that feature.

The resolution is to change stage 2 to filter the {K,V} pairs to check they are in the range when they are extracted.  This means that the process of range checking remains different whether or not a seglist is passed - so perhaps the root cause of confusion within the code remains.  However, there was no simple alternative way to fix the bug and keep the code concise.