### PR TITLE
Mas i370 d31 sstmemory

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -136,6 +136,7 @@
 
 -export_type([tag/0,
                 key/0,
+                sqn/0,
                 object_spec/0,
                 segment_hash/0,
                 ledger_status/0,

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -146,6 +146,11 @@ handle_cast({remove_logs, ForcedLogs}, State) ->
 
 handle_info(timeout, State) ->
     request_work(State),
+    % When handling work, the clerk can collect a large number of binary
+    % references, so proactively GC this process before receiving any future
+    % work.  In under pressure clusters, clerks with large binary memory
+    % footprints can occur.
+    garbage_collect(),
     {noreply, State, ?MAX_TIMEOUT}.
 
 terminate(Reason, _State) ->

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -749,12 +749,14 @@ handle_call({fetch, Key, Hash, UseL0Index}, _From, State) ->
     {reply, R, State#state{timings=UpdTimings0, timings_countdown=CountDown}};
 handle_call({check_sqn, Key, Hash, SQN}, _From, State) ->
     {reply,
-        compare_to_sqn(plain_fetch_mem(Key,
-                                        Hash,
-                                        State#state.manifest,
-                                        State#state.levelzero_cache,
-                                        State#state.levelzero_index),
-                        SQN),
+        compare_to_sqn(
+            fetch_sqn(
+                Key,
+                Hash,
+                State#state.manifest,
+                State#state.levelzero_cache,
+                State#state.levelzero_index),
+                SQN),
         State};
 handle_call({fetch_keys, 
                     StartKey, EndKey, 
@@ -1456,14 +1458,18 @@ timed_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, Timings) ->
     {R, UpdTimings}.
 
 
--spec plain_fetch_mem(tuple(), {integer(), integer()}, 
-                        leveled_pmanifest:manifest(), list(), 
-                        leveled_pmem:index_array()) -> not_present|tuple().
+-spec fetch_sqn(
+    leveled_codec:ledger_key(),
+    leveled_codec:segment_hash(),
+    leveled_pmanifest:manifest(),
+    list(),
+    leveled_pmem:index_array()) ->
+        not_present|leveled_codec:ledger_kv()|leveled_codec:ledger_sqn().
 %% @doc
 %% Fetch the result from the penciller, starting by looking in the memory, 
 %% and if it is not found looking down level by level through the LSM tree.
-plain_fetch_mem(Key, Hash, Manifest, L0Cache, L0Index) ->
-    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_get/4),
+fetch_sqn(Key, Hash, Manifest, L0Cache, L0Index) ->
+    R = fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, fun sst_getsqn/4),
     element(1, R).
 
 fetch_mem(Key, Hash, Manifest, L0Cache, L0Index, FetchFun) ->
@@ -1516,8 +1522,8 @@ timed_sst_get(PID, Key, Hash, Level) ->
     T0 = timer:now_diff(os:timestamp(), SW),
     log_slowfetch(T0, R, PID, Level, ?SLOW_FETCH).
 
-sst_get(PID, Key, Hash, Level) ->
-    leveled_sst:sst_get(PID, Key, Hash).
+sst_getsqn(PID, Key, Hash, _Level) ->
+    leveled_sst:sst_getsqn(PID, Key, Hash).
 
 log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     case {T0, R} of
@@ -1532,29 +1538,26 @@ log_slowfetch(T0, R, PID, Level, FetchTolerance) ->
     end.
 
 
--spec compare_to_sqn(tuple()|not_present, integer()) -> sqn_check().
+-spec compare_to_sqn(
+    leveled_codec:ledger_kv()|leveled_codec:sqn()|not_present,
+    integer()) -> sqn_check().
 %% @doc
 %% Check to see if the SQN in the penciller is after the SQN expected for an 
 %% object (used to allow the journal to check compaction status from a cache
 %% of the ledger - objects with a more recent sequence number can be compacted).
+compare_to_sqn(not_present, _SQN) ->
+    missing;
+compare_to_sqn(ObjSQN, SQN) when is_integer(ObjSQN), ObjSQN > SQN ->
+    replaced;
+compare_to_sqn(ObjSQN, _SQN) when is_integer(ObjSQN) ->
+    % Normally we would expect the SQN to be equal here, but
+    % this also allows for the Journal to have a more advanced
+    % value. We return true here as we wouldn't want to
+    % compact thta more advanced value, but this may cause
+    % confusion in snapshots.
+    current;
 compare_to_sqn(Obj, SQN) ->
-    case Obj of
-        not_present ->
-            missing;
-        Obj ->
-            SQNToCompare = leveled_codec:strip_to_seqonly(Obj),
-            if
-                SQNToCompare > SQN ->
-                    replaced;
-                true ->
-                    % Normally we would expect the SQN to be equal here, but
-                    % this also allows for the Journal to have a more advanced
-                    % value. We return true here as we wouldn't want to
-                    % compact thta more advanced value, but this may cause
-                    % confusion in snapshots.
-                    current
-            end
-    end.
+    compare_to_sqn(leveled_codec:strip_to_seqonly(Obj), SQN).
 
 
 %%%============================================================================

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -86,7 +86,6 @@
 -define(TREE_SIZE, 4).
 -define(TIMING_SAMPLECOUNTDOWN, 20000).
 -define(TIMING_SAMPLESIZE, 100).
--define(CACHE_SIZE, 32).
 -define(BLOCK_LENGTHS_LENGTH, 20).
 -define(LMD_LENGTH, 4).
 -define(FLIPPER32, 4294967295).
@@ -1169,13 +1168,17 @@ cache_hash({_SegHash, ExtraHash}, Level) when is_integer(ExtraHash) ->
 %% as each level has more files than the previous level.  Load tests with
 %% any sort of pareto distribution show far better cost/benefit ratios for
 %% cache at higher levels.
--spec cache_size(non_neg_integer()) -> no_cache|32|64|128.
+-spec cache_size(non_neg_integer()) -> no_cache|4|32|64.
 cache_size(N) when N < 3 ->
-    128;
-cache_size(3) ->
     64;
+cache_size(3) ->
+    32;
 cache_size(4) ->
     32;
+cache_size(5) ->
+    4;
+cache_size(6) ->
+    4;
 cache_size(_LowerLevel) ->
     no_cache.
 
@@ -3721,45 +3724,65 @@ simple_switchcache_test() ->
     KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?LOOK_SLOTSIZE),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, Bloom} = 
+    {ok, OpenP4, {FirstKey, LastKey}, Bloom} = 
         testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    ok = sst_switchlevels(Pid, 5),
+    ok = sst_switchlevels(OpenP4, 5),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    gen_fsm:send_event(Pid, timeout),
+    gen_fsm:send_event(OpenP4, timeout),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
                     KVList1),
-    ok = sst_close(Pid),
+    ok = sst_close(OpenP4),
     OptsSST = #sst_options{press_method=native,
                             log_options=leveled_log:get_opts()},
