### PR TITLE
Mas pr231 review

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1061,9 +1061,8 @@ init([Opts]) ->
             {InkerOpts, PencillerOpts} = set_options(Opts),
 
             LogLevel = proplists:get_value(log_level, Opts),
-            ok = application:set_env(leveled, log_level, LogLevel),
             ForcedLogs = proplists:get_value(forced_logs, Opts),
-            ok = application:set_env(leveled, forced_logs, ForcedLogs),
+            leveled_log:save(LogLevel, ForcedLogs),
 
             ConfiguredCacheSize = 
                 max(proplists:get_value(cache_size, Opts), ?MIN_CACHE_SIZE),

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -498,10 +498,11 @@ generate_orderedkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_orderedkeys(Seqn, Count, Acc, BucketLow, BucketHigh) ->
     BNumber = Seqn div (BucketHigh - BucketLow),
-    BucketExt = string:right(integer_to_list(BucketLow + BNumber), 4, $0),
+    BucketExt = leveled_util:string_right(
+                  integer_to_list(BucketLow + BNumber), 4, $0),
     KNumber = Seqn * 100 + leveled_rand:uniform(100),
     KeyExt = 
-        string:right(integer_to_list(KNumber), 8, $0),
+        leveled_util:string_right(integer_to_list(KNumber), 8, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BucketExt, "Key" ++ KeyExt, o),
     Chunk = leveled_rand:rand_bytes(16),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -498,11 +498,11 @@ generate_orderedkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_orderedkeys(Seqn, Count, Acc, BucketLow, BucketHigh) ->
     BNumber = Seqn div (BucketHigh - BucketLow),
-    BucketExt = leveled_util:string_right(
-                  integer_to_list(BucketLow + BNumber), 4, $0),
-    KNumber = Seqn * 100 + leveled_rand:uniform(100),
-    KeyExt = 
-        leveled_util:string_right(integer_to_list(KNumber), 8, $0),
+    BucketExt =
+        io_lib:format("K~4..0B", [BucketLow + BNumber]),
+    KeyExt =
+        io_lib:format("K~8..0B", [Seqn * 100 + leveled_rand:uniform(100)]),
+    
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BucketExt, "Key" ++ KeyExt, o),
     Chunk = leveled_rand:rand_bytes(16),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -79,12 +79,16 @@
         handle_cast/2,
         handle_info/2,
         terminate/2,
-        clerk_new/1,
+        code_change/3]).
+
+-export([clerk_new/1,
         clerk_compact/7,
         clerk_hashtablecalc/3,
         clerk_trim/3,
         clerk_stop/1,
-        code_change/3]).      
+        clerk_loglevel/2,
+        clerk_addlogs/2,
+        clerk_removelogs/2]).   
 
 -export([schedule_compaction/3]).
 
