### PR TITLE
GC before transitioning a L0 to reader

### DIFF
--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -186,8 +186,9 @@ merge(SrcLevel, Manifest, RootPath, OptsSST) ->
     leveled_log:log("PC008", [SrcLevel, Candidates]),
     case Candidates of
         0 ->
-            leveled_log:log("PC009",
-                                [Src#manifest_entry.filename, SrcLevel + 1]),
+            NewLevel = SrcLevel + 1,
+            leveled_log:log("PC009", [Src#manifest_entry.filename, NewLevel]),
+            leveled_sst:sst_switchlevels(Src#manifest_entry.owner, NewLevel),
             Man0 = leveled_pmanifest:switch_manifest_entry(Manifest,
                                                             NewSQN,
                                                             SrcLevel,


### PR DESCRIPTION
The L0 Pid has used a lot of memory in the construction of the file (something like 50MB).  This won't be GC'd immediately.  This is fine, as this will normally be short-lived.  However if the SST file is switched levels ... then this may mean that we have multiple SST files with memory  in this state.

To make sure that the erlang VM has this memory freed, this garbage_collects a SST file if it is switched. 

Not doing this may cause issues in the handoff scenario in Riak (with large transfer limits)