### PR TITLE
Mas i370 deletepending

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -3074,8 +3074,10 @@ is_empty_headonly_test() ->
 
 undefined_rootpath_test() ->
     Opts = [{max_journalsize, 1000000}, {cache_size, 500}],
+    error_logger:tty(false),
     R = gen_server:start(?MODULE, [set_defaults(Opts)], []),
-    ?assertMatch({error, no_root_path}, R).
+    ?assertMatch({error, no_root_path}, R),
+    error_logger:tty(true).
         
 
 foldkeys_headonly_test() ->

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -550,7 +550,7 @@ release_snapshot(Manifest, Pid) ->
 %% @doc
 %% A SST file which is in the delete_pending state can check to see if it is
 %% ready to delete against the manifest.
-%% This does not up date the manifest, a call is required to clear_pending to
+%% This does not update the manifest, a call is required to clear_pending to
 %% remove the file from the manifest's list of pending_deletes.
 -spec ready_to_delete(manifest(), string()) -> boolean().
 ready_to_delete(Manifest, Filename) ->


### PR DESCRIPTION
Previously delete_confirmation was blocked on work_ongoing.

However, if the penciller has a work backlog, work_ongoing may be a recurring problem ... and some files, may remain undeleted long after their use - lifetimes for L0 fails in particular have seen to rise from 10-15s to 5m +.

Letting L0 files linger can have a significant impact on memory.  In put-heavy tests (e.g. when testing riak-admin transfers) the memory footprint of a riak node has bene observed peaking more than 80% above normal levels, when compared to using this patch.

This PR allows for deletes to be confirmed even when there is work ongoing, by postponing the updating of the manifest until the manifest is next returned from the clerk.