@@ -104,7 +108,7 @@
 
 -record(state, {inker :: pid() | undefined,
                 max_run_length :: integer() | undefined,
-                cdb_options,
+                cdb_options = #cdb_options{} :: #cdb_options{},
                 waste_retention_period :: integer() | undefined,
                 waste_path :: string() | undefined,
                 reload_strategy = ?DEFAULT_RELOAD_STRATEGY :: list(),
@@ -179,6 +183,24 @@ clerk_hashtablecalc(HashTree, StartPos, CDBpid) ->
 %% Stop the clerk
 clerk_stop(Pid) ->
     gen_server:cast(Pid, stop).
+
+-spec clerk_loglevel(pid(), leveled_log:log_level()) -> ok.
+%% @doc
+%% Change the log level of the Journal
+clerk_loglevel(Pid, LogLevel) ->
+    gen_server:cast(Pid, {log_level, LogLevel}).
+
+-spec clerk_addlogs(pid(), list(string())) -> ok.
+%% @doc
+%% Add to the list of forced logs, a list of more forced logs
+clerk_addlogs(Pid, ForcedLogs) ->
+    gen_server:cast(Pid, {add_logs, ForcedLogs}).
+
+-spec clerk_removelogs(pid(), list(string())) -> ok.
+%% @doc
+%% Remove from the list of forced logs, a list of forced logs
+clerk_removelogs(Pid, ForcedLogs) ->
+    gen_server:cast(Pid, {remove_logs, ForcedLogs}).
 
 %%%============================================================================
 %%% gen_server callbacks
@@ -292,6 +314,21 @@ handle_cast({hashtable_calc, HashTree, StartPos, CDBpid}, State) ->
     {IndexList, HashTreeBin} = leveled_cdb:hashtable_calc(HashTree, StartPos),
     ok = leveled_cdb:cdb_returnhashtable(CDBpid, IndexList, HashTreeBin),
     {stop, normal, State};
+handle_cast({log_level, LogLevel}, State) ->
+    ok = leveled_log:set_loglevel(LogLevel),
+    CDBopts = State#state.cdb_options,
+    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    {noreply, State#state{cdb_options = CDBopts0}};
+handle_cast({add_logs, ForcedLogs}, State) ->
+    ok = leveled_log:add_forcedlogs(ForcedLogs),
+    CDBopts = State#state.cdb_options,
+    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    {noreply, State#state{cdb_options = CDBopts0}};
+handle_cast({remove_logs, ForcedLogs}, State) ->
+    ok = leveled_log:remove_forcedlogs(ForcedLogs),
+    CDBopts = State#state.cdb_options,
+    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    {noreply, State#state{cdb_options = CDBopts0}};
 handle_cast(stop, State) ->
     {stop, normal, State}.
 

--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -140,7 +140,7 @@
 %% @doc
 %% Generate a new clerk
 clerk_new(InkerClerkOpts) ->
-    gen_server:start_link(?MODULE, [InkerClerkOpts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), InkerClerkOpts], []).
 
 -spec clerk_compact(pid(), pid(), 
                     fun(), fun(), fun(),  
@@ -170,7 +170,8 @@ clerk_trim(Pid, Inker, PersistedSQN) ->
 %% of the hastable in the CDB file - so that the file is not blocked during
 %% this calculation
 clerk_hashtablecalc(HashTree, StartPos, CDBpid) ->
-    {ok, Clerk} = gen_server:start_link(?MODULE, [#iclerk_options{}], []),
+    {ok, Clerk} = gen_server:start_link(?MODULE, [leveled_log:get_opts(),
+                                                  #iclerk_options{}], []),
     gen_server:cast(Clerk, {hashtable_calc, HashTree, StartPos, CDBpid}).
 
 -spec clerk_stop(pid()) -> ok.
@@ -183,7 +184,8 @@ clerk_stop(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([IClerkOpts]) ->
+init([LogOpts, IClerkOpts]) ->
+    leveled_log:save(LogOpts),
     ReloadStrategy = IClerkOpts#iclerk_options.reload_strategy,
     CDBopts = IClerkOpts#iclerk_options.cdb_options,
     WP = CDBopts#cdb_options.waste_path,

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -1401,9 +1401,9 @@ compact_journal_testto(WRP, ExpectedFiles) ->
                             5000),
     timer:sleep(1000),
     CompactedManifest2 = ink_getmanifest(Ink1),
+    {ok, PrefixTest} = re:compile(?COMPACT_FP),
     lists:foreach(fun({_SQN, FN, _P, _LK}) ->
-                            ?assertMatch(0, leveled_util:string_str(
-                                              FN, ?COMPACT_FP))
+                            nomatch = re:run(FN, PrefixTest)
                         end,
                     CompactedManifest2),
     ?assertMatch(2, length(CompactedManifest2)),

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -174,13 +174,13 @@
 %% The inker will need to know what the reload strategy is, to inform the
 %% clerk about the rules to enforce during compaction.
 ink_start(InkerOpts) ->
-    gen_server:start_link(?MODULE, [InkerOpts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), InkerOpts], []).
 
 -spec ink_snapstart(inker_options()) -> {ok, pid()}.
 %% @doc
 %% Don't link on startup as snapshot
 ink_snapstart(InkerOpts) ->
-    gen_server:start(?MODULE, [InkerOpts], []).
+    gen_server:start(?MODULE, [leveled_log:get_opts(), InkerOpts], []).
 
 -spec ink_put(pid(),
                 leveled_codec:ledger_key(),
@@ -450,7 +450,8 @@ ink_checksqn(Pid, LedgerSQN) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([InkerOpts]) ->
+init([LogOpts, InkerOpts]) ->
+    leveled_log:save(LogOpts),
     leveled_rand:seed(),
     case {InkerOpts#inker_options.root_path,
             InkerOpts#inker_options.start_snapshot} of

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -1386,7 +1386,8 @@ compact_journal_testto(WRP, ExpectedFiles) ->
     timer:sleep(1000),
     CompactedManifest2 = ink_getmanifest(Ink1),
     lists:foreach(fun({_SQN, FN, _P, _LK}) ->
-                            ?assertMatch(0, string:str(FN, ?COMPACT_FP))
+                            ?assertMatch(0, leveled_util:string_str(
+                                              FN, ?COMPACT_FP))
                         end,
                     CompactedManifest2),
     ?assertMatch(2, length(CompactedManifest2)),

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -489,8 +489,7 @@ should_i_log(LogLevel, Levels, LogRef) ->
 
 is_active_level([L|_], L, _) -> true;
 is_active_level([L|_], _, L) -> false;
-is_active_level([_|T], C, L) -> is_active_level(T, C, L);
-is_active_level([]   , _, _) -> false.
+is_active_level([_|T], C, L) -> is_active_level(T, C, L).
 
 log_timer(LogReference, Subs, StartTime) ->
     log_timer(LogReference, Subs, StartTime, ?LOG_LEVELS).
@@ -571,5 +570,10 @@ shouldilog_test() ->
     ok = remove_forcedlogs(["G0001"]),
     ok = set_loglevel(info),
     ?assertMatch(false, should_i_log(debug, ?LOG_LEVELS, "D0001")).
+
+badloglevel_test() ->
+    % Set a bad log level - and everything logs
+    ?assertMatch(true, is_active_level(?LOG_LEVELS, debug, unsupported)),
+    ?assertMatch(true, is_active_level(?LOG_LEVELS, critical, unsupported)).
 
 -endif.

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -15,7 +15,8 @@
             add_forcedlogs/1,
             remove_forcedlogs/1,
             get_opts/0,
-            save/1]).
+            save/1,
+            return_settings/0]).
 
 
 -record(log_options, {log_level = info :: log_level(), 
@@ -24,7 +25,7 @@
 -type log_level()  ::  debug | info | warn | error | critical.
 -type log_options() :: #log_options{}.
 
--export_type([log_options/0]).
+-export_type([log_options/0, log_level/0]).
 
 -define(LOG_LEVELS, [debug, info, warn, error, critical]).
 -define(DEFAULT_LOG_LEVEL, error).
@@ -442,6 +443,12 @@ get_opts() ->
                          forced_logs = []}
     end.
 
+-spec return_settings() -> {log_level(), list(string())}.
+%% @doc
+%% Return the settings outside of the record
+return_settings() ->
+    LO = get_opts(),
+    {LO#log_options.log_level, LO#log_options.forced_logs}.
 
 %%%============================================================================
 %%% Prompt Logs

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -265,11 +265,13 @@ generate_randomkeys(Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Count, Acc, BucketLow, BRange) ->
-    BNumber = leveled_util:string_right(
-                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                4, $0),
-    KNumber = leveled_util:string_right(
-                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber =
+        lists:flatten(
+            io_lib:format("~4..0B",
+                            [BucketLow + leveled_rand:uniform(BRange)])),
+    KNumber =
+        lists:flatten(
+            io_lib:format("~4..0B", [leveled_rand:uniform(1000)])),
     K = {o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
     RandKey = {K, {Count + 1,
                     {active, infinity},

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -60,7 +60,8 @@
 clerk_new(Owner, Manifest, CompressionMethod) ->
     {ok, Pid} = 
         gen_server:start_link(?MODULE, 
-                                [{compression_method, CompressionMethod}],
+                                [leveled_log:get_opts(),
+                                 {compression_method, CompressionMethod}],
                                 []),
     ok = gen_server:call(Pid, {load, Owner, Manifest}, infinity),
     leveled_log:log("PC001", [Pid, Owner]),
@@ -82,7 +83,8 @@ clerk_close(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([{compression_method, CompressionMethod}]) ->
+init([LogOpts, {compression_method, CompressionMethod}]) ->
+    leveled_log:save(LogOpts),
     {ok, #state{compression_method = CompressionMethod}}.
 
 handle_call({load, Owner, RootPath}, _From, State) ->

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -263,9 +263,11 @@ generate_randomkeys(Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     K = {o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
     RandKey = {K, {Count + 1,
                     {active, infinity},

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -317,13 +317,13 @@
 %% query is run against the level zero space and just the query results are
 %5 copied into the clone.  
 pcl_start(PCLopts) ->
-    gen_server:start_link(?MODULE, [PCLopts], []).
+    gen_server:start_link(?MODULE, [leveled_log:get_opts(), PCLopts], []).
 
 -spec pcl_snapstart(penciller_options()) -> {ok, pid()}.
 %% @doc
 %% Don't link to the bookie - this is a snpashot
 pcl_snapstart(PCLopts) ->
-    gen_server:start(?MODULE, [PCLopts], []).
+    gen_server:start(?MODULE, [leveled_log:get_opts(), PCLopts], []).
 
 -spec pcl_pushmem(pid(), bookies_memory()) -> ok|returned.
 %% @doc
@@ -600,7 +600,8 @@ pcl_checkforwork(Pid) ->
 %%% gen_server callbacks
 %%%============================================================================
 
-init([PCLopts]) ->
+init([LogOpts, PCLopts]) ->
+    leveled_log:save(LogOpts),
     leveled_rand:seed(),
     case {PCLopts#penciller_options.root_path,
             PCLopts#penciller_options.start_snapshot,

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -257,9 +257,11 @@ generate_randomkeys(Seqn, Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
-    BNumber = string:right(integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                                            4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
+                4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -262,11 +262,12 @@ generate_randomkeys(Seqn, Count, BucketRangeLow, BucketRangeHigh) ->
 generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
-    BNumber = leveled_util:string_right(
-                integer_to_list(BucketLow + leveled_rand:uniform(BRange)),
-                4, $0),
-    KNumber = leveled_util:string_right(
-                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber =
+        lists:flatten(
+            io_lib:format("K~4..0B",
+                            [BucketLow + leveled_rand:uniform(BRange)])),
+    KNumber =
+        lists:flatten(io_lib:format("K~4..0B", [leveled_rand:uniform(1000)])),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -264,10 +264,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BNumber =
         lists:flatten(
-            io_lib:format("K~4..0B",
+            io_lib:format("~4..0B",
                             [BucketLow + leveled_rand:uniform(BRange)])),
     KNumber =
-        lists:flatten(io_lib:format("K~4..0B", [leveled_rand:uniform(1000)])),
+        lists:flatten(io_lib:format("~4..0B", [leveled_rand:uniform(1000)])),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2487,8 +2487,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 6, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 6, $0),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BNumber, "Key" ++ KNumber, o),
     Chunk = leveled_rand:rand_bytes(64),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2490,10 +2490,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = leveled_util:string_right(
-                integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = leveled_util:string_right(
-                integer_to_list(leveled_rand:uniform(1000)), 6, $0),
+    BNumber =
+        lists:flatten(io_lib:format("K~4..0B", [BucketLow + BRand])),
+    KNumber =
+        lists:flatten(io_lib:format("K~6..0B", [leveled_rand:uniform(1000)])),
     LK = leveled_codec:to_ledgerkey("Bucket" ++ BNumber, "Key" ++ KNumber, o),
     Chunk = leveled_rand:rand_bytes(64),
     {_B, _K, MV, _H, _LMs} =

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -581,10 +581,12 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = leveled_util:string_right(
-                integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = leveled_util:string_right(
-                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber =
+        lists:flatten(
+            io_lib:format("K~4..0B", [BucketLow + BRand])),
+    KNumber =
+        lists:flatten(
+            io_lib:format("K~8..0B", [leveled_rand:uniform(1000)])),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -581,8 +581,10 @@ generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
 generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     BRand = leveled_rand:uniform(BRange),
-    BNumber = string:right(integer_to_list(BucketLow + BRand), 4, $0),
-    KNumber = string:right(integer_to_list(leveled_rand:uniform(1000)), 4, $0),
+    BNumber = leveled_util:string_right(
+                integer_to_list(BucketLow + BRand), 4, $0),
+    KNumber = leveled_util:string_right(
+                integer_to_list(leveled_rand:uniform(1000)), 4, $0),
     {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
                 {Seqn, {active, infinity}, null}},
     generate_randomkeys(Seqn + 1,

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -16,18 +16,6 @@
             integer_time/1,
             magic_hash/1]).
 
--export([string_right/3,
-         string_str/2]).
-
--ifdef(OTP_RELEASE).
-
--if(?OTP_RELEASE >= 21).
--else.
--define(LEGACY_OTP, true).
--endif.
-
--endif.  % (OTP_RELEASE)
-
 
 -spec generate_uuid() -> list().
 %% @doc
@@ -76,47 +64,6 @@ hash1(H, <<B:8/integer, Rest/bytes>>) ->
     H2 = H1 bxor B,
     hash1(H2, Rest).
 
-%% A number of string functions have become deprecated in OTP 21
-%%
--ifdef(LEGACY_OTP).
-
-string_right(String, Len, Char) ->
-    string:right(String, Len, Char).
-
-string_str(S, Sub) ->
-    string:str(S, Sub).
-
--else.
-
-string_right(String, Len, Char) when is_list(String), is_integer(Char) ->
-    Slen = length(String),
-    if
-	Slen > Len -> lists:nthtail(Slen-Len, String);
-	Slen < Len -> chars(Char, Len-Slen, String);
-	Slen =:= Len -> String
-    end.
-
-chars(C, N, Tail) when N > 0 ->
-    chars(C, N-1, [C|Tail]);
-chars(C, 0, Tail) when is_integer(C) ->
-    Tail.
-
-
-string_str(S, Sub) when is_list(Sub) -> str(S, Sub, 1).
-
-str([C|S], [C|Sub], I) ->
-    case l_prefix(Sub, S) of
-        true -> I;
-        false -> str(S, [C|Sub], I+1)
-    end;
-str([_|S], Sub, I) -> str(S, Sub, I+1);
-str([], _Sub, _I) -> 0.
-
-l_prefix([C|Pre], [C|String]) -> l_prefix(Pre, String);
-l_prefix([], String) when is_list(String) -> true;
-l_prefix(Pre, String) when is_list(Pre), is_list(String) -> false.
-
--endif.
 
 %%%============================================================================
 %%% Test

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -197,8 +197,8 @@ journal_compaction_tester(Restart, WRP) ->
     ObjListD = testutil:generate_objects(10000, 2),
     lists:foreach(fun({_R, O, _S}) ->
                         testutil:book_riakdelete(Bookie0,
-                                                    O#r_object.bucket,
-                                                    O#r_object.key,
+                                                    testutil:get_bucket(O),
+                                                    testutil:get_key(O),
                                                     [])
                         end,
                     ObjListD),
@@ -577,8 +577,8 @@ load_and_count_withdelete(_Config) ->
                         0,
                         lists:seq(1, 20)),
     testutil:check_forobject(Bookie1, TestObject),
-    {BucketD, KeyD} = {TestObject#r_object.bucket,
-                            TestObject#r_object.key},
+    {BucketD, KeyD} =
+        {testutil:get_bucket(TestObject), testutil:get_key(TestObject)},
     {_, 1} = testutil:check_bucket_stats(Bookie1, BucketD),
     ok = testutil:book_riakdelete(Bookie1, BucketD, KeyD, []),
     not_found = testutil:book_riakget(Bookie1, BucketD, KeyD),

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -445,10 +445,12 @@ small_load_with2i(_Config) ->
     
     %% Delete the objects from the ChkList removing the indexes
     lists:foreach(fun({_RN, Obj, Spc}) ->
-                        DSpc = lists:map(fun({add, F, T}) -> {remove, F, T}
-                                                                end,
+                        DSpc = lists:map(fun({add, F, T}) -> 
+                                                {remove, F, T}
+                                            end,
                                             Spc),
-                        {B, K} = {Obj#r_object.bucket, Obj#r_object.key},
+                        {B, K} =
+                            {testutil:get_bucket(Obj), testutil:get_key(Obj)},
                         testutil:book_riakdelete(Bookie1, B, K, DSpc)
                         end,
                     ChkList1),

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -256,8 +256,8 @@ recovr_strategy(_Config) ->
     {TestObject, TestSpec} = testutil:generate_testobject(),
     ok = testutil:book_riakput(Book1, TestObject, TestSpec),
     ok = testutil:book_riakdelete(Book1,
-                                    TestObject#r_object.bucket,
-                                    TestObject#r_object.key,
+                                    testutil:get_bucket(TestObject),
+                                    testutil:get_key(TestObject),
                                     []),
     
     lists:foreach(fun({K, _SpcL}) -> 

--- a/test/end_to_end/riak_SUITE.erl
+++ b/test/end_to_end/riak_SUITE.erl
@@ -639,14 +639,14 @@ test_segfilter_query(Bookie, CLs) ->
 
     SegMapFun = 
         fun({_RN, RiakObject, _Spc}) ->
-            B = RiakObject#r_object.bucket,
-            K = RiakObject#r_object.key,
+            B = testutil:get_bucket(RiakObject),
+            K = testutil:get_key(RiakObject),
             leveled_tictac:keyto_segment32(<<B/binary, K/binary>>)
         end,
     BKMapFun = 
         fun({_RN, RiakObject, _Spc}) ->
-            B = RiakObject#r_object.bucket,
-            K = RiakObject#r_object.key,
+            B = testutil:get_bucket(RiakObject),
+            K = testutil:get_key(RiakObject),
             {B, K}
         end,
 

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -71,6 +71,18 @@
 -define(EMPTY_VTAG_BIN, <<"e">>).
 -define(ROOT_PATH, "test").
 
+-record(r_content, {
+          metadata,
+          value :: term()
+         }).
+
+-record(r_object, {
+          bucket,
+          key,
+          contents :: [#r_content{}],
+          vclock,
+          updatemetadata=dict:store(clean, true, dict:new()),
+          updatevalue :: term()}).
 
 riak_object(Bucket, Key, Value, MetaData) ->
     Content = #r_content{metadata=dict:from_list(MetaData), value=Value},


### PR DESCRIPTION
This is based on https://github.com/martinsumner/leveled/pull/231

Two changes required here:

- The use of string:right/2 and string:str/2 is no longer supported in OTP 21.
- There are issues with using set_env to change the log level and forced log list. 

The first issue has been handled by simply replacing the use of those functions.   They were only used in eunit tests, and they have been replaced with lists:flatten(io_lib:format()) and a regular expression respectively.

For the log issue, this takes @uwiger's change to pass log_options down through the chain of processes after having it passed in at startup.  However, there are some external functions added to allow for the logs to be changed at run-time:

```
-spec book_logsettings(pid()) -> {leveled_log:log_level(), list(string())}.
%% @doc
%% Retrieve the current log settings
...
-spec book_loglevel(pid(), leveled_log:log_level()) -> ok.
%% @doc
%% Change the log level of the store
...
-spec book_addlogs(pid(), list(string())) -> ok.
%% @doc
%% Add to the list of forced logs, a list of more forced logs
...
-spec book_removelogs(pid(), list(string())) -> ok.
%% @doc
%% Remove from the list of forced logs, a list of forced logs
```

These will filter down through the processes an update.  The exception is the `leveled_cdb` and `leveled_sst` file controllingactors.  They will not receive the update (but new actors of this type will start with the new settings).