### PR TITLE
Memory management

### DIFF
--- a/src/leveled_head.erl
+++ b/src/leveled_head.erl
@@ -263,8 +263,8 @@ riak_extract_metadata(delete, Size) ->
     {{delete, null, null, Size}, []};
 riak_extract_metadata(ObjBin, Size) ->
     {VclockBin, SibBin, LastMods} = riak_metadata_from_binary(ObjBin),
-    {{SibBin, 
-            VclockBin, 
+    {{binary:copy(SibBin), 
+            binary:copy(VclockBin), 
             erlang:phash2(lists:sort(binary_to_term(VclockBin))), 
             Size},
         LastMods}.


### PR DESCRIPTION
Extracting binary from within a binary leaves a reference to the whole of the original binary.

If there are a lot of very large objects received back to back - this can explode the amount of memory the penciller appears to hold (and gc cannot resolve this).

To dereference from the larger binary, need to do a binary copy.

The difference in throughput before and after the change (using the standard NHS volume test) is within the margin of error - there was 0.8% more throughput achieved with the binary copy.

<img width="1229" alt="Comparison with and without binary copy" src="https://user-images.githubusercontent.com/1628897/59673032-81405e00-91b8-11e9-9292-b60f0b1385a7.png">
