### PR TITLE
Handle a Filename not being present in pending_deletes

### DIFF
--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -2108,6 +2108,7 @@ find_firstzero_test() ->
 
 cyclecount_test() ->
     io:format("~n~nStarting cycle count test~n"),
+    ok = filelib:ensure_dir("test/test_area"),
     KVL1 = generate_sequentialkeys(5000, []),
     KVL2 = lists:foldl(fun({K, V}, Acc) ->
                             H = hash(K),

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -2108,7 +2108,7 @@ find_firstzero_test() ->
 
 cyclecount_test() ->
     io:format("~n~nStarting cycle count test~n"),
-    ok = filelib:ensure_dir("test/test_area"),
+    ok = filelib:ensure_dir("test/test_area/"),
     KVL1 = generate_sequentialkeys(5000, []),
     KVL2 = lists:foldl(fun({K, V}, Acc) ->
                             H = hash(K),


### PR DESCRIPTION
This may be due to a situation whereby a second confirm_delete has been sent before the sst_deleteconfirmed has been received from the first request.

Now this will now cause inert action rather than crashing.