### PR TITLE
Mas i370 d29 sstmemory

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -136,6 +136,7 @@
 
 -export_type([tag/0,
                 key/0,
+                sqn/0,
                 object_spec/0,
                 segment_hash/0,
                 ledger_status/0,

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -136,7 +136,6 @@
 
 -export_type([tag/0,
                 key/0,
-                sqn/0,
                 object_spec/0,
                 segment_hash/0,
                 ledger_status/0,

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -747,12 +747,14 @@ handle_call({fetch, Key, Hash, UseL0Index}, _From, State) ->
     {reply, R, State#state{timings=UpdTimings0, timings_countdown=CountDown}};
 handle_call({check_sqn, Key, Hash, SQN}, _From, State) ->
     {reply,
-        compare_to_sqn(plain_fetch_mem(Key,
-                                        Hash,
-                                        State#state.manifest,
-                                        State#state.levelzero_cache,
-                                        State#state.levelzero_index),
-                        SQN),
+        compare_to_sqn(
+            fetch_sqn(
+                Key,
+                Hash,
+                State#state.manifest,
+                State#state.levelzero_cache,
+                State#state.levelzero_index),
+                SQN),
         State};
 handle_call({fetch_keys, 
                     StartKey, EndKey, 
@@ -1437,14 +1439,18 @@ timed_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, Timings) ->
     {R, UpdTimings}.
 
 
--spec plain_fetch_mem(tuple(), {integer(), integer()}, 
-                        leveled_pmanifest:manifest(), list(), 
-                        leveled_pmem:index_array()) -> not_present|tuple().
+-spec fetch_sqn(
+    leveled_codec:ledger_key(),
+    leveled_codec:segment_hash(),
+    leveled_pmanifest:manifest(),
+    list(),
+    leveled_pmem:index_array()) ->
+        not_present|leveled_codec:ledger_kv()|leveled_codec:ledger_sqn().
 %% @doc
 %% Fetch the result from the penciller, starting by looking in the memory, 
 %% and if it is not found looking down level by level through the LSM tree.
-plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
-    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_get/4),
+fetch_sqn(Key, Hash, Manifest, L0Cache, L0Index) ->
+    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_getsqn/4),
     element(1, R).
 
 fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, FetchFun) ->
@@ -1497,8 +1503,8 @@ timed_sst_get(PID, Key, Hash, Level) ->
     T0 = timer:now_diff(os:timestamp(), SW),
     log_slowfetch(T0, R, PID, Level, ?SLOW_FETCH).
 
-sst_get(PID, Key, Hash, Level) ->
-    leveled_sst:sst_get(PID, Key, Hash).
+sst_getsqn(PID, Key, Hash, _Level) ->
+    leveled_sst:sst_getsqn(PID, Key, Hash).
 
 log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     case {T0, R} of
@@ -1513,29 +1519,26 @@ log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     end.
 
 
--spec compare_to_sqn(tuple()|not_present, integer()) -> sqn_check().
+-spec compare_to_sqn(
+    leveled_codec:ledger_kv()|leveled_codec:sqn()|not_present,
+    integer()) -> sqn_check().
 %% @doc
 %% Check to see if the SQN in the penciller is after the SQN expected for an 
 %% object (used to allow the journal to check compaction status from a cache
 %% of the ledger - objects with a more recent sequence number can be compacted).
+compare_to_sqn(not_present, _SQN) ->
+    missing;
+compare_to_sqn(ObjSQN, SQN) when is_integer(ObjSQN), ObjSQN > SQN ->
+    replaced;
+compare_to_sqn(ObjSQN, _SQN) when is_integer(ObjSQN) ->
+    % Normally we would expect the SQN to be equal here, but
+    % this also allows for the Journal to have a more advanced
+    % value. We return true here as we wouldn't want to
+    % compact thta more advanced value, but this may cause
+    % confusion in snapshots.
+    current;
 compare_to_sqn(Obj, SQN) ->
-    case Obj of
-        not_present ->
-            missing;
-        Obj ->
-            SQNToCompare = leveled_codec:strip_to_seqonly(Obj),
-            if
-                SQNToCompare > SQN ->
-                    replaced;
-                true ->
-                    % Normally we would expect the SQN to be equal here, but
-                    % this also allows for the Journal to have a more advanced
-                    % value. We return true here as we wouldn't want to
-                    % compact thta more advanced value, but this may cause
-                    % confusion in snapshots.
-                    current
-            end
-    end.
+    compare_to_sqn(leveled_codec:strip_to_seqonly(Obj), SQN).
 
 
 %%%============================================================================

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -747,12 +747,13 @@ handle_call({fetch, Key, Hash, UseL0Index}, _From, State) ->
     {reply, R, State#state{timings=UpdTimings0, timings_countdown=CountDown}};
 handle_call({check_sqn, Key, Hash, SQN}, _From, State) ->
     {reply,
-        compare_to_sqn(plain_fetch_mem(Key,
-                                        Hash,
-                                        State#state.manifest,
-                                        State#state.levelzero_cache,
-                                        State#state.levelzero_index),
-                        SQN),
+        compare_to_sqn(
+            plain_fetch_sqn(Key,
+                Hash,
+                State#state.manifest,
+                State#state.levelzero_cache,
+                State#state.levelzero_index),
+                SQN),
         State};
 handle_call({fetch_keys, 
                     StartKey, EndKey, 
@@ -1437,14 +1438,17 @@ timed_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, Timings) ->
     {R, UpdTimings}.
 
 
--spec plain_fetch_mem(tuple(), {integer(), integer()}, 
-                        leveled_pmanifest:manifest(), list(), 
-                        leveled_pmem:index_array()) -> not_present|tuple().
+-spec plain_fetch_sqn(
+    tuple(),
+    {integer(), integer()},
+    leveled_pmanifest:manifest(),
+    list(), 
+    leveled_pmem:index_array()) -> not_present|levled_codec:sqn().
 %% @doc
 %% Fetch the result from the penciller, starting by looking in the memory, 
 %% and if it is not found looking down level by level through the LSM tree.
-plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
-    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_get/4),
+plain_fetch_sqn(Key, Hash, Manifest, L0Cache, L0Index) ->
+    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_getsqn/4),
     element(1, R).
 
 fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, FetchFun) ->
@@ -1497,8 +1501,8 @@ timed_sst_get(PID, Key, Hash, Level) ->
     T0 = timer:now_diff(os:timestamp(), SW),
     log_slowfetch(T0, R, PID, Level, ?SLOW_FETCH).
 
-sst_get(PID, Key, Hash, Level) ->
-    leveled_sst:sst_get(PID, Key, Hash).
+sst_getsqn(PID, Key, Hash, _Level) ->
+    leveled_sst:sst_getsqn(PID, Key, Hash).
 
 log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     case {T0, R} of
@@ -1513,29 +1517,29 @@ log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     end.
 
 
--spec compare_to_sqn(tuple()|not_present, integer()) -> sqn_check().
+-spec compare_to_sqn(
+    leveled_codec:ledger_kv()|leveled_codec:sqn()|not_present,
+    integer()) -> sqn_check().
 %% @doc
 %% Check to see if the SQN in the penciller is after the SQN expected for an 
 %% object (used to allow the journal to check compaction status from a cache
 %% of the ledger - objects with a more recent sequence number can be compacted).
+compare_to_sqn(not_present, SQN) ->
+    missing;
+compare_to_sqn(FoundSQN, SQN) when is_integer(FoundSQN) ->
+    if
+        SQNToCompare > SQN ->
+            replaced;
+        true ->
+            % Normally we would expect the SQN to be equal here, but
+            % this also allows for the Journal to have a more advanced
+            % value. We return true here as we wouldn't want to
+            % compact thta more advanced value, but this may cause
+            % confusion in snapshots.
+            current
+    end;
 compare_to_sqn(Obj, SQN) ->
-    case Obj of
-        not_present ->
-            missing;
-        Obj ->
-            SQNToCompare = leveled_codec:strip_to_seqonly(Obj),
-            if
-                SQNToCompare > SQN ->
-                    replaced;
-                true ->
-                    % Normally we would expect the SQN to be equal here, but
-                    % this also allows for the Journal to have a more advanced
-                    % value. We return true here as we wouldn't want to
-                    % compact thta more advanced value, but this may cause
-                    % confusion in snapshots.
-                    current
-            end
-    end.
+    compare_to_sqn(leveled_codec:strip_to_seqonly(Obj), SQN).
 
 
 %%%============================================================================

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -1431,7 +1431,8 @@ roll_memory(State, true) ->
 %% the result tuple includes the level at which the result was found.
 timed_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, Timings) ->
     SW = os:timestamp(),
-    {R, Level} = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index),
+    {R, Level} =
+        fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun timed_sst_get/4),
     UpdTimings = update_timings(SW, Timings, R, Level),
     {R, UpdTimings}.
 
@@ -1443,10 +1444,10 @@ timed_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, Timings) ->
 %% Fetch the result from the penciller, starting by looking in the memory, 
 %% and if it is not found looking down level by level through the LSM tree.
 plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
-    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index),
+    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_get/4),
     element(1, R).
 
-fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
+fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, FetchFun) ->
     PosList = 
         case L0Index of
             none ->
@@ -1457,7 +1458,7 @@ fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
     L0Check = leveled_pmem:check_levelzero(Key, Hash, PosList, L0Cache),
     case L0Check of
         {false, not_found} ->
-            fetch(Key, Hash, Manifest, 0, fun timed_sst_get/4);
+            fetch(Key, Hash, Manifest, 0, FetchFun);
         {true, KV} ->
             {KV, memory}
     end.
@@ -1495,6 +1496,9 @@ timed_sst_get(PID, Key, Hash, Level) ->
     R = leveled_sst:sst_get(PID, Key, Hash),
     T0 = timer:now_diff(os:timestamp(), SW),
     log_slowfetch(T0, R, PID, Level, ?SLOW_FETCH).
+
+sst_get(PID, Key, Hash, Level) ->
+    leveled_sst:sst_get(PID, Key, Hash).
 
 log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     case {T0, R} of

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -184,6 +184,8 @@
         :: #summary{}.
 -type blockindex_cache()
         :: any().  % An array but OTP 16 types
+-type fetch_cache()
+        :: any()|no_cache. % An array but OTP 16 types
 
 %% yield_blockquery is used to determine if the work necessary to process a
 %% range query beyond the fetching the slot should be managed from within
