### PR TITLE
Mas i370 patch c

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -162,7 +162,7 @@
                         loader = leveled_tree:empty(?CACHE_TYPE)
                                     :: tuple()|empty_cache,
                         load_queue = [] :: list(),
-                        index = leveled_pmem:new_index(), % array or empty_index
+                        index = leveled_pmem:new_index(),
                         min_sqn = infinity :: integer()|infinity,
                         max_sqn = 0 :: integer()}).
 
@@ -2384,7 +2384,7 @@ addto_ledgercache({H, SQN, KeyChanges}, Cache, loader) ->
 %% Check the ledger cache for a Key, when the ledger cache is in loader mode
 %% and so is populating a queue not an ETS table
 check_in_ledgercache(PK, Hash, Cache, loader) ->
-    case leveled_pmem:check_index(Hash, Cache#ledger_cache.index) of
+    case leveled_pmem:check_index(Hash, [Cache#ledger_cache.index]) of
         [] ->
             false;
         _ ->

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -81,7 +81,7 @@
 -type ledger_key() :: 
         {tag(), any(), any(), any()}|all.
 -type slimmed_key() ::
-        {binary(), binary()|null}|binary()|null|all.
+        {binary()|null, binary()|null}|binary()|null|all.
 -type ledger_value() ::
         ledger_value_v1()|ledger_value_v2().
 -type ledger_value_v1() ::
@@ -376,6 +376,8 @@ endkey_passed({K1, K2, K3, null}, {K1, K2, K3, _}) ->
 endkey_passed({K1, null}, {K1, _}) ->
     % See leveled_sst SlotIndex implementation.  Here keys may be slimmed to
     % single binaries or two element tuples before forming the index.
+    false;
+endkey_passed({null, _QK1}, {_RK1, _RK2}) ->
     false;
 endkey_passed(null, _) ->
     false;

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -148,7 +148,9 @@
     {"P0031",
         {info, "Completion of update to levelzero"
                     ++ " with cache_size=~w level0_due=~w"
-                    ++ " and change_pending=~w"}},
+                    ++ " change_pending=~w"
+                    ++ " MinSQN=~w MaxSQN=~w"
+                    ++ " CacheTime_us=~w RollTime_us=~w"}},
     {"P0032",
         {info, "Fetch head timing with sample_count=~w and level timings of"
                     ++ " foundmem_time=~w found0_time=~w found1_time=~w" 

--- a/src/leveled_pmem.erl
+++ b/src/leveled_pmem.erl
@@ -37,7 +37,6 @@
         merge_trees/4,
         add_to_index/3,
         new_index/0,
-        clear_index/1,
         check_index/2,
         cache_full/1
         ]).      
@@ -46,8 +45,7 @@
 
 -define(MAX_CACHE_LINES, 31). % Must be less than 128
 
-% -type index_array() :: array:array().
--type index_array() :: any()|none. % To live with OTP16
+-type index_array() :: list(array:array())|[]|none. 
 
 -export_type([index_array/0]).
 
@@ -61,8 +59,8 @@
 cache_full(L0Cache) ->
     length(L0Cache) == ?MAX_CACHE_LINES.
 
--spec prepare_for_index(index_array(), leveled_codec:segment_hash()) 
-                                                            -> index_array().
+-spec prepare_for_index(
+    array:array(), leveled_codec:segment_hash()) -> array:array().
 %% @doc
 %% Add the hash of a key to the index.  This is 'prepared' in the sense that
 %% this index is not use until it is loaded into the main index.
@@ -77,45 +75,39 @@ prepare_for_index(IndexArray, Hash) ->
     Bin = array:get(Slot, IndexArray),
     array:set(Slot, <<Bin/binary, 1:1/integer, H0:23/integer>>, IndexArray).
 
--spec add_to_index(index_array(), index_array(), integer()) -> index_array().
+-spec add_to_index(array:array(), index_array(), integer()) -> index_array().
 %% @doc
 %% Expand the penciller's current index array with the details from a new
 %% ledger cache tree sent from the Bookie.  The tree will have a cache slot
 %% which is the index of this ledger_cache in the list of the ledger_caches
 add_to_index(LM1Array, L0Index, CacheSlot) when CacheSlot < 128 ->
-    IndexAddFun =
-        fun(Slot, Acc) ->
-            Bin0 = array:get(Slot, Acc),
-            BinLM1 = array:get(Slot, LM1Array),
-            array:set(Slot,
-                        <<Bin0/binary,
-                            0:1/integer, CacheSlot:7/integer,
-                            BinLM1/binary>>,
-                        Acc)
-        end,
-    lists:foldl(IndexAddFun, L0Index, lists:seq(0, 255)).
+    [LM1Array|L0Index].
 
--spec new_index() -> index_array().
+-spec new_index() -> array:array().
 %% @doc
 %% Create a new index array
 new_index() ->
     array:new([{size, 256}, {default, <<>>}]).
 
--spec clear_index(index_array()) -> index_array().
-%% @doc
-%% Create a new index array
-clear_index(_L0Index) ->
-    new_index().
-
--spec check_index({integer(), integer()}, index_array()) -> list(integer()).
+-spec check_index(leveled_codec:segment_hash(), index_array())
+        -> list(non_neg_integer()).
 %% @doc
 %% return a list of positions in the list of cache arrays that may contain the
 %% key associated with the hash being checked
 check_index(Hash, L0Index) ->
     {Slot, H0} = split_hash(Hash),
-    Bin = array:get(Slot, L0Index),
-    find_pos(Bin, H0, [], 0).    
-
+    {_L, Positions} =
+        lists:foldl(
+            fun(A, {SlotC, PosList}) ->
+                B = array:get(Slot, A),
+                case find_pos(B, H0) of
+                    true -> {SlotC + 1, [SlotC|PosList]};
+                    false -> {SlotC + 1, PosList}
+                end
+            end,
+            {1, []},
+            L0Index),
+    lists:reverse(Positions).    
 
 -spec add_to_cache(integer(),
                     {tuple(), integer(), integer()},
@@ -128,16 +120,11 @@ check_index(Hash, L0Index) ->
 %% the Ledger's SQN.
 add_to_cache(L0Size, {LevelMinus1, MinSQN, MaxSQN}, LedgerSQN, TreeList) ->
     LM1Size = leveled_tree:tsize(LevelMinus1),
-    case LM1Size of
-        0 ->
-            {LedgerSQN, L0Size, TreeList};
-        _ ->
-            if
-                MinSQN >= LedgerSQN ->
-                    {MaxSQN,
-                        L0Size + LM1Size,
-                        lists:append(TreeList, [LevelMinus1])}
-            end
+    if
+        MinSQN >= LedgerSQN ->
+            {MaxSQN,
+                L0Size + LM1Size,
+                [LevelMinus1|TreeList]}
     end.
 
 -spec to_list(
@@ -151,7 +138,7 @@ add_to_cache(L0Size, {LevelMinus1, MinSQN, MaxSQN}, LedgerSQN, TreeList) ->
 %% does a large object copy of the whole cache.
 to_list(Slots, FetchFun) ->
     SW = os:timestamp(),
-    SlotList = lists:reverse(lists:seq(1, Slots)),
+    SlotList = lists:seq(1, Slots),
     FullList = lists:foldl(fun(Slot, Acc) ->
                                 Tree = FetchFun(Slot),
                                 L = leveled_tree:to_list(Tree),
@@ -194,32 +181,24 @@ check_levelzero(Key, Hash, PosList, TreeList) ->
 %% currently unmerged bookie's ledger cache) that are between StartKey
 %% and EndKey (inclusive).
 merge_trees(StartKey, EndKey, TreeList, LevelMinus1) ->
-    lists:foldl(fun(Tree, Acc) ->
-                        R = leveled_tree:match_range(StartKey,
-                                                        EndKey,
-                                                        Tree),
-                        lists:ukeymerge(1, Acc, R) end,
-                    [],
-                    [LevelMinus1|lists:reverse(TreeList)]).
+    lists:foldl(
+        fun(Tree, Acc) ->
+            R = leveled_tree:match_range(StartKey, EndKey, Tree),
+            lists:ukeymerge(1, Acc, R) end,
+            [],
+            [LevelMinus1|TreeList]).
 
 %%%============================================================================
 %%% Internal Functions
 %%%============================================================================
 
 
-find_pos(<<>>, _Hash, PosList, _SlotID) ->
-    PosList;
-find_pos(<<1:1/integer, Hash:23/integer, T/binary>>, Hash, PosList, SlotID) ->
-    case lists:member(SlotID, PosList) of
-        true ->
-            find_pos(T, Hash, PosList, SlotID);
-        false ->
-            find_pos(T, Hash, PosList ++ [SlotID], SlotID)
-    end;
-find_pos(<<1:1/integer, _Miss:23/integer, T/binary>>, Hash, PosList, SlotID) ->
-    find_pos(T, Hash, PosList, SlotID);
-find_pos(<<0:1/integer, NxtSlot:7/integer, T/binary>>, Hash, PosList, _SlotID) ->
-    find_pos(T, Hash, PosList, NxtSlot).
+find_pos(<<>>, _Hash) ->
+    false;
+find_pos(<<1:1/integer, Hash:23/integer, _T/binary>>, Hash) ->
+    true;
+find_pos(<<1:1/integer, _Miss:23/integer, T/binary>>, Hash) ->
+    find_pos(T, Hash).
 
 
 split_hash({SegmentID, ExtraHash}) ->
@@ -243,9 +222,7 @@ check_slotlist(Key, _Hash, CheckList, TreeList) ->
                     end
             end
             end,
-    lists:foldl(SlotCheckFun,
-                    {false, not_found},
-                    lists:reverse(CheckList)).
+    lists:foldl(SlotCheckFun, {false, not_found}, CheckList).
 
 %%%============================================================================
 %%% Test
@@ -326,7 +303,7 @@ compare_method_test() ->
             end,
     
     S0 = lists:foldl(fun({Key, _V}, Acc) ->
-                            R0 = lists:foldr(FindKeyFun(Key),
+                            R0 = lists:foldl(FindKeyFun(Key),
                                                 {false, not_found},
                                                 TreeList),
                             [R0|Acc] end,
@@ -395,7 +372,7 @@ with_index_test2() ->
             {R, UpdL0Index, lists:ukeymerge(1, LM1, SrcList)}
         end,
     
-    R0 = lists:foldl(LoadFun, {{0, 0, []}, new_index(), []}, lists:seq(1, 16)),
+    R0 = lists:foldl(LoadFun, {{0, 0, []}, [], []}, lists:seq(1, 16)),
     
     {{SQN, Size, TreeList}, L0Index, SrcKVL} = R0,
     ?assertMatch(32000, SQN),
@@ -412,5 +389,53 @@ with_index_test2() ->
     
     _R1 = lists:foldl(CheckFun, {L0Index, TreeList}, SrcKVL).
             
+
+index_performance_test() ->
+    LM1 = generate_randomkeys_aslist(1, 2000, 1, 500),
+    LM2 = generate_randomkeys_aslist(2001, 2000, 1, 500),
+    HL1 = lists:map(fun({K, _V}) -> leveled_codec:segment_hash(K) end, LM1),
+    HL2 = lists:map(fun({K, _V}) -> leveled_codec:segment_hash(K) end, LM2),
+
+    SWP = os:timestamp(),
+    A1 =
+        lists:foldl(
+            fun(H, A) -> prepare_for_index(A, H) end,
+            new_index(),
+            HL1),
+    io:format(
+        user, 
+        "~nPrepare single index takes ~w microsec~n",
+        [timer:now_diff(os:timestamp(), SWP)]),
+    
+    SWL = os:timestamp(),
+    PMI1 = 
+        lists:foldl(
+            fun(I, Idx) -> add_to_index(A1, Idx, I) end, [], lists:seq(1, 8)),
+    io:format(
+        user, 
+        "Appending to array takes ~w microsec~n",
+        [timer:now_diff(os:timestamp(), SWL)]),
+    
+    SWC1 = os:timestamp(),
+    R0 = lists:seq(1, 8),
+    lists:foreach(fun(H) -> ?assertMatch(R0, check_index(H, PMI1)) end, HL1),
+    io:format(
+        user, 
+        "Checking 2000 matches in array at each level takes ~w microsec~n",
+        [timer:now_diff(os:timestamp(), SWC1)]),
+    
+    SWC2 = os:timestamp(),
+    FPT = 
+        lists:foldl(
+            fun(H, FPC) -> FPC + length(check_index(H, PMI1)) end,
+            0,
+            HL2),
+    io:format(
+        user, 
+        "Checking 2000 misses in array at each level takes ~w microsec " ++
+        "with ~w false positives~n",
+        [timer:now_diff(os:timestamp(), SWC2), FPT]).
+
+
 
 -endif.

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -587,13 +587,29 @@ generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     KNumber =
         lists:flatten(
             io_lib:format("K~8..0B", [leveled_rand:uniform(1000)])),
-    {K, V} = {{o, "Bucket" ++ BNumber, "Key" ++ KNumber, null},
-                {Seqn, {active, infinity}, null}},
+    {K, V} =
+        {{o_kv,
+            {<<"btype">>, list_to_binary("Bucket" ++ BNumber)},
+            list_to_binary("Key" ++ KNumber),
+            null},
+            Seqn},
     generate_randomkeys(Seqn + 1,
                         Count - 1,
                         [{K, V}|Acc],
                         BucketLow,
                         BRange).
+
+generate_simplekeys(Seqn, Count) ->
+    generate_simplekeys(Seqn, Count, []).
+
+generate_simplekeys(_Seqn, 0, Acc) ->
+    Acc;
+generate_simplekeys(Seqn, Count, Acc) ->
+    KNumber =
+        list_to_binary(
+            lists:flatten(
+                io_lib:format("K~8..0B", [leveled_rand:uniform(100000)]))),
+    generate_simplekeys(Seqn + 1, Count - 1, [{KNumber, Seqn}|Acc]).
 
 
 tree_search_test() ->
@@ -685,34 +701,47 @@ tolist_test_by_type(Type) ->
     ?assertMatch(KL, T_Reverse).
     
 tree_timing_test() ->
+    log_tree_test_by_(16, tree, 8000),
     log_tree_test_by_(16, tree, 4000),
-    tree_test_by_(8, tree, 1000),
-    tree_test_by_(4, tree, 256).
+    log_tree_test_by_(4, tree, 256).
 
 idxt_timing_test() ->
+    log_tree_test_by_(16, idxt, 8000),
     log_tree_test_by_(16, idxt, 4000),
-    tree_test_by_(8, idxt, 1000),
-    tree_test_by_(4, idxt, 256).
+    log_tree_test_by_(4, idxt, 256).
 
 skpl_timing_test() ->
-    tree_test_by_(auto, skpl, 6000),
+    log_tree_test_by_(auto, skpl, 8000),
     log_tree_test_by_(auto, skpl, 4000),
-    tree_test_by_(auto, skpl, 1000),
-    tree_test_by_(auto, skpl, 256).
+    log_tree_test_by_simplekey_(auto, skpl, 4000),
+    log_tree_test_by_(auto, skpl, 512),
+    log_tree_test_by_simplekey_(auto, skpl, 512),
+    log_tree_test_by_(auto, skpl, 256),
+    log_tree_test_by_simplekey_(auto, skpl, 256).
 
 log_tree_test_by_(Width, Type, N) ->
-    erlang:statistics(runtime),
-    G0 = erlang:statistics(garbage_collection),
-    tree_test_by_(Width, Type, N),
-    {_, T1} = erlang:statistics(runtime),
-    G1 = erlang:statistics(garbage_collection),
-    io:format(user, "Test took ~w ms and GC transitioned from ~w to ~w~n",
-                [T1, G0, G1]).
-
-tree_test_by_(Width, Type, N) ->
-    io:format(user, "~nTree test for type and width: ~w ~w~n", [Type, Width]),
     KL = lists:ukeysort(1, generate_randomkeys(1, N, 1, N div 5)),
-    
+    SW = os:timestamp(),
+    tree_test_by_(Width, Type, KL),
+    io:format(user, "Test took ~w ms",
+                [timer:now_diff(os:timestamp(), SW) div 1000]).
+
+log_tree_test_by_simplekey_(Width, Type, N) ->
+    KL = lists:ukeysort(1, generate_simplekeys(1, N)),
+    SW = os:timestamp(),
+    tree_test_by_(Width, Type, KL, false),
+    io:format(user, "Test with simple key took ~w ms",
+                [timer:now_diff(os:timestamp(), SW) div 1000]).
+
+tree_test_by_(Width, Type, KL) ->
+    tree_test_by_(Width, Type, KL, true).
+
+tree_test_by_(Width, Type, KL, ComplexKey) ->
+    io:format(
+        user,
+        "~n~nTree test with complexkey=~w for type and width: ~w ~w~n",
+        [ComplexKey, Type, Width]),
+
     OS = ets:new(test, [ordered_set, private]),
     ets:insert(OS, KL),
     SWaETS = os:timestamp(),
@@ -721,6 +750,9 @@ tree_test_by_(Width, Type, N) ->
                         " of size ~w~n",
                 [timer:now_diff(os:timestamp(), SWaETS),
                     tsize(Tree0)]),
+    io:format(user,
+        "Tree has footprint size ~w flat_size ~w~n",
+        [erts_debug:size(Tree0), erts_debug:flat_size(Tree0)]),
     
     SWaGSL = os:timestamp(),
     Tree1 = from_orderedlist(KL, Type, Width),
@@ -728,6 +760,10 @@ tree_test_by_(Width, Type, N) ->
                         " of size ~w~n",
                 [timer:now_diff(os:timestamp(), SWaGSL),
                     tsize(Tree1)]),
+    io:format(user,
+        "Tree has footprint size ~w flat_size ~w~n",
+        [erts_debug:size(Tree1), erts_debug:flat_size(Tree1)]),
+
     SWaLUP = os:timestamp(),
     lists:foreach(match_fun(Tree0), KL),
     lists:foreach(match_fun(Tree1), KL),
@@ -743,11 +779,25 @@ tree_test_by_(Width, Type, N) ->
                 [timer:now_diff(os:timestamp(), SWaSRCH1)]),
     
     BitBiggerKeyFun =
-        fun(Idx) ->
-            {K, _V} = lists:nth(Idx, KL),
-            {o, B, FullKey, null} = K,
-            {{o, B, FullKey ++ "0", null}, lists:nth(Idx + 1, KL)}
-        end,
+        case ComplexKey of
+            true ->
+                fun(Idx) ->
+                    {K, _V} = lists:nth(Idx, KL),
+                    {o_kv, B, FullKey, null} = K,
+                    {{o_kv,
+                        B,
+                        list_to_binary(binary_to_list(FullKey) ++ "0"),
+                        null},
+                        lists:nth(Idx + 1, KL)}
+                end;
+            false ->
+                fun(Idx) ->
+                    {K, _V} = lists:nth(Idx, KL),
+                    {list_to_binary(binary_to_list(K) ++ "0"),
+                        lists:nth(Idx + 1, KL)}
+                end
+        end,            
+    
     SrchKL = lists:map(BitBiggerKeyFun, lists:seq(1, length(KL) - 1)),
     
     SWaSRCH2 = os:timestamp(),
@@ -778,10 +828,14 @@ matchrange_test_by_type(Type) ->
     FirstKey = element(1, lists:nth(1, KL)),
     FinalKey = element(1, lists:last(KL)),
     PenultimateKey = element(1, lists:nth(length(KL) - 1, KL)),
-    AfterFirstKey = setelement(3, FirstKey, element(3, FirstKey) ++ "0"),
-    AfterPenultimateKey = setelement(3,
-                                    PenultimateKey,
-                                    element(3, PenultimateKey) ++ "0"),
+    AfterFirstKey =
+        setelement(3,
+        FirstKey,
+        list_to_binary(binary_to_list(element(3, FirstKey)) ++ "0")),
+    AfterPenultimateKey =
+        setelement(3,
+        PenultimateKey,
+        list_to_binary(binary_to_list(element(3, PenultimateKey)) ++ "0")),
     
     LengthR =
         fun(SK, EK, T) ->
@@ -812,10 +866,12 @@ extra_matchrange_test_by_type(Type) ->
         fun(RangeL) ->
             SKeyV = lists:nth(1, RangeL),
             EKeyV = lists:nth(50, RangeL),
-            {{o, SB, SK, null}, _SV} = SKeyV,
-            {{o, EB, EK, null}, _EV} = EKeyV,
-            SRangeK = {o, SB, SK ++ "0", null},
-            ERangeK = {o, EB, EK ++ "0", null},
+            {{o_kv, SB, SK, null}, _SV} = SKeyV,
+            {{o_kv, EB, EK, null}, _EV} = EKeyV,
+            SRangeK =
+                {o_kv, SB, list_to_binary(binary_to_list(SK) ++ "0"), null},
+            ERangeK =
+                {o_kv, EB, list_to_binary(binary_to_list(EK) ++ "0"), null},
             ?assertMatch(49, length(match_range(SRangeK, ERangeK, Tree0)))
         end,
     lists:foreach(TestRangeLFun, RangeLists).
@@ -840,10 +896,12 @@ extra_searchrange_test_by_type(Type) ->
             % start key
             SKeyV = lists:nth(1, RangeL),
             EKeyV = lists:nth(50, RangeL),
-            {{o, SB, SK, null}, _SV} = SKeyV,
-            {{o, EB, EK, null}, _EV} = EKeyV,
-            FRangeK = {o, SB, SK ++ "0", null},
-            BRangeK = {o, EB, EK ++ "0", null},
+            {{o_kv, SB, SK, null}, _SV} = SKeyV,
+            {{o_kv, EB, EK, null}, _EV} = EKeyV,
+            FRangeK =
+                {o_kv, SB, list_to_binary(binary_to_list(SK) ++ "0"), null},
+            BRangeK =
+                {o_kv, EB, list_to_binary(binary_to_list(EK) ++ "0"), null},
             ?assertMatch(25, length(search_range(FRangeK, BRangeK, Tree0, SKFun)))
         end,
     lists:foreach(TestRangeLFun, lists:seq(1, 50)).

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -708,7 +708,9 @@ tree_timing_test() ->
 idxt_timing_test() ->
     log_tree_test_by_(16, idxt, 8000),
     log_tree_test_by_(16, idxt, 4000),
-    log_tree_test_by_(4, idxt, 256).
+    log_tree_test_by_(4, idxt, 256),
+    log_tree_test_by_(16, idxt, 256),
+    log_tree_test_by_simplekey_(16, idxt, 256).
 
 skpl_timing_test() ->
     log_tree_test_by_(auto, skpl, 8000),
@@ -751,8 +753,8 @@ tree_test_by_(Width, Type, KL, ComplexKey) ->
                 [timer:now_diff(os:timestamp(), SWaETS),
                     tsize(Tree0)]),
     io:format(user,
-        "Tree has footprint size ~w flat_size ~w~n",
-        [erts_debug:size(Tree0), erts_debug:flat_size(Tree0)]),
+        "Tree has footprint size ~w bytes flat_size ~w bytes~n",
+        [erts_debug:size(Tree0) * 8, erts_debug:flat_size(Tree0) * 8]),
     
     SWaGSL = os:timestamp(),
     Tree1 = from_orderedlist(KL, Type, Width),
@@ -761,8 +763,8 @@ tree_test_by_(Width, Type, KL, ComplexKey) ->
                 [timer:now_diff(os:timestamp(), SWaGSL),
                     tsize(Tree1)]),
     io:format(user,
-        "Tree has footprint size ~w flat_size ~w~n",
-        [erts_debug:size(Tree1), erts_debug:flat_size(Tree1)]),
+        "Tree has footprint size ~w bytes flat_size ~w bytes~n",
+        [erts_debug:size(Tree1) * 8, erts_debug:flat_size(Tree1) * 8]),
 
     SWaLUP = os:timestamp(),
     lists:foreach(match_fun(Tree0), KL),


