### PR TITLE
Amend defaults

### DIFF
--- a/priv/leveled.schema
+++ b/priv/leveled.schema
@@ -21,14 +21,14 @@
 
 %% @doc The key size of the Bookie's in-memory cache 
 {mapping, "leveled.cache_size", "leveled.cache_size", [
-  {default, 2500},
+  {default, 2000},
   {datatype, integer},
   hidden
 ]}.
 
 %% @doc The key size of the Penciller's in-memory cache
 {mapping, "leveled.penciller_cache_size", "leveled.penciller_cache_size", [
-  {default, 28000},
+  {default, 20000},
   {datatype, integer},
   hidden
 ]}.
@@ -102,9 +102,9 @@
 
 %% @doc The number of times per day to score an individual file for compaction.
 %% The default value will lead to each file, on average, being scored once
-%% every 8 hours
+%% every 12 hours
 {mapping, "leveled.compaction_scores_perday", "leveled.compaction_scores_perday", [
-  {default, 3},
+  {default, 2},
   {datatype, integer}
 ]}.
 
@@ -170,7 +170,7 @@
 ]}.
 
 %% @doc Snapshot timeout (long)
-%% Maximum expected time for any othe rfold.  A fold which is taking longer
+%% Maximum expected time for any other fold.  A fold which is taking longer
 %% than this may fail as it will be released - potentially allowing for some
 %% file processes to delete.  Timeout is in seconds.
 {mapping, "leveled.snapshot_timeout_long", "leveled.snapshot_timeout_long", [

--- a/priv/leveled_multi.schema
+++ b/priv/leveled_multi.schema
@@ -98,7 +98,7 @@
 
 %% @doc The number of times per day to score an individual file for compaction
 %% The default value will lead to each file, on average, being scored once
-%% every 8 hours
+%% every 12 hours
 {mapping, "multi_backend.$name.leveled.compaction_scores_perday", "riak_kv.multi_backend", [
   {default, 2},
   {datatype, integer}

--- a/priv/leveled_multi.schema
+++ b/priv/leveled_multi.schema
@@ -23,14 +23,14 @@
 
 %% @doc The key size of the Bookie's in-memory cache 
 {mapping, "multi_backend.$name.leveled.cache_size", "riak_kv.multi_backend", [
-  {default, 4000},
+  {default, 2000},
   {datatype, integer},
   hidden
 ]}.
 
 %% @doc The key size of the Penciller's in-memory cache
 {mapping, "multi_backend.$name.leveled.penciller_cache_size", "riak_kv.multi_backend", [
-  {default, 28000},
+  {default, 20000},
   {datatype, integer},
   hidden
 ]}.
@@ -100,7 +100,7 @@
 %% The default value will lead to each file, on average, being scored once
 %% every 8 hours
 {mapping, "multi_backend.$name.leveled.compaction_scores_perday", "riak_kv.multi_backend", [
-  {default, 3},
+  {default, 2},
   {datatype, integer}
 ]}.
 
@@ -169,7 +169,7 @@
 ]}.
 
 %% @doc Snapshot timeout (long)
-%% Maximum expected time for any othe rfold.  A fold which is taking longer
+%% Maximum expected time for any other fold.  A fold which is taking longer
 %% than this may fail as it will be released - potentially allowing for some
 %% file processes to delete.  Timeout is in seconds.
 {mapping, "multi_backend.$name.leveled.snapshot_timeout_long", "riak_kv.multi_backend", [


### PR DESCRIPTION
3.0.9 testing has used different defaults for cache_size and penciller_cache_size.  There has been no noticeable drop in the performance of Riak using these defaults, so adopting here.

The new defaults have a lower memory requirement per vnode, which is useful as recent changes and performance test results are changing the standard recommendations for ring_size.

It is now preferred to choose larger ring_sizes by default (e.g. 256  for 6 - 12 nodes, 512 for 12 - 20 nodes, 1024 for 20 +).

By choosing larger ring sizes, the benefits of scaling up a cluster will continue to make a difference even as the node count goes beyond the recommended "correct" setting.  e.g. It might be reasonable (depending on hardware choices) to grow a ring_size=512 cluster to beyond 30 nodes, yet still be relatively efficient and performant at 8 nodes.