@@ -193,45 +195,45 @@
 %% extra copying.  Files at the top of the tree yield, those lower down don't.
 
 -record(state,      
-                {summary,
-                    handle :: file:fd() | undefined,
-                    penciller :: pid() | undefined | false,
-                    root_path,
-                    filename,
-                    yield_blockquery = false :: boolean(),
-                    blockindex_cache :: blockindex_cache()|undefined,
-                    compression_method = native :: press_method(),
-                    index_moddate = ?INDEX_MODDATE :: boolean(),
-                    timings = no_timing :: sst_timings(),
-                    timings_countdown = 0 :: integer(),
-                    starting_pid :: pid()|undefined,
-                    fetch_cache = array:new([{size, ?CACHE_SIZE}]),
-                    new_slots :: list()|undefined,
-                    deferred_startup_tuple :: tuple()|undefined,
-                    level :: non_neg_integer()|undefined,
-                    tomb_count = not_counted
-                            :: non_neg_integer()|not_counted,
-                    high_modified_date :: non_neg_integer()|undefined}).
+        {summary,
+            handle :: file:fd() | undefined,
+            penciller :: pid() | undefined | false,
+            root_path,
+            filename,
+            yield_blockquery = false :: boolean(),
+            blockindex_cache :: blockindex_cache()|undefined,
+            compression_method = native :: press_method(),
+            index_moddate = ?INDEX_MODDATE :: boolean(),
+            timings = no_timing :: sst_timings(),
+            timings_countdown = 0 :: integer(),
+            starting_pid :: pid()|undefined,
+            fetch_cache = array:new([{size, ?CACHE_SIZE}]) :: fetch_cache(),
+            new_slots :: list()|undefined,
+            deferred_startup_tuple :: tuple()|undefined,
+            level :: non_neg_integer()|undefined,
+            tomb_count = not_counted
+                    :: non_neg_integer()|not_counted,
+            high_modified_date :: non_neg_integer()|undefined}).
 
 -record(sst_timings, 
-                {sample_count = 0 :: integer(),
-                    index_query_time = 0 :: integer(),
-                    lookup_cache_time = 0 :: integer(),
-                    slot_index_time = 0 :: integer(),
-                    fetch_cache_time = 0 :: integer(),
-                    slot_fetch_time = 0 :: integer(),
-                    noncached_block_time = 0 :: integer(),
-                    lookup_cache_count = 0 :: integer(),
-                    slot_index_count = 0 :: integer(),
-                    fetch_cache_count = 0 :: integer(),
-                    slot_fetch_count = 0 :: integer(),
-                    noncached_block_count = 0 :: integer()}).
+        {sample_count = 0 :: integer(),
+            index_query_time = 0 :: integer(),
+            lookup_cache_time = 0 :: integer(),
+            slot_index_time = 0 :: integer(),
+            fetch_cache_time = 0 :: integer(),
+            slot_fetch_time = 0 :: integer(),
+            noncached_block_time = 0 :: integer(),
+            lookup_cache_count = 0 :: integer(),
+            slot_index_count = 0 :: integer(),
+            fetch_cache_count = 0 :: integer(),
+            slot_fetch_count = 0 :: integer(),
+            noncached_block_count = 0 :: integer()}).
 
 -record(build_timings,
-                {slot_hashlist = 0 :: integer(),
-                    slot_serialise = 0 :: integer(),
-                    slot_finish = 0 :: integer(),
-                    fold_toslot = 0 :: integer()}).
+        {slot_hashlist = 0 :: integer(),
+            slot_serialise = 0 :: integer(),
+            slot_finish = 0 :: integer(),
+            fold_toslot = 0 :: integer()}).
 
 -type sst_state() :: #state{}.
 -type sst_timings() :: no_timing|#sst_timings{}.
@@ -1091,6 +1093,24 @@ extract_hash(NotHash) ->
 cache_hash({_SegHash, ExtraHash}) when is_integer(ExtraHash) ->
     ExtraHash band (?CACHE_SIZE - 1).
 
+-spec fetch_from_cache(
+    non_neg_integer(),
+    fetch_cache()) -> undefined|leveled_codec:ledger_kv().
+fetch_from_cache(_CacheHash, no_cache) ->
+    undefined;
+fetch_from_cache(CacheHash, Cache) ->
+    array:get(CacheHash, Cache).
+
+-spec add_to_cache(
+    non_neg_integer(),
+    leveled_codec:ledger_kv()
+    fetch_cache()) -> fetch_cache().
+add_to_cache(_CacheHash, _KV, no_cache) ->
+    no_cache;
+add_to_cache(CacheHash, KV, FetchCache) ->
+    array:set(CacheHash, KV, FetchCache).
+
+
 -spec tune_hash(non_neg_integer()) -> non_neg_integer().
 %% @doc
 %% Only 15 bits of the hash is ever interesting
