### PR TITLE
warning-free vsns of string:str/2 & string:right/3

### DIFF
--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -498,10 +498,11 @@ generate_orderedkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_orderedkeys(Seqn, Count, Acc, BucketLow, BucketHigh) ->
     BNumber = Seqn div (BucketHigh - BucketLow),
-    BucketExt = string:right(integer_to_list(BucketLow + BNumber), 4, $0),
+    BucketExt = leveled_util:string_right(
+                  integer_to_list(BucketLow + BNumber), 4, $0),
     KNumber = Seqn * 100 + leveled_rand:uniform(100),
     KeyExt = 
-        string:right(integer_to_list(KNumber), 8, $0),
+        leveled_util:string_right(integer_to_list(KNumber), 8, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BucketExt, "Key" ++ KeyExt, o),
     Chunk = leveled_rand:rand_bytes(16),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -1386,7 +1386,8 @@ compact_journal_testto(WRP, ExpectedFiles) ->
     timer:sleep(1000),
     CompactedManifest2 = ink_getmanifest(Ink1),
     lists:foreach(fun({_SQN, FN, _P, _LK}) ->
-                            ?assertMatch(0, string:str(FN, ?COMPACT_FP))
+                            ?assertMatch(0, leveled_util:string_str(
+                                              FN, ?COMPACT_FP))
                         end,
                     CompactedManifest2),
     ?assertMatch(2, length(CompactedManifest2)),

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -263,9 +263,11 @@ generate_randomkeys(Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     K = {o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
     RandKey = {K, {Count + 1,
                     {active, infinity},

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -257,9 +257,11 @@ generate_randomkeys(Seqn, Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2487,8 +2487,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 6, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 6, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BNumber, "Key" ++ KNumber, o),
     Chunk = leveled_rand:rand_bytes(64),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -581,8 +581,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,


### PR DESCRIPTION
It seems as if OTP is in the process of deprecating `string:str/2` and `string:right/3` (building OTP from the latest sources will give warnings, which results in build failure due to `warnings_as_errors`, though OTP 21.1 does not give these warnings.)

These changes offer compatible implementations of `string:str/2` and `string:right/3`. Perhaps unnecessary to conditionally compile ... Without conditional compilation, the changes pass eunit tests on OTP 20.3. On 21.1 there are other failures unrelated to this PR (also on master, see issue #223).