### PR TITLE
Address OTP24 warnings, ct and eunit paths

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [warnings_as_errors,
-	    {platform_define, "^2[0-1]{1}", fsm_deprecated},
+	    {platform_define, "^2[0-4]{1}", fsm_deprecated},
             {platform_define, "^1[7-8]{1}", old_rand},
             {platform_define, "^17", no_log2},
             {platform_define, "^R", no_sync},
@@ -12,9 +12,15 @@
 {profiles,
  [{eqc, [{deps, [meck, fqc]},
     {erl_opts, [debug_info,  {parse_transform, eqc_cover}]},
-    {extra_src_dirs, ["test"]}]}
+    {extra_src_dirs, ["test"]}]},
+  {test, [
+    {eunit_compile_opts, [{src_dirs, ["src", "test/end_to_end", "test/volume"]}]}
+   ]}
  ]}.
 
 {deps, [
         {lz4, ".*", {git, "https://github.com/szktty/erlang-lz4", {tag, "0.2.4"}}}
         ]}.
+
+{ct_opts, [{dir, ["test/end_to_end",
+                  "test/volume" ]}]}.

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -2826,9 +2826,9 @@ foldobjects_vs_hashtree_testto() ->
         fun(B, K, ProxyV, Acc) ->
             {proxy_object,
                 MD,
-                _Size,
+                _Size1,
                 _Fetcher} = binary_to_term(ProxyV),
-            {Hash, _Size, _UserDefinedMD} = MD,
+            {Hash, _Size0, _UserDefinedMD} = MD,
             [{B, K, Hash}|Acc]
         end,
 

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -1555,7 +1555,7 @@ read_integerpairs(<<Int1:32, Int2:32, Rest/binary>>, Pairs) ->
 %% false - don't check the CRC before returning key & value
 %% loose_presence - confirm that the hash of the key is present
 search_hash_table(_Handle, 
-                    {_, _, _TotalSlots, _TotalSlots}, 
+                    {_, _, TotalSlots, TotalSlots},
                     _Hash, _Key,
                     _QuickCheck, _BinaryMode, Timings) -> 
     % We have done the full loop - value must not be present

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -1397,7 +1397,7 @@ compact_journal_testto(WRP, ExpectedFiles) ->
     build_dummy_journal(fun test_ledgerkey/1),
     {ok, Ink1} = ink_start(InkOpts),
     
-    {ok, NewSQN1, _ObjSize} = ink_put(Ink1,
+    {ok, NewSQN1, ObjSize} = ink_put(Ink1,
                                         test_ledgerkey("KeyAA"),
                                         "TestValueAA",
                                         {[], infinity}),
@@ -1417,7 +1417,7 @@ compact_journal_testto(WRP, ExpectedFiles) ->
                             {SQN, test_ledgerkey(PK)}
                             end,
                         FunnyLoop),
-    {ok, NewSQN2, _ObjSize} = ink_put(Ink1,
+    {ok, NewSQN2, ObjSize} = ink_put(Ink1,
                                         test_ledgerkey("KeyBB"),
                                         "TestValueBB",
                                         {[], infinity}),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -297,16 +297,16 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, IndexModDate) ->
             {ok, Pid, {SK, EK}, Bloom}
     end.
 
