### PR TITLE
Mas i229 loadrepeatedkey

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -2028,7 +2028,7 @@ addto_ledgercache({H, SQN, KeyChanges}, Cache) ->
                                     -> ledger_cache().
 %% @doc
 %% Add a set of changes associated witha single sequence number (journal 
-%% update) to the ledger cache.  This is used explicitly when laoding the
+%% update) to the ledger cache.  This is used explicitly when loading the
 %% ledger from the Journal (i.e. at startup) - and in this case the ETS insert
 %% can be bypassed, as all changes will be flushed to the Penciller before the
 %% load is complete.

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -200,7 +200,12 @@ merge_trees(StartKey, EndKey, TreeList, LevelMinus1) ->
 find_pos(<<>>, _Hash, PosList, _SlotID) ->
     PosList;
 find_pos(<<1:1/integer, Hash:23/integer, T/binary>>, Hash, PosList, SlotID) ->
-    find_pos(T, Hash, PosList ++ [SlotID], SlotID);
+    case lists:member(SlotID, PosList) of
+        true ->
+            find_pos(T, Hash, PosList, SlotID);
+        false ->
+            find_pos(T, Hash, PosList ++ [SlotID], SlotID)
+    end;
 find_pos(<<1:1/integer, _Miss:23/integer, T/binary>>, Hash, PosList, SlotID) ->
     find_pos(T, Hash, PosList, SlotID);
 find_pos(<<0:1/integer, NxtSlot:7/integer, T/binary>>, Hash, PosList, _SlotID) ->

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -30,7 +30,7 @@ recovery_with_samekeyupdates(_Config) ->
     % run a test that involves many updates to the same key, and check that
     % this doesn't cause performance to flatline in either the normal "PUT"
     % case, or in the case of the recovery from a lost keystore
-    AcceptableDuration = 300, % 5 minutes
+    AcceptableDuration = 180, % 3 minutes
     E2E_SW = os:timestamp(), % Used to track time for overall job
     
     RootPath = testutil:reset_filestructure(),


### PR DESCRIPTION
The index of the penciller L0 has an entry for every addition to the cache, including repeated additions for the same key.

Reading that index was producing a list of slots, which included multiple references to the same slot - and so slots were bing checked multiple times.

This change stops the behaviour of checking the slot multiple times, by making sure that a slot is not in the list of slots returned from reading the index before adding it.

There are still some potential inefficiencies here - as the size of the index is unnecessarily large.  However, in the test scenario (repeatedly updating the same 5 keys 5K times each), that inefficiency is a hit of<1ms per fetch.  So, for now, this can be carried, and the issue can be resolved through a minimal change.

Fixing the problem more completely would change the PUT path, and how the index is built.  This would involve some usort on the inputs to the index before the index is built (rather than just appending to the index binary each PUT).  The impact of this on CPU at PUT time is hard to predict.