@@ -1227,7 +1247,7 @@ fetch(LedgerKey, Hash, State, Timings0) ->
                         update_timings(SW2, Timings2, slot_index, true),
                     FetchCache = State#state.fetch_cache,
                     CacheHash = cache_hash(Hash),
-                    case array:get(CacheHash, FetchCache) of 
+                    case fetch_from_cache(CacheHash, FetchCache) of 
                         {LedgerKey, V} ->
                             {_SW4, Timings4} = 
                                 update_timings(SW3, 
@@ -1246,8 +1266,8 @@ fetch(LedgerKey, Hash, State, Timings0) ->
                                                 PressMethod,
                                                 IdxModDate,
                                                 not_present),
-                            FetchCache0 = 
-                                array:set(CacheHash, Result, FetchCache),
+                            FetchCache0 =
+                                add_to_cache(CacheHash, Result, FetchCache),
                             {_SW4, Timings4} = 
                                 update_timings(SW3, 
                                                 Timings3, 
@@ -1371,10 +1391,10 @@ write_file(RootPath, Filename, SummaryBin, SlotsBin,
                                         false),
     FinalName.
 
-read_file(Filename, State, LoadPageCache) ->
+read_file(Filename, State, CacheFile) ->
     {Handle, FileVersion, SummaryBin} = 
         open_reader(filename:join(State#state.root_path, Filename),
-                    LoadPageCache),
+                    CacheFile),
     UpdState0 = imp_fileversion(FileVersion, State),
     {Summary, Bloom, SlotList, TombCount} =
         read_table_summary(SummaryBin, UpdState0#state.tomb_count),
@@ -1385,10 +1405,18 @@ read_file(Filename, State, LoadPageCache) ->
     leveled_log:log("SST03", [Filename,
                                 Summary#summary.size,
                                 Summary#summary.max_sqn]),
+    FetchCache =
+        case CacheFile of
+            true ->
+                State#state.fetch_cache;
+            false ->
+                no_cache
+        end,
     {UpdState1#state{summary = UpdSummary,
                         handle = Handle,
                         filename = Filename,
-                        tomb_count = TombCount},
+                        tomb_count = TombCount,
+                        fetch_cache = FetchCache},
         Bloom}.
 
 gen_fileversion(PressMethod, IdxModDate, CountOfTombs) ->

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -193,6 +193,12 @@
         :: any().  % An array but OTP 16 types
 -type fetch_cache()
         :: any()|no_cache. % An array but OTP 16 types
+-type cache_size()
+        :: no_cache|1|32|64.
+-type cache_hash()
+        :: no_cache|non_neg_integer().
+-type level()
+        :: non_neg_integer().
 
 %% yield_blockquery is used to determine if the work necessary to process a
 %% range query beyond the fetching the slot should be managed from within
@@ -217,7 +223,7 @@
             fetch_cache = no_cache :: fetch_cache(),
             new_slots :: list()|undefined,
             deferred_startup_tuple :: tuple()|undefined,
-            level :: non_neg_integer()|undefined,
+            level :: level()|undefined,
             tomb_count = not_counted
                     :: non_neg_integer()|not_counted,
             high_modified_date :: non_neg_integer()|undefined}).
@@ -252,7 +258,7 @@
 %%% API
 %%%============================================================================
 
--spec sst_open(string(), string(), sst_options(), non_neg_integer())
+-spec sst_open(string(), string(), sst_options(), level())
             -> {ok, pid(), 
                     {leveled_codec:ledger_key(), leveled_codec:ledger_key()}, 
                     binary()}.
@@ -274,7 +280,7 @@ sst_open(RootPath, Filename, OptsSST, Level) ->
             {ok, Pid, {SK, EK}, Bloom}
     end.
 