--spec sst_newmerge(string(), string(), 
-                    list(leveled_codec:ledger_kv()|sst_pointer()), 
+-spec sst_newmerge(string(), string(),
                     list(leveled_codec:ledger_kv()|sst_pointer()),
-                    boolean(), integer(), 
+                    list(leveled_codec:ledger_kv()|sst_pointer()),
+                    boolean(), integer(),
                     integer(), sst_options())
-            -> empty|{ok, pid(), 
-                {{list(leveled_codec:ledger_kv()), 
-                        list(leveled_codec:ledger_kv())}, 
-                    leveled_codec:ledger_key(), 
-                    leveled_codec:ledger_key()}, 
+            -> empty|{ok, pid(),
+                {{list(leveled_codec:ledger_kv()),
+                        list(leveled_codec:ledger_kv())},
+                    leveled_codec:ledger_key(),
+                    leveled_codec:ledger_key()},
                     binary()}.
 %% @doc
 %% Start a new SST file at the assigned level passing in a two lists of
@@ -319,11 +319,11 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, IndexModDate) ->
 %% be that the merge_lists returns nothing (for example when a basement file is
 %% all tombstones) - and the atom empty is returned in this case so that the
 %% file is not added to the manifest.
-sst_newmerge(RootPath, Filename, 
-        KVL1, KVL2, IsBasement, Level, 
+sst_newmerge(RootPath, Filename,
+        KVL1, KVL2, IsBasement, Level,
         MaxSQN, OptsSST) ->
-    sst_newmerge(RootPath, Filename, 
-        KVL1, KVL2, IsBasement, Level, 
+    sst_newmerge(RootPath, Filename,
+        KVL1, KVL2, IsBasement, Level,
         MaxSQN, OptsSST, ?INDEX_MODDATE, ?TOMB_COUNT).
 
 sst_newmerge(RootPath, Filename, 
@@ -2759,14 +2759,14 @@ update_timings(SW, Timings, Stage, Continue) ->
 -define(TEST_AREA, "test/test_area/").
 
 testsst_new(RootPath, Filename, Level, KVList, MaxSQN, PressMethod) ->
-    OptsSST = 
+    OptsSST =
         #sst_options{press_method=PressMethod,
                         log_options=leveled_log:get_opts()},
     sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, false).
 
-testsst_new(RootPath, Filename, 
+testsst_new(RootPath, Filename,
             KVL1, KVL2, IsBasement, Level, MaxSQN, PressMethod) ->
-    OptsSST = 
+    OptsSST =
         #sst_options{press_method=PressMethod,
                         log_options=leveled_log:get_opts()},
     sst_newmerge(RootPath, Filename, KVL1, KVL2, IsBasement, Level, MaxSQN,
@@ -2850,17 +2850,17 @@ tombcount_test() ->
     OptsSST = 
         #sst_options{press_method=native,
                         log_options=leveled_log:get_opts()},
-    {ok, SST1, _KD, _BB} = sst_newmerge(RP, Filename, 
-                                KVL1, KVL2, false, 2, 
-                                N, OptsSST, false, false),
+    {ok, SST1, KD, BB} = sst_newmerge(RP, Filename,
+                               KVL1, KVL2, false, 2,
+                               N, OptsSST, false, false),
     ?assertMatch(not_counted, sst_gettombcount(SST1)),
     ok = sst_close(SST1),
     ok = file:delete(filename:join(RP, Filename ++ ".sst")),
 
-    {ok, SST2, _KD, _BB} = sst_newmerge(RP, Filename, 
-                                KVL1, KVL2, false, 2, 
-                                N, OptsSST, false, true),
-    
+    {ok, SST2, KD, BB} = sst_newmerge(RP, Filename,
+                               KVL1, KVL2, false, 2,
+                               N, OptsSST, false, true),
+
     ?assertMatch(ExpectedCount, sst_gettombcount(SST2)),
     ok = sst_close(SST2),
     ok = file:delete(filename:join(RP, Filename ++ ".sst")).
@@ -2913,7 +2913,7 @@ indexed_list_test() ->
 
     SW0 = os:timestamp(),
 
-    {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} = 
+    {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(lookup, KVL1, native, ?INDEX_MODDATE, no_timing),
     io:format(user,
                 "Indexed list created slot in ~w microseconds of size ~w~n",
@@ -2942,7 +2942,7 @@ indexed_list_mixedkeys_test() ->
     KVL1 = lists:sublist(KVL0, 33),
     Keys = lists:ukeysort(1, generate_indexkeys(60) ++ KVL1),
 
-    {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} = 
+    {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(lookup, Keys, native, ?INDEX_MODDATE, no_timing),
 
     {TestK1, TestV1} = lists:nth(4, KVL1),
@@ -2969,7 +2969,7 @@ indexed_list_mixedkeys2_test() ->
     IdxKeys2 = lists:ukeysort(1, generate_indexkeys(30)),
     % this isn't actually ordered correctly
     Keys = IdxKeys1 ++ KVL1 ++ IdxKeys2,
-    {{_Header, FullBin, _HL, _LK}, no_timing} = 
+    {{_Header, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(lookup, Keys, native, ?INDEX_MODDATE, no_timing),
     lists:foreach(fun({K, V}) ->
                         MH = leveled_codec:segment_hash(K),
@@ -2980,9 +2980,9 @@ indexed_list_mixedkeys2_test() ->
 indexed_list_allindexkeys_test() ->
     Keys = lists:sublist(lists:ukeysort(1, generate_indexkeys(150)), 
                             ?LOOK_SLOTSIZE),
-    {{HeaderT, FullBinT, _HL, _LK}, no_timing} = 
+    {{HeaderT, FullBinT, HL, LK}, no_timing} =
         generate_binary_slot(lookup, Keys, native, true, no_timing),
-    {{HeaderF, FullBinF, _HL, _LK}, no_timing} = 
+    {{HeaderF, FullBinF, HL, LK}, no_timing} =
         generate_binary_slot(lookup, Keys, native, false, no_timing),
     EmptySlotSize = ?LOOK_SLOTSIZE - 1,
     LMD = ?FLIPPER32,
@@ -3234,7 +3234,7 @@ simple_persisted_range_tester(SSTNewFun) ->
     KVList1 = lists:ukeysort(1, KVList0),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} =
         SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
     
     {o, B, K, null} = LastKey,
@@ -3276,7 +3276,7 @@ simple_persisted_rangesegfilter_tester(SSTNewFun) ->
     KVList1 = lists:ukeysort(1, KVList0),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} =
         SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
     
     SK1 = element(1, lists:nth(124, KVList1)),
@@ -3424,7 +3424,7 @@ simple_persisted_slotsize_tester(SSTNewFun) ->
                             ?LOOK_SLOTSIZE),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} =
         SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
     lists:foreach(fun({K, V}) ->
                         ?assertMatch({K, V}, sst_get(Pid, K))
@@ -3465,7 +3465,7 @@ simple_persisted_tester(SSTNewFun) ->
     KVList1 = lists:ukeysort(1, KVList0),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, Pid, {FirstKey, LastKey}, Bloom} =
         SSTNewFun(RP, Filename, Level, KVList1, length(KVList1), native),
     
     B0 = check_binary_references(Pid),
@@ -3533,7 +3533,7 @@ simple_persisted_tester(SSTNewFun) ->
     ?assertMatch(SubKVList1L, length(FetchedList2)),
     ?assertMatch(SubKVList1, FetchedList2),
     
-    {Eight000Key, _v800} = lists:nth(800, KVList1),
+    {Eight000Key, V800} = lists:nth(800, KVList1),
     SubKVListA1 = lists:sublist(KVList1, 10, 791),
     SubKVListA1L = length(SubKVListA1),
     FetchListA2 = sst_getkvrange(Pid, TenthKey, Eight000Key, 2),
@@ -3565,7 +3565,7 @@ simple_persisted_tester(SSTNewFun) ->
                                     Eight000Key,
                                     4),
     FetchedListB4 = lists:foldl(FoldFun, [], FetchListB4),
-    ?assertMatch([{Eight000Key, _v800}], FetchedListB4),
+    ?assertMatch([{Eight000Key, V800}], FetchedListB4),
     
     B1 = check_binary_references(Pid),
 
@@ -3574,7 +3574,7 @@ simple_persisted_tester(SSTNewFun) ->
     io:format(user, "Reopen SST file~n", []),
     OptsSST = #sst_options{press_method=native,
                             log_options=leveled_log:get_opts()},
-    {ok, OpenP, {FirstKey, LastKey}, _Bloom} =
+    {ok, OpenP, {FirstKey, LastKey}, Bloom} =
         sst_open(RP, Filename ++ ".sst", OptsSST, Level),
 
     B2 = check_binary_references(OpenP),

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -244,8 +244,8 @@ alter_segment(Segment, Hash, Tree) ->
 %% Returns a list of segment IDs which hold differences between the state
 %% represented by the two trees.
 find_dirtyleaves(SrcTree, SnkTree) ->
-    _Size = SrcTree#tictactree.size,
-    _Size = SnkTree#tictactree.size,
+    Size = SrcTree#tictactree.size,
+    Size = SnkTree#tictactree.size,
     
     IdxList = find_dirtysegments(fetch_root(SrcTree), fetch_root(SnkTree)),
     SrcLeaves = fetch_leaves(SrcTree, IdxList),

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -103,11 +103,11 @@ magichashperf_test() ->
             {K, X}
         end,
     KL = lists:map(KeyFun, lists:seq(1, 1000)),
-    {TimeMH, _HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
+    {TimeMH, HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
     io:format(user, "1000 keys magic hashed in ~w microseconds~n", [TimeMH]),
     {TimePH, _Hl2} = timer:tc(lists, map, [fun(K) -> erlang:phash2(K) end, KL]),
     io:format(user, "1000 keys phash2 hashed in ~w microseconds~n", [TimePH]),
-    {TimeMH2, _HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
+    {TimeMH2, HL1} = timer:tc(lists, map, [fun(K) -> magic_hash(K) end, KL]),
     io:format(user, "1000 keys magic hashed in ~w microseconds~n", [TimeMH2]).
 
 


### PR DESCRIPTION
OTP 24 introduces some new warnings. Also, the `platform_define` regexp for `fsm_deprecated` was extended.
Some CT and EUnit options added to the rebar.config to ensure that tests can be run (some eunit tests failed - not sure if caused by some of the code changes to eliminate warnings, i.e. reuse of variables with '_' prefix).