-    {ok, OpenP, {FirstKey, LastKey}, Bloom} =
+    {ok, OpenP5, {FirstKey, LastKey}, Bloom} =
         sst_open(RP, Filename ++ ".sst", OptsSST, 5),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
-    gen_fsm:send_event(Pid, timeout),
+    gen_fsm:send_event(OpenP5, timeout),
     lists:foreach(fun({K, V}) ->
-                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
                         end,
                     KVList1),
-    ok = sst_close(OpenP),
+    ok = sst_switchlevels(OpenP5, 6),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(OpenP5, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    ok = sst_switchlevels(OpenP5, 7),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(OpenP5, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP5, K))
+                        end,
+                    KVList1),
+    ok = sst_close(OpenP5),
     ok = file:delete(filename:join(RP, Filename ++ ".sst")).
 
 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -827,16 +827,22 @@ reader(close, _From, State) ->
     {stop, normal, ok, State}.
 
 reader(timeout, State) ->
-    FreshCache = new_cache(State#state.level),
+    FreshFetchCache = new_cache(State#state.level),
+    Summary = State#state.summary,
+    FreshBlockIndexCache = new_blockindex_cache(Summary#summary.size),
     {next_state,
         reader,
-        State#state{fetch_cache = FreshCache},
+        State#state{
+            fetch_cache = FreshFetchCache,
+            blockindex_cache = FreshBlockIndexCache},
         hibernate};
 reader({switch_levels, NewLevel}, State) ->
     FreshCache = new_cache(NewLevel),
     {next_state,
         reader,
-        State#state{level = NewLevel, fetch_cache = FreshCache},
+        State#state{
+            level = NewLevel,
+            fetch_cache = FreshCache},
         hibernate}.
 
 

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -96,7 +96,12 @@
 -define(TOMB_COUNT, true).
 -define(USE_SET_FOR_SPEED, 64).
 -define(STARTUP_TIMEOUT, 10000).
+
+-ifdef(TEST).
+-define(HIBERNATE_TIMEOUT, 5000).
+-else.
 -define(HIBERNATE_TIMEOUT, 60000).
+-endif.
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -813,6 +818,8 @@ reader(close, _From, State) ->
     ok = file:close(State#state.handle),
     {stop, normal, ok, State}.
 
+reader(timeout, State) ->
+    {next_state, reader, State, hibernate};
 reader({switch_levels, NewLevel}, State) ->
     {next_state, reader, State#state{level = NewLevel}, hibernate}.
 
@@ -3695,6 +3702,24 @@ simple_persisted_slotsize_tester(SSTNewFun) ->
     ok = sst_close(Pid),
     ok = file:delete(filename:join(RP, Filename ++ ".sst")).
 
+reader_hibernate_test_() ->
+    {timeout, 90, fun reader_hibernate_tester/0}.
+
+reader_hibernate_tester() ->
+    {RP, Filename} = {?TEST_AREA, "readerhibernate_test"},
+    KVList0 = generate_randomkeys(1, ?LOOK_SLOTSIZE * 32, 1, 20),
+    KVList1 = lists:ukeysort(1, KVList0),
+    [{FirstKey, FV}|_Rest] = KVList1,
+    {LastKey, _LV} = lists:last(KVList1),
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+        testsst_new(RP, Filename, 1, KVList1, length(KVList1), native),
+    ?assertMatch({FirstKey, FV}, sst_get(Pid, FirstKey)),
+    SQN = leveled_codec:strip_to_seqonly({FirstKey, FV}),
+    ?assertMatch(
+        SQN,
+        sst_getsqn(Pid, FirstKey, leveled_codec:segment_hash(FirstKey))),
+    timer:sleep(?HIBERNATE_TIMEOUT + 1000),
+    ?assertMatch({FirstKey, FV}, sst_get(Pid, FirstKey)).
 
 delete_pending_test_() ->
     {timeout, 30, fun delete_pending_tester/0}.

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -215,8 +215,7 @@
                     timings = no_timing :: sst_timings(),
                     timings_countdown = 0 :: integer(),
                     starting_pid :: pid()|undefined,
-                    fetch_cache = array:new([{size, ?CACHE_SIZE}]) ::
-                        fetch_cache() | redacted,
+                    fetch_cache = no_cache :: fetch_cache() | redacted,
                     new_slots :: list()|undefined,
                     deferred_startup_tuple :: tuple()|undefined,
                     level :: non_neg_integer()|undefined,
@@ -558,7 +557,7 @@ starting({sst_open, RootPath, Filename, OptsSST, Level}, _From, State) ->
     {reply,
         {ok, {Summary#summary.first_key, Summary#summary.last_key}, Bloom},
         reader,
-        UpdState#state{level = Level}};
+        UpdState#state{level = Level, fetch_cache = new_cache(Level)}};
 starting({sst_new, 
             RootPath, Filename, Level, 
             {SlotList, FirstKey}, MaxSQN,
@@ -598,7 +597,8 @@ starting({sst_new,
         UpdState#state{blockindex_cache = BlockIndex,
                         high_modified_date = HighModDate,
                         starting_pid = StartingPID,
-                        level = Level}};
+                        level = Level,
+                        fetch_cache = new_cache(Level)}};
 starting({sst_newlevelzero, RootPath, Filename,
                     Penciller, MaxSQN,
                     OptsSST, IdxModDate}, _From, State) -> 
@@ -606,7 +606,10 @@ starting({sst_newlevelzero, RootPath, Filename,
         {RootPath, Filename, Penciller, MaxSQN, OptsSST,
             IdxModDate},
     {reply, ok, starting,
-        State#state{deferred_startup_tuple = DeferredStartupTuple, level = 0}};
+        State#state{
+            deferred_startup_tuple = DeferredStartupTuple,
+            level = 0,
+            fetch_cache = new_cache(0)}};
 starting(close, _From, State) ->
     % No file should have been created, so nothing to close.
     {stop, normal, ok, State}.
@@ -819,9 +822,17 @@ reader(close, _From, State) ->
     {stop, normal, ok, State}.
 
 reader(timeout, State) ->
-    {next_state, reader, State, hibernate};
+    FreshCache = new_cache(State#state.level),
+    {next_state,
+        reader,
+        State#state{fetch_cache = FreshCache},
+        hibernate};
 reader({switch_levels, NewLevel}, State) ->
-    {next_state, reader, State#state{level = NewLevel}, hibernate}.
+    FreshCache = new_cache(NewLevel),
+    {next_state,
+        reader,
+        State#state{level = NewLevel, fetch_cache = FreshCache},
+        hibernate}.
 
 
 delete_pending({get_sqn, LedgerKey, Hash}, _From, State) ->
@@ -1135,8 +1146,38 @@ extract_hash({SegHash, _ExtraHash}) when is_integer(SegHash) ->
 extract_hash(NotHash) ->
     NotHash.
 
-cache_hash({_SegHash, ExtraHash}) when is_integer(ExtraHash) ->
-    ExtraHash band (?CACHE_SIZE - 1).
+
+-spec new_cache(non_neg_integer()) -> fetch_cache().
+new_cache(Level) ->
+    case cache_size(Level) of
+        no_cache ->
+            no_cache;
+        CacheSize ->
+            array:new([{size, CacheSize}])
+    end.
+
+-spec cache_hash(leveled_codec:segment_hash(), non_neg_integer()) ->
+    non_neg_integer()|no_cache.
+cache_hash({_SegHash, ExtraHash}, Level) when is_integer(ExtraHash) ->
+    case cache_size(Level) of
+        no_cache -> no_cache;
+        CH -> ExtraHash band (CH - 1)
+    end.
+
+%% @doc
+%% The lower the level, the bigger the memory cost of supporting the cache,
+%% as each level has more files than the previous level.  Load tests with
+%% any sort of pareto distribution show far better cost/benefit ratios for
+%% cache at higher levels.
+-spec cache_size(non_neg_integer()) -> no_cache|32|64|128.
+cache_size(N) when N < 3 ->
+    128;
+cache_size(3) ->
+    64;
+cache_size(4) ->
+    32;
+cache_size(_LowerLevel) ->
+    no_cache.
 
 -spec fetch_from_cache(
     non_neg_integer(),
@@ -1291,7 +1332,7 @@ fetch(LedgerKey, Hash, State, Timings0) ->
                     {SW3, Timings3} =
                         update_timings(SW2, Timings2, slot_index, true),
                     FetchCache = State#state.fetch_cache,
-                    CacheHash = cache_hash(Hash),
+                    CacheHash = cache_hash(Hash, State#state.level),
                     case fetch_from_cache(CacheHash, FetchCache) of 
                         {LedgerKey, V} ->
                             {_SW4, Timings4} = 
@@ -1436,10 +1477,11 @@ write_file(RootPath, Filename, SummaryBin, SlotsBin,
                                         false),
     FinalName.
 
-read_file(Filename, State, CacheFile) ->
+read_file(Filename, State, LoadPageCache) ->
     {Handle, FileVersion, SummaryBin} = 
-        open_reader(filename:join(State#state.root_path, Filename),
-                    CacheFile),
+        open_reader(
+            filename:join(State#state.root_path, Filename),
+            LoadPageCache),
     UpdState0 = imp_fileversion(FileVersion, State),
     {Summary, Bloom, SlotList, TombCount} =
         read_table_summary(SummaryBin, UpdState0#state.tomb_count),
@@ -1450,18 +1492,10 @@ read_file(Filename, State, CacheFile) ->
     leveled_log:log("SST03", [Filename,
                                 Summary#summary.size,
                                 Summary#summary.max_sqn]),
-    FetchCache =
-        case CacheFile of
-            true ->
-                State#state.fetch_cache;
-            false ->
-                no_cache
-        end,
     {UpdState1#state{summary = UpdSummary,
                         handle = Handle,
                         filename = Filename,
-                        tomb_count = TombCount,
-                        fetch_cache = FetchCache},
+                        tomb_count = TombCount},
         Bloom}.
 
 gen_fileversion(PressMethod, IdxModDate, CountOfTombs) ->
@@ -3680,11 +3714,57 @@ additional_range_test() ->
     % Test blows up anyway
     % R8 = sst_getkvrange(P1, element(1, PastEKV), element(1, PastEKV), 2),
     % ?assertMatch([], R8).
-    
+
+simple_switchcache_test() ->
+    {RP, Filename} = {?TEST_AREA, "simple_switchcache_test"},
+    KVList0 = generate_randomkeys(1, ?LOOK_SLOTSIZE * 2, 1, 20),
+    KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?LOOK_SLOTSIZE),
+    [{FirstKey, _FV}|_Rest] = KVList1,
+    {LastKey, _LV} = lists:last(KVList1),
+    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+        testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    ok = sst_switchlevels(Pid, 5),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(Pid, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(Pid, K))
+                        end,
+                    KVList1),
+    ok = sst_close(Pid),
+    OptsSST = #sst_options{press_method=native,
+                            log_options=leveled_log:get_opts()},
+    {ok, OpenP, {FirstKey, LastKey}, _Bloom} =
+        sst_open(RP, Filename ++ ".sst", OptsSST, 5),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    gen_fsm:send_event(Pid, timeout),
+    lists:foreach(fun({K, V}) ->
+                        ?assertMatch({K, V}, sst_get(OpenP, K))
+                        end,
+                    KVList1),
+    ok = sst_close(OpenP),
+    ok = file:delete(filename:join(RP, Filename ++ ".sst")).
+
 
 simple_persisted_slotsize_test() ->
     simple_persisted_slotsize_tester(fun testsst_new/6).
-
 
 simple_persisted_slotsize_tester(SSTNewFun) ->
     {RP, Filename} = {?TEST_AREA, "simple_slotsize_test"},

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -3721,7 +3721,7 @@ simple_switchcache_test() ->
     KVList1 = lists:sublist(lists:ukeysort(1, KVList0), ?LOOK_SLOTSIZE),
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
-    {ok, Pid, {FirstKey, LastKey}, _Bloom} = 
+    {ok, Pid, {FirstKey, LastKey}, Bloom} = 
         testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
     lists:foreach(fun({K, V}) ->
                         ?assertMatch({K, V}, sst_get(Pid, K))
@@ -3744,7 +3744,7 @@ simple_switchcache_test() ->
     ok = sst_close(Pid),
     OptsSST = #sst_options{press_method=native,
                             log_options=leveled_log:get_opts()},
-    {ok, OpenP, {FirstKey, LastKey}, _Bloom} =
+    {ok, OpenP, {FirstKey, LastKey}, Bloom} =
         sst_open(RP, Filename ++ ".sst", OptsSST, 5),
     lists:foreach(fun({K, V}) ->
                         ?assertMatch({K, V}, sst_get(OpenP, K))

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -96,6 +96,7 @@
 -define(TOMB_COUNT, true).
 -define(USE_SET_FOR_SPEED, 64).
 -define(STARTUP_TIMEOUT, 10000).
+-define(HIBERNATE_TIMEOUT, 60000).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -119,6 +120,7 @@
             sst_open/4,
             sst_get/2,
             sst_get/3,
+            sst_getsqn/3,
             sst_expandpointer/5,
             sst_getmaxsequencenumber/1,
             sst_setfordelete/2,
@@ -435,6 +437,15 @@ sst_get(Pid, LedgerKey) ->
 sst_get(Pid, LedgerKey, Hash) ->
     gen_fsm:sync_send_event(Pid, {get_kv, LedgerKey, Hash}, infinity).
 
+-spec sst_getsqn(pid(),
+    leveled_codec:ledger_key(),
+    leveled_codec:segment_hash()) -> leveled_codec:sqn()|not_present.
+%% @doc
+%% Return a SQN for the key or not_present if the key is not in
+%% the store (with the magic hash precalculated).
+sst_getsqn(Pid, LedgerKey, Hash) ->
+    gen_fsm:sync_send_event(Pid, {get_sqn, LedgerKey, Hash}, infinity).
+
 -spec sst_getmaxsequencenumber(pid()) -> integer().
 %% @doc
 %% Get the maximume sequence number for this SST file
@@ -696,6 +707,11 @@ starting({sst_returnslot, FetchedSlot, FetchFun, SlotCount}, State) ->
                 State#state{new_slots = FetchedSlots}}
     end.
 
+reader({get_sqn, LedgerKey, Hash}, _From, State) ->
+    % Get a KV value and potentially take sample timings
+    {Result, UpdState, _UpdTimings} = 
+        fetch(LedgerKey, Hash, State, no_timing),
+    {reply, sqn_only(Result), reader, UpdState, ?HIBERNATE_TIMEOUT};
 reader({get_kv, LedgerKey, Hash}, _From, State) ->
     % Get a KV value and potentially take sample timings
     {Result, UpdState, UpdTimings} = 
@@ -801,6 +817,11 @@ reader({switch_levels, NewLevel}, State) ->
     {next_state, reader, State#state{level = NewLevel}, hibernate}.
 
 
+delete_pending({get_sqn, LedgerKey, Hash}, _From, State) ->
+    % Get a KV value and potentially take sample timings
+    {Result, UpdState, _UpdTimings} = 
+        fetch(LedgerKey, Hash, State, no_timing),
+    {reply, sqn_only(Result), delete_pending, UpdState, ?DELETE_TIMEOUT};
 delete_pending({get_kv, LedgerKey, Hash}, _From, State) ->
     {Result, UpdState, _Ts} = fetch(LedgerKey, Hash, State, no_timing),
     {reply, Result, delete_pending, UpdState, ?DELETE_TIMEOUT};
@@ -1095,6 +1116,12 @@ member_check(Hash, {sets, HashSet}) ->
 member_check(_Miss, _Checker) ->
     false.
 
+-spec sqn_only(leveled_codec:ledger_kv()|not_present)
+        -> leveled_codec:sqn()|not_present.
+sqn_only(not_present) ->
+    not_present;
+sqn_only(KV) ->
+    leveled_codec:strip_to_seqonly(KV).
 
 extract_hash({SegHash, _ExtraHash}) when is_integer(SegHash) ->
     tune_hash(SegHash);
@@ -1114,7 +1141,7 @@ fetch_from_cache(CacheHash, Cache) ->
 
 -spec add_to_cache(
     non_neg_integer(),
-    leveled_codec:ledger_kv()
+    leveled_codec:ledger_kv(),
     fetch_cache()) -> fetch_cache().
 add_to_cache(_CacheHash, _KV, no_cache) ->
     no_cache;


### PR DESCRIPTION
On very large stores with lots of old, and largely untouched objects, too much memory is taken up by relatively inactive files.

The fetch_cache has an unpredictable size, and it is hard to reason or prove its effectiveness.

This change takes the existing caching level configuration, which prevents automatic fadvise of files below a certain level in the LSM tree, and also blocks the creation of the fetch_cache below a certain level.

There has been some observations of memory fragmentation as well. There is currently no hibernation of unused files. Unused files will still be used during all object folds and journal compaction because of SQN checking, so SQN checking is now used as a potential trigger for hibernation - if there is no activity in the 60s following. a SQN check the managing process for the SST file will hibernate.