### PR TITLE
Uw avoid set env

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1061,9 +1061,8 @@ init([Opts]) ->
             {InkerOpts, PencillerOpts} = set_options(Opts),
 
             LogLevel = proplists:get_value(log_level, Opts),
-            ok = application:set_env(leveled, log_level, LogLevel),
             ForcedLogs = proplists:get_value(forced_logs, Opts),
-            ok = application:set_env(leveled, forced_logs, ForcedLogs),
+            leveled_log:save(LogLevel, ForcedLogs),
 
             ConfiguredCacheSize = 
                 max(proplists:get_value(cache_size, Opts), ?MIN_CACHE_SIZE),

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -498,10 +498,11 @@ generate_orderedkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_orderedkeys(Seqn, Count, Acc, BucketLow, BucketHigh) ->
     BNumber = Seqn div (BucketHigh - BucketLow),
-    BucketExt = string:right(integer_to_list(BucketLow + BNumber), 4, $0),
+    BucketExt = leveled_util:string_right(
+                  integer_to_list(BucketLow + BNumber), 4, $0),
     KNumber = Seqn * 100 + leveled_rand:uniform(100),
     KeyExt = 
-        string:right(integer_to_list(KNumber), 8, $0),
+        leveled_util:string_right(integer_to_list(KNumber), 8, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BucketExt, "Key" ++ KeyExt, o),
     Chunk = leveled_rand:rand_bytes(16),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -140,7 +140,7 @@
 %% @doc
 %% Generate a new clerk
 clerk_new(InkerClerkOpts) ->
-    gen_server:start_link(?MODULE, [InkerClerkOpts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), InkerClerkOpts], []).
 
 -spec clerk_compact(pid(), pid(), 
                     fun(), fun(), fun(),  
@@ -170,7 +170,8 @@ clerk_trim(Pid, Inker, PersistedSQN) ->
 %% of the hastable in the CDB file - so that the file is not blocked during
 %% this calculation
 clerk_hashtablecalc(HashTree, StartPos, CDBpid) ->
-    {ok, Clerk} = gen_server:start_link(?MODULE, [#iclerk_options{}], []),
+    {ok, Clerk} = gen_server:start_link(?MODULE, [leveled_log:get_opts(),
+                                                  #iclerk_options{}], []),
     gen_server:cast(Clerk, {hashtable_calc, HashTree, StartPos, CDBpid}).
 
 -spec clerk_stop(pid()) -> ok.
@@ -183,7 +184,8 @@ clerk_stop(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([IClerkOpts]) ->
+init([LogOpts, IClerkOpts]) ->
+    leveled_log:save(LogOpts),
     ReloadStrategy = IClerkOpts#iclerk_options.reload_strategy,
     CDBopts = IClerkOpts#iclerk_options.cdb_options,
     WP = CDBopts#cdb_options.waste_path,

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -174,13 +174,13 @@
 %% The inker will need to know what the reload strategy is, to inform the
 %% clerk about the rules to enforce during compaction.
 ink_start(InkerOpts) ->
-    gen_server:start_link(?MODULE, [InkerOpts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), InkerOpts], []).
 
 -spec ink_snapstart(inker_options()) -> {ok, pid()}.
 %% @doc
 %% Don't link on startup as snapshot
 ink_snapstart(InkerOpts) ->
-    gen_server:start(?MODULE, [InkerOpts], []).
+    gen_server:start(?MODULE, [leveled_log:get_opts(), InkerOpts], []).
 
 -spec ink_put(pid(),
                 leveled_codec:ledger_key(),
@@ -450,7 +450,8 @@ ink_checksqn(Pid, LedgerSQN) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([InkerOpts]) ->
+init([LogOpts, InkerOpts]) ->
+    leveled_log:save(LogOpts),
     leveled_rand:seed(),
     case {InkerOpts#inker_options.root_path,
             InkerOpts#inker_options.start_snapshot} of

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -1386,7 +1386,8 @@ compact_journal_testto(WRP, ExpectedFiles) ->
     timer:sleep(1000),
     CompactedManifest2 = ink_getmanifest(Ink1),
     lists:foreach(fun({_SQN, FN, _P, _LK}) ->
-                            ?assertMatch(0, string:str(FN, ?COMPACT_FP))
+                            ?assertMatch(0, leveled_util:string_str(
+                                              FN, ?COMPACT_FP))
                         end,
                     CompactedManifest2),
     ?assertMatch(2, length(CompactedManifest2)),

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -60,7 +60,8 @@
 clerk_new(Owner, Manifest, CompressionMethod) ->
     {ok, Pid} = 
         gen_server:start_link(?MODULE, 
-                                [{compression_method, CompressionMethod}],
+                                [leveled_log:get_opts(),
+                                 {compression_method, CompressionMethod}],
                                 []),
     ok = gen_server:call(Pid, {load, Owner, Manifest}, infinity),
     leveled_log:log("PC001", [Pid, Owner]),
@@ -82,7 +83,8 @@ clerk_close(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([{compression_method, CompressionMethod}]) ->
+init([LogOpts, {compression_method, CompressionMethod}]) ->
+    leveled_log:save(LogOpts),
     {ok, #state{compression_method = CompressionMethod}}.
 
 handle_call({load, Owner, RootPath}, _From, State) ->

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -263,9 +263,11 @@ generate_randomkeys(Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     K = {o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
     RandKey = {K, {Count + 1,
                     {active, infinity},

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -317,13 +317,13 @@
 %% query is run against the level zero space and just the query results are
 %5 copied into the clone.  
 pcl_start(PCLopts) ->
-    gen_server:start_link(?MODULE, [PCLopts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), PCLopts], []).
 
 -spec pcl_snapstart(penciller_options()) -> {ok, pid()}.
 %% @doc
 %% Don't link to the bookie - this is a snpashot
 pcl_snapstart(PCLopts) ->
-    gen_server:start(?MODULE, [PCLopts], []).
+    gen_server:start(?MODULE, [leveled_log:get_opts(), PCLopts], []).
 
 -spec pcl_pushmem(pid(), bookies_memory()) -> ok|returned.
 %% @doc
@@ -600,7 +600,8 @@ pcl_checkforwork(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([PCLopts]) ->
+init([LogOpts, PCLopts]) ->
+    leveled_log:save(LogOpts),
     leveled_rand:seed(),
     case {PCLopts#penciller_options.root_path,
             PCLopts#penciller_options.start_snapshot,

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -257,9 +257,11 @@ generate_randomkeys(Seqn, Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2487,8 +2487,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 6, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 6, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BNumber, "Key" ++ KNumber, o),
     Chunk = leveled_rand:rand_bytes(64),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -581,8 +581,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,


### PR DESCRIPTION
Using `application:set_env/3` to store the log level is problematic in two ways:

* If multiple leveled instances are used in the same system, each subsequent log level setting will affect all running instances.
* Whereas the application_controller is mostly non-blocking, it isn't for `application:stop/1`, so any attempt to alter the log level after application:stop/1 is called (e.g. on mnesia) will cause a timeout exception.

This PR instead stores the log settings in the process dictionary of `leveled_bookie`. The processes spawned thereafter read the log settings before spawning and pass them on. A way to dynamically alter the log level is missing.

The change has been tested on an OTP 21 system, where both eunit and ct tests passed.