### PR TITLE
Mas i244 startupcachesizes

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -139,7 +139,7 @@
         {warn, "We're doomed - intention recorded to destroy all files"}},
     {"P0031",
         {info, "Completion of update to levelzero"
-                    ++ " with cache size status ~w ~w"}},
+                    ++ " with cache_size=~w status=~w and update_success=~w"}},
     {"P0032",
         {info, "Fetch head timing with sample_count=~w and level timings of"
                     ++ " foundmem_time=~w found0_time=~w found1_time=~w" 
@@ -171,6 +171,8 @@
         {info, "Archiving filename ~s as unused at startup"}},
     {"P0041",
         {info, "Penciller manifest switched from SQN ~w to ~w"}},
+    {"P0042",
+        {warn, "Cache full so attempting roll memory with l0_size=~w"}},
         
     {"PC001",
         {info, "Penciller's clerk ~w started with owner ~w"}},

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -75,6 +75,9 @@
     {"B0019",
         {warn, "Use of book_indexfold with constraint of Bucket ~w with "
                     ++ "no StartKey is deprecated"}},
+    {"B0020",
+        {warn, "Ratio of penciller cache size ~w to bookie's memory "
+                    ++ "cache size ~w is larger than expected"}},
 
     {"R0001",
         {debug, "Object fold to process batch of ~w objects"}},

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -38,7 +38,8 @@
         add_to_index/3,
         new_index/0,
         clear_index/1,
-        check_index/2
+        check_index/2,
+        cache_full/1
         ]).      
 
 -include_lib("eunit/include/eunit.hrl").
@@ -51,6 +52,12 @@
 %%%============================================================================
 %%% API
 %%%============================================================================
+
+-spec cache_full(list()) -> boolean().
+%% @doc
+%% If there are already 127 entries in the cache then the cache is full
+cache_full(L0Cache) ->
+    length(L0Cache) == 127.
 
 -spec prepare_for_index(index_array(), leveled_codec:segment_hash()) 
                                                             -> index_array().

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -474,9 +474,16 @@ fetchput_snapshot(_Config) ->
 load_and_count(_Config) ->
     % Use artificially small files, and the load keys, counting they're all
     % present
+    load_and_count(50000000, 2500, 28000),
+    load_and_count(200000000, 100, 300000).
+
+
+load_and_count(JournalSize, BookiesMemSize, PencillerMemSize) ->
     RootPath = testutil:reset_filestructure(),
     StartOpts1 = [{root_path, RootPath},
-                    {max_journalsize, 50000000},
+                    {max_journalsize, JournalSize},
+                    {cache_size, BookiesMemSize},
+                    {max_pencillercachesize, PencillerMemSize},
                     {sync_strategy, testutil:sync_strategy()}],
     {ok, Bookie1} = leveled_bookie:book_start(StartOpts1),
     {TestObject, TestSpec} = testutil:generate_testobject(),


### PR DESCRIPTION
Check startup cache sizes, and log a warning if they make no sense.  Also, handle the situation where the cache list is full - and rather than crashing 'return' PUT requests to the bookie (so that it can slow offer if necessary).