### PR DESCRIPTION
https://github.com/martinsumner/leveled/issues/370

Previous attempts to manage memory usage in large stores has focused on the Block Index Cache, which is about 2 bytes per key (for directly fetchable keys i.e. not index entries) in the leveled_sst files.  These caches grow through use, but were never expunged - and perhaps files with mainly dead data would falsely retain these caches without performance benefits.

The balance is difficult though, between clearing these caches and the non-functional value in  retaining them (especially wrt to increasing the speed of AAE-related queries).

Running a 36 hour test with relatively small values, to build up a key store.  

Three things are noted:

- Memory fragmentation across the nodes on the cluster is between 52% and 56%.
- The memory footprint of leveled_sst processes is still large, even when the Block Index Cache has been expunged (following journal compaction).
- The memory footprint of leveled _sst files (as measured by `process_info(P, memory)`) is commonly about 8 times larger than the footprint of process state (as measured by `erts_debug:flat_size(sys:get_state(P))`) even after forced garbage collection on the PID.  It is some times 25 times larger.  This is the case even when binary memory owned by the process is empty (as measured by `process_info(P, binary)`). **EDIT ... IGNORE THIS! `erts_debug:flat_size/1` is measured in words not bytes!  One word equals 8 bytes on a 64-bit system**

This PR is a combination of three refactoring exercises intended to try and improve this situation:

- https://github.com/martinsumner/leveled/commit/d393c99856ba79dff2da0b83157f43eb4e9cb6e2 which refactors the penciller memory.  Partly for readability (to stop LoopState being passed to internal functions), but also to try and do memory efficient operations where possible (e.g. `[Addition|ExistingList]` to extend lists).
- https://github.com/martinsumner/leveled/commit/415e682c6d8d2b9c9354a05f487abd2984e4dc44 which changes the index kept within a leveled_sst file (of 1 in 128 keys).  This now attempts to find common elements in this index, (e.g. where all entries in the SST file have the same Type/Bucket) and then only index the deltas.
- https://github.com/martinsumner/leveled/commit/56c5e2565ddde15edebd7c0097cb57882b91d3ed which fixes a bug in the Block Index Cache which meant that when a BIC is cleared, if memory of the HMD date for the file is retained, the cache would never be rebuilt. The refactoring also reduces unnecessary changes to the BIC as the BIC is populated, and an unnecessary fold over the BIC to rediscover the HMD.

It is hoped that tidying up these elements will make it easier to investigate further memory overheads (and perhaps in the case of the leveled_sst index changes, directly improve memory footprint). 