--spec sst_new(string(), string(), integer(), 
+-spec sst_new(string(), string(), level(), 
                     list(leveled_codec:ledger_kv()), 
                     integer(), sst_options()) 
             -> {ok, pid(), 
@@ -317,7 +323,7 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, IndexModDate) ->
 -spec sst_newmerge(string(), string(), 
                     list(leveled_codec:ledger_kv()|sst_pointer()), 
                     list(leveled_codec:ledger_kv()|sst_pointer()),
-                    boolean(), integer(), 
+                    boolean(), level(), 
                     integer(), sst_options())
             -> empty|{ok, pid(), 
                 {{list(leveled_codec:ledger_kv()), 
@@ -338,7 +344,7 @@ sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, IndexModDate) ->
 %% file is not added to the manifest.
 sst_newmerge(RootPath, Filename, 
         KVL1, KVL2, IsBasement, Level, 
-        MaxSQN, OptsSST) ->
+        MaxSQN, OptsSST) when Level > 0 ->
     sst_newmerge(RootPath, Filename, 
         KVL1, KVL2, IsBasement, Level, 
         MaxSQN, OptsSST, ?INDEX_MODDATE, ?TOMB_COUNT).
@@ -1137,7 +1143,7 @@ extract_hash(NotHash) ->
     NotHash.
 
 
--spec new_cache(non_neg_integer()) -> fetch_cache().
+-spec new_cache(level()) -> fetch_cache().
 new_cache(Level) ->
     case cache_size(Level) of
         no_cache ->
@@ -1147,7 +1153,7 @@ new_cache(Level) ->
     end.
 
 -spec cache_hash(leveled_codec:segment_hash(), non_neg_integer()) ->
-    non_neg_integer()|no_cache.
+    cache_hash().
 cache_hash({_SegHash, ExtraHash}, Level) when is_integer(ExtraHash) ->
     case cache_size(Level) of
         no_cache -> no_cache;
@@ -1159,18 +1165,22 @@ cache_hash({_SegHash, ExtraHash}, Level) when is_integer(ExtraHash) ->
 %% as each level has more files than the previous level.  Load tests with
 %% any sort of pareto distribution show far better cost/benefit ratios for
 %% cache at higher levels.
--spec cache_size(non_neg_integer()) -> no_cache|32|64|128.
+-spec cache_size(level()) -> cache_size().
 cache_size(N) when N < 3 ->
-    128;
-cache_size(3) ->
     64;
+cache_size(3) ->
+    32;
 cache_size(4) ->
     32;
+cache_size(5) ->
+    4;
+cache_size(6) ->
+    4;
 cache_size(_LowerLevel) ->
     no_cache.
 
 -spec fetch_from_cache(
-    non_neg_integer(),
+    cache_hash(),
     fetch_cache()) -> undefined|leveled_codec:ledger_kv().
 fetch_from_cache(_CacheHash, no_cache) ->
     undefined;
@@ -1435,7 +1445,7 @@ compress_level(Level, _PressMethod) when Level < ?COMPRESS_AT_LEVEL ->
 compress_level(_Level, PressMethod) ->
     PressMethod.
 
--spec maxslots_level(non_neg_integer(), pos_integer()) ->  pos_integer().
+-spec maxslots_level(level(), pos_integer()) ->  pos_integer().
 maxslots_level(Level, MaxSlotCount) when Level < ?DOUBLESIZE_LEVEL ->
     MaxSlotCount;
 maxslots_level(_Level, MaxSlotCount) ->
@@ -3702,45 +3712,65 @@ simple_switchcache_test() ->
     KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?LOOK_SLOTSIZE),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, OpenP4, {FirstKey, LastKey}, _Bloom} = 
         testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    ok = sst_switchlevels(Pid, 5),
+    ok = sst_switchlevels(OpenP4, 5),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    gen_fsm:send_event(Pid, timeout),
+    gen_fsm:send_event(OpenP4, timeout),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    ok = sst_close(Pid),
+    ok = sst_close(OpenP4),
     OptsSST = #sst_options{press_method=native,
                             log_options=leveled_log:get_opts()},
-    {ok, OpenP, {FirstKey, LastKey}, _Bloom} =
+    {ok, OpenP5, {FirstKey, LastKey}, _Bloom} =
         sst_open(RP, Filename ++ ".sst", OptsSST, 5),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
-    gen_fsm:send_event(Pid, timeout),
+    gen_fsm:send_event(OpenP5, timeout),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
-    ok = sst_close(OpenP),
+    ok = sst_switchlevels(OpenP5, 6),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(OpenP5, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    ok = sst_switchlevels(OpenP5, 7),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(OpenP5, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    ok = sst_close(OpenP5),
     ok = file:delete(filename:join(RP, Filename ++ ".sst")).
 
 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -214,7 +214,7 @@
             timings = no_timing :: sst_timings(),
             timings_countdown = 0 :: integer(),
             starting_pid :: pid()|undefined,
-            fetch_cache = array:new([{size, ?CACHE_SIZE}]) :: fetch_cache(),
+            fetch_cache = no_cache :: fetch_cache(),
             new_slots :: list()|undefined,
             deferred_startup_tuple :: tuple()|undefined,
             level :: non_neg_integer()|undefined,
@@ -556,7 +556,7 @@ starting({sst_open, RootPath, Filename, OptsSST, Level}, _From, State) ->
     {reply,
         {ok, {Summary#summary.first_key, Summary#summary.last_key}, Bloom},
         reader,
-        UpdState#state{level = Level}};
+        UpdState#state{level = Level, fetch_cache = new_cache(Level)}};
 starting({sst_new, 
             RootPath, Filename, Level, 
             {SlotList, FirstKey}, MaxSQN,
@@ -596,7 +596,8 @@ starting({sst_new,
         UpdState#state{blockindex_cache = BlockIndex,
                         high_modified_date = HighModDate,
                         starting_pid = StartingPID,
-                        level = Level}};
+                        level = Level,
+                        fetch_cache = new_cache(Level)}};
 starting({sst_newlevelzero, RootPath, Filename,
                     Penciller, MaxSQN,
                     OptsSST, IdxModDate}, _From, State) -> 
@@ -604,7 +605,10 @@ starting({sst_newlevelzero, RootPath, Filename,
         {RootPath, Filename, Penciller, MaxSQN, OptsSST,
             IdxModDate},
     {reply, ok, starting,
-        State#state{deferred_startup_tuple = DeferredStartupTuple, level = 0}};
+        State#state{
+            deferred_startup_tuple = DeferredStartupTuple,
+            level = 0,
+            fetch_cache = new_cache(0)}};
 starting(close, _From, State) ->
     % No file should have been created, so nothing to close.
     {stop, normal, ok, State}.
@@ -817,9 +821,17 @@ reader(close, _From, State) ->
     {stop, normal, ok, State}.
 
 reader(timeout, State) ->
-    {next_state, reader, State, hibernate};
+    FreshCache = new_cache(State#state.level),
+    {next_state,
+        reader,
+        State#state{fetch_cache = FreshCache},
+        hibernate};
 reader({switch_levels, NewLevel}, State) ->
-    {next_state, reader, State#state{level = NewLevel}, hibernate}.
+    FreshCache = new_cache(NewLevel),
+    {next_state,
+        reader,
+        State#state{level = NewLevel, fetch_cache = FreshCache},
+        hibernate}.
 
 
 delete_pending({get_sqn, LedgerKey, Hash}, _From, State) ->
@@ -1124,8 +1136,38 @@ extract_hash({SegHash, _ExtraHash}) when is_integer(SegHash) ->
 extract_hash(NotHash) ->
     NotHash.
 
-cache_hash({_SegHash, ExtraHash}) when is_integer(ExtraHash) ->
-    ExtraHash band (?CACHE_SIZE - 1).
+
+-spec new_cache(non_neg_integer()) -> fetch_cache().
+new_cache(Level) ->
+    case cache_size(Level) of
+        no_cache ->
+            no_cache;
+        CacheSize ->
+            array:new([{size, CacheSize}])
+    end.
+
+-spec cache_hash(leveled_codec:segment_hash(), non_neg_integer()) ->
+    non_neg_integer()|no_cache.
+cache_hash({_SegHash, ExtraHash}, Level) when is_integer(ExtraHash) ->
+    case cache_size(Level) of
+        no_cache -> no_cache;
+        CH -> ExtraHash band (CH - 1)
+    end.
+
+%% @doc
+%% The lower the level, the bigger the memory cost of supporting the cache,
+%% as each level has more files than the previous level.  Load tests with
+%% any sort of pareto distribution show far better cost/benefit ratios for
+%% cache at higher levels.
+-spec cache_size(non_neg_integer()) -> no_cache|32|64|128.
+cache_size(N) when N < 3 ->
+    128;
+cache_size(3) ->
+    64;
+cache_size(4) ->
+    32;
+cache_size(_LowerLevel) ->
+    no_cache.
 
 -spec fetch_from_cache(
     non_neg_integer(),
@@ -1280,7 +1322,7 @@ fetch(LedgerKey, Hash, State, Timings0) ->
                     {SW3, Timings3} =
                         update_timings(SW2, Timings2, slot_index, true),
                     FetchCache = State#state.fetch_cache,
-                    CacheHash = cache_hash(Hash),
+                    CacheHash = cache_hash(Hash, State#state.level),
                     case fetch_from_cache(CacheHash, FetchCache) of 
                         {LedgerKey, V} ->
                             {_SW4, Timings4} = 
@@ -1425,10 +1467,11 @@ write_file(RootPath, Filename, SummaryBin, SlotsBin,
                                         false),
     FinalName.
 
-read_file(Filename, State, CacheFile) ->
+read_file(Filename, State, LoadPageCache) ->
     {Handle, FileVersion, SummaryBin} = 
-        open_reader(filename:join(State#state.root_path, Filename),
-                    CacheFile),
+        open_reader(
+            filename:join(State#state.root_path, Filename),
+            LoadPageCache),
     UpdState0 = imp_fileversion(FileVersion, State),
     {Summary, Bloom, SlotList, TombCount} =
         read_table_summary(SummaryBin, UpdState0#state.tomb_count),
@@ -1439,18 +1482,10 @@ read_file(Filename, State, CacheFile) ->
     leveled_log:log("SST03", [Filename,
                                 Summary#summary.size,
                                 Summary#summary.max_sqn]),
-    FetchCache =
-        case CacheFile of
-            true ->
-                State#state.fetch_cache;
-            false ->
-                no_cache
-        end,
     {UpdState1#state{summary = UpdSummary,
                         handle = Handle,
                         filename = Filename,
-                        tomb_count = TombCount,
-                        fetch_cache = FetchCache},
+                        tomb_count = TombCount},
         Bloom}.
 
 gen_fileversion(PressMethod, IdxModDate, CountOfTombs) ->
@@ -3660,11 +3695,57 @@ additional_range_test() ->
     % Test blows up anyway
     % R8 = sst_getkvrange(P1, element(1, PastEKV), element(1, PastEKV), 2),
     % ?assertMatch([], R8).
-    
+
+simple_switchcache_test() ->
+    {RP, Filename} = {?TEST_AREA, "simple_switchcache_test"},
+    KVList0 = generate_randomkeys(1, ?LOOK_SLOTSIZE * 2, 1, 20),
+    KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?LOOK_SLOTSIZE),
+    [{FirstKey, _FV}|_Rest] = KVList1,
+    {LastKey, _LV} = lists:last(KVList1),
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+        testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    ok = sst_switchlevels(Pid, 5),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(Pid, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    ok = sst_close(Pid),
+    OptsSST = #sst_options{press_method=native,
+                            log_options=leveled_log:get_opts()},
+    {ok, OpenP, {FirstKey, LastKey}, _Bloom} =
+        sst_open(RP, Filename ++ ".sst", OptsSST, 5),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(Pid, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    ok = sst_close(OpenP),
+    ok = file:delete(filename:join(RP, Filename ++ ".sst")).
+
 
 simple_persisted_slotsize_test() ->
     simple_persisted_slotsize_tester(fun testsst_new/6).
-
 
 simple_persisted_slotsize_tester(SSTNewFun) ->
     {RP, Filename} = {?TEST_AREA, "simple_slotsize_test"},

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -96,6 +96,7 @@
 -define(TOMB_COUNT, true).
 -define(USE_SET_FOR_SPEED, 64).
 -define(STARTUP_TIMEOUT, 10000).
+-define(HIBERNATE_TIMEOUT, 60000).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -118,6 +119,7 @@
             sst_open/4,
             sst_get/2,
             sst_get/3,
+            sst_getsqn/3,
             sst_expandpointer/5,
             sst_getmaxsequencenumber/1,
             sst_setfordelete/2,
@@ -433,6 +435,15 @@ sst_get(Pid, LedgerKey) ->
 sst_get(Pid, LedgerKey, Hash) ->
     gen_fsm:sync_send_event(Pid, {get_kv, LedgerKey, Hash}, infinity).
 
+-spec sst_getsqn(pid(),
+    leveled_codec:ledger_key(),
+    leveled_codec:segment_hash()) -> leveled_codec:sqn()|not_present.
+%% @doc
+%% Return a SQN for the key or not_present if the key is not in
+%% the store (with the magic hash precalculated).
+sst_getsqn(Pid, LedgerKey, Hash) ->
+    gen_fsm:sync_send_event(Pid, {get_sqn, LedgerKey, Hash}, infinity).
+
 -spec sst_getmaxsequencenumber(pid()) -> integer().
 %% @doc
 %% Get the maximume sequence number for this SST file
@@ -694,6 +705,11 @@ starting({sst_returnslot, FetchedSlot, FetchFun, SlotCount}, State) ->
                 State#state{new_slots = FetchedSlots}}
     end.
 
+reader({get_sqn, LedgerKey, Hash}, _From, State) ->
+    % Get a KV value and potentially take sample timings
+    {Result, UpdState, _UpdTimings} = 
+        fetch(LedgerKey, Hash, State, no_timing),
+    {reply, sqn_only(Result), reader, UpdState, ?HIBERNATE_TIMEOUT};
 reader({get_kv, LedgerKey, Hash}, _From, State) ->
     % Get a KV value and potentially take sample timings
     {Result, UpdState, UpdTimings} = 
@@ -799,6 +815,11 @@ reader({switch_levels, NewLevel}, State) ->
     {next_state, reader, State#state{level = NewLevel}, hibernate}.
 
 
+delete_pending({get_sqn, LedgerKey, Hash}, _From, State) ->
+    % Get a KV value and potentially take sample timings
+    {Result, UpdState, _UpdTimings} = 
+        fetch(LedgerKey, Hash, State, no_timing),
+    {reply, sqn_only(Result), delete_pending, UpdState, ?DELETE_TIMEOUT};
 delete_pending({get_kv, LedgerKey, Hash}, _From, State) ->
     {Result, UpdState, _Ts} = fetch(LedgerKey, Hash, State, no_timing),
     {reply, Result, delete_pending, UpdState, ?DELETE_TIMEOUT};
@@ -1084,6 +1105,12 @@ member_check(Hash, {sets, HashSet}) ->
 member_check(_Miss, _Checker) ->
     false.
 
+-spec sqn_only(leveled_codec:ledger_kv()|not_present)
+        -> leveled_codec:sqn()|not_present.
+sqn_only(not_present) ->
+    not_present;
+sqn_only(KV) ->
+    leveled_codec:strip_to_seqonly(KV).
 
 extract_hash({SegHash, _ExtraHash}) when is_integer(SegHash) ->
     tune_hash(SegHash);
@@ -1103,7 +1130,7 @@ fetch_from_cache(CacheHash, Cache) ->
 
 -spec add_to_cache(
     non_neg_integer(),
-    leveled_codec:ledger_kv()
+    leveled_codec:ledger_kv(),
     fetch_cache()) -> fetch_cache().
 add_to_cache(_CacheHash, _KV, no_cache) ->
     no_cache;

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -96,7 +96,6 @@
 -define(TOMB_COUNT, true).
 -define(USE_SET_FOR_SPEED, 64).
 -define(STARTUP_TIMEOUT, 10000).
--define(READER_TIMEOUT, 60000).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -119,7 +118,6 @@
             sst_open/4,
             sst_get/2,
             sst_get/3,
-            sst_getsqn/3,
             sst_expandpointer/5,
             sst_getmaxsequencenumber/1,
             sst_setfordelete/2,
@@ -435,17 +433,6 @@ sst_get(Pid, LedgerKey) ->
 sst_get(Pid, LedgerKey, Hash) ->
     gen_fsm:sync_send_event(Pid, {get_kv, LedgerKey, Hash}, infinity).
 
--spec sst_getsqn(
-    pid(),
-    leveled_codec:ledger_key(),
-    leveled_codec:segment_hash()) -> leveled_codec:sqn()|not_present.
-%% @doc
-%% Return a Key, Value pair matching a Key or not_present if the Key is not in
-%% the store (with the magic hash precalculated).
-sst_getsqn(Pid, LedgerKey, Hash) ->
-    gen_fsm:sync_send_event(Pid, {get_sqn, LedgerKey, Hash}, infinity).
-
-
 -spec sst_getmaxsequencenumber(pid()) -> integer().
 %% @doc
 %% Get the maximume sequence number for this SST file
@@ -707,10 +694,6 @@ starting({sst_returnslot, FetchedSlot, FetchFun, SlotCount}, State) ->
                 State#state{new_slots = FetchedSlots}}
     end.
 
-reader({get_sqn, LedgerKey, Hash}, _From, State) ->
-    {Result, UpdState, _UpdTimings} = 
-        fetch(LedgerKey, Hash, State, no_timing),
-    {reply, sqn_only(Result), reader, UpdState, ?READER_TIMEOUT};
 reader({get_kv, LedgerKey, Hash}, _From, State) ->
     % Get a KV value and potentially take sample timings
     {Result, UpdState, UpdTimings} = 
@@ -812,16 +795,10 @@ reader(close, _From, State) ->
     ok = file:close(State#state.handle),
     {stop, normal, ok, State}.
 
-reader(timeout, State) ->
-    {next_state, reader, State, hibernate};
 reader({switch_levels, NewLevel}, State) ->
     {next_state, reader, State#state{level = NewLevel}, hibernate}.
 
 
-delete_pending({get_sqn, LedgerKey, Hash}, _From, State) ->
-    {Result, UpdState, _UpdTimings} = 
-        fetch(LedgerKey, Hash, State, no_timing),
-    {reply, sqn_only(Result), delete_pending, UpdState};
 delete_pending({get_kv, LedgerKey, Hash}, _From, State) ->
     {Result, UpdState, _Ts} = fetch(LedgerKey, Hash, State, no_timing),
     {reply, Result, delete_pending, UpdState, ?DELETE_TIMEOUT};
@@ -1219,11 +1196,9 @@ check_modified(_, _, _) ->
     true.
 
 -spec fetch(tuple(), 
-        {integer(), integer()}|integer(), 
-        sst_state(), sst_timings()) 
-        -> {not_present|leveled_codec:ledger_kv(),
-            sst_state(),
-            sst_timings()}.
+            {integer(), integer()}|integer(), 
+            sst_state(), sst_timings()) 
+                        -> {not_present|tuple(), sst_state(), sst_timings()}.
 %% @doc
 %%
 %% Fetch a key from the store, potentially taking timings.  Result should be
@@ -1648,6 +1623,7 @@ deserialise_checkedblock(Bin, _Other) ->
     binary_to_term(Bin).
 
 
+
 -spec hmac(binary()|integer()) -> integer().
 %% @doc
 %% Perform a CRC check on an input
@@ -1655,14 +1631,6 @@ hmac(Bin) when is_binary(Bin) ->
     erlang:crc32(Bin);
 hmac(Int) when is_integer(Int) ->
     Int bxor ?FLIPPER32.
-
-
--spec sqn_only(not_present|leveled_codec:ledger_kv())
-        -> not_present|leveled_codec:sqn().
-sqn_only(not_present) ->
-    not_present;
-sqn_only(KV) ->
-    leveled_codec:strip_to_seqonly(KV).
 
 %%%============================================================================
 %%% SlotIndex Implementation


### PR DESCRIPTION
On very large stores with lots of old, and largely untouched objects, too much memory is taken up by relatively inactive files.

The fetch_cache has an unpredictable size, and it is hard to reason or prove its effectiveness.

This change takes the existing caching level configuration, which prevents automatic fadvise of files below a certain level in the LSM tree, and also blocks the creation of the fetch_cache below a certain level.

There has been some observations of memory fragmentation as well. There is currently no hibernation of unused files. Unused files will still be used during all object folds and journal compaction because of SQN checking, so SQN checking is now used as a potential trigger for hibernation - if there is no activity in the 60s following. a SQN check the managing process for the SST file will hibernate.