### PR TITLE
Mas i211 breakingfolds

### DIFF
--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -451,7 +451,7 @@ pcl_fetchkeysbysegment(Pid, StartKey, EndKey, AccFun, InitAcc,
                     {fetch_keys, 
                         StartKey, EndKey, AccFun, InitAcc0, 
                         SegmentList, LastModRange, MaxKeys, 
-                        as_pcl},
+                        by_runner},
                     infinity).
 
 -spec pcl_fetchnextkey(pid(), 

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -782,7 +782,7 @@ multibucket_fold(_Config) ->
                                         ?RIAK_TAG, 
                                         {FoldBucketsFun, []}, 
                                         all),
-    BucketList = Folder(),
+    BucketList = lists:reverse(Folder()),
     ExpectedBucketList = 
         [{<<"Type1">>, <<"Bucket1">>}, {<<"Type2">>, <<"Bucket4">>}, 
             <<"Bucket2">>, <<"Bucket3">>],


### PR DESCRIPTION
For all async queries - allow the fold function to break out fo the query through a throw.

The throw will end the query (whilst still ensuring that the snapshot is tidied), and then re-throw so that a worker running the fold receives the break.

This can be used for ending a range query at a given point (e.g. at a special end_key which can't be articulated otherwise, or at a maximum number of results).  Note ordering of keys should not be assumed for foldobjects with sqn_order set to be the order.