### PR TITLE
Check SQN order fold does not fold beyond end of snapshot

### DIFF
--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -1482,6 +1482,11 @@ compare_to_sqn(Obj, SQN) ->
                 SQNToCompare > SQN ->
                     false;
                 true ->
+                    % Normally we would expect the SQN to be equal here, but
+                    % this also allows for the Journal to have a more advanced
+                    % value. We return true here as we wouldn't want to
+                    % compact thta more advanced value, but this may cause
+                    % confusion in snapshots.
                     true
             end
     end.


### PR DESCRIPTION
The Journal snapshot is not a true snapshot, in that the active file in the snapshot can still be taking appends.  So when getting a snapshot it is necessary to check if folding over the snapshot that the SQN is <= JournalSQN when the snapshot is taken.

Normally consistency of the snapshot is managed as the operation depends on the penciller, and the penciller *is* a snapshot.  Not in this case, as the penciller will return true on a sqn check if the pcl SQN is behind the Journal.  So the Journal folder, has been given an additional check to stop at the JournalSQN.

This is perhaps a fault in the pcl check sqn, which should only return true on an exact match?  I'm nervous about changing this though, so we have a less pure fix for now.