### PR TITLE
Mas i249 sstcloseraces

### DIFF
--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -638,8 +638,12 @@ reader(close, _From, State) ->
     {stop, normal, ok, State}.
 
 reader(timeout, State) ->
-    true = is_process_alive(State#state.starting_pid),
-    {next_state, reader, State}.
+    case is_process_alive(State#state.starting_pid) of
+        true ->
+            {next_state, reader, State};
+        false ->
+            {stop, normal, State}
+    end.
 
 
 delete_pending({get_kv, LedgerKey, Hash}, _From, State) ->

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -92,6 +92,7 @@
 -define(COMPRESS_AT_LEVEL, 1).
 -define(INDEX_MODDATE, true).
 -define(USE_SET_FOR_SPEED, 64).
+-define(STARTUP_TIMEOUT, 10000).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -103,6 +104,7 @@
         code_change/4,
         starting/2,
         starting/3,
+        reader/2,
         reader/3,
         delete_pending/2,
         delete_pending/3]).
@@ -185,6 +187,7 @@
                     index_moddate = ?INDEX_MODDATE :: boolean(),
                     timings = no_timing :: sst_timings(),
                     timings_countdown = 0 :: integer(),
+                    starting_pid :: pid()|undefined,
                     fetch_cache = array:new([{size, ?CACHE_SIZE}])}).
 
 -record(sst_timings, 
@@ -266,7 +269,8 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, IndexModDate) ->
                                         {SlotList, FK},
                                         MaxSQN,
                                         OptsSST0,
-                                        IndexModDate},
+                                        IndexModDate,
+                                        self()},
                                     infinity) of
         {ok, {SK, EK}, Bloom} ->
             {ok, Pid, {SK, EK}, Bloom}
@@ -322,7 +326,8 @@ sst_new(RootPath, Filename,
                                                 {SlotList, FK},
                                                 MaxSQN,
                                                 OptsSST0,
-                                                IndexModDate},
+                                                IndexModDate,
+                                                self()},
                                             infinity) of
                 {ok, {SK, EK}, Bloom} ->
                     {ok, Pid, {{Rem1, Rem2}, SK, EK}, Bloom}
@@ -463,7 +468,7 @@ starting({sst_open, RootPath, Filename, OptsSST}, _From, State) ->
 starting({sst_new, 
             RootPath, Filename, Level, 
             {SlotList, FirstKey}, MaxSQN,
-            OptsSST, IdxModDate}, _From, State) ->
+            OptsSST, IdxModDate, StartingPID}, _From, State) ->
     SW = os:timestamp(),
     leveled_log:save(OptsSST#sst_options.log_options),
     PressMethod = OptsSST#sst_options.press_method,
@@ -485,7 +490,9 @@ starting({sst_new,
     {reply,
         {ok, {Summary#summary.first_key, Summary#summary.last_key}, Bloom},
         reader,
-        UpdState#state{blockindex_cache = BlockIndex}}.
+        UpdState#state{blockindex_cache = BlockIndex,
+                        starting_pid = StartingPID},
+        ?STARTUP_TIMEOUT}.
 
 starting({sst_newlevelzero, RootPath, Filename,
                     Slots, FetchFun, Penciller, MaxSQN,
@@ -629,6 +636,10 @@ reader(background_complete, _From, State) ->
 reader(close, _From, State) ->
     ok = file:close(State#state.handle),
     {stop, normal, ok, State}.
+
+reader(timeout, State) ->
+    true = is_process_alive(State#state.starting_pid),
+    {next_state, reader, State}.
 
 
 delete_pending({get_kv, LedgerKey, Hash}, _From, State) ->

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -170,7 +170,7 @@ bigsst_littlesst(_Config) ->
     RootPath = testutil:reset_filestructure(),
     StartOpts1 = [{root_path, RootPath},
                     {max_journalsize, 50000000},
-                    {cache_size, 1000},
+                    {cache_size, 500},
                     {max_pencillercachesize, 16000},
                     {max_sstslots, 256},
                     {sync_strategy, testutil:sync_strategy()},
@@ -195,7 +195,7 @@ bigsst_littlesst(_Config) ->
     ok = leveled_bookie:book_destroy(Bookie2),
     io:format("Big SST ~w files Little SST ~w files~n",
                 [length(FNS1), length(FNS2)]),
-    true = length(FNS2) >  (2 * length(FNS1)).
+    true = length(FNS2) >=  (2 * length(FNS1)).
     
 
 


### PR DESCRIPTION
Ensure that sst files outside of the manifest when the penciller closes, are still shut down.