### PR TITLE
Stop using sync_send_event/2 with default timeout

### DIFF
--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -359,7 +359,8 @@ sst_newlevelzero(RootPath, Filename,
                                     Penciller,
                                     MaxSQN,
                                     OptsSST0,
-                                    ?INDEX_MODDATE}),
+                                    ?INDEX_MODDATE}, 
+                                infinity),
     ok = 
         case is_list(Fetcher) of
             true ->


### PR DESCRIPTION
On CDB and SST files.  Only use for close and APIs exclusively used in unit tests.