### PR TITLE
Prefer version of lz4 with simpler build

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -16,5 +16,5 @@
  ]}.
 
 {deps, [
-        {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4", {tag, "0.2.4"}}}
+        {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4", {ref, "e7ccf4fc9a806982055f26772522c3543c89d1b5"}}}
         ]}.


### PR DESCRIPTION
... thanks to rebar3 pc plugin rather than custom makefile.

I also [requested upstream when a new tag will be released](https://github.com/szktty/erlang-lz4/issues/11) though I am not sure whether and when that will happen.

----

Attempting to compile locally project including this as a dependency, I got error hence this PR.
```
cc .../_build/default/lib/lz4/c_src/lz4hc.o .../_build/default/lib/lz4/c_src/lz4_nif.o .../_build/default/lib/lz4/c_src/lz4.o -L /Users/.../homebrew/opt/libsodium/lib -shared -L /Users/.../kerl/installations/OTP-20.3.8.20/lib/erl_interface-3.10.2.1/lib -lerl_interface -lei -o .../_build/default/lib/lz4/c_src/../priv/lz4.so
Undefined symbols for architecture x86_64:
  "_enif_alloc_binary", referenced from:
      _nif_compress in lz4_nif.o
      _nif_uncompress in lz4_nif.o
```