### PR TITLE
Mas i370 patch d

### DIFF
--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -81,7 +81,7 @@
 -type ledger_key() :: 
         {tag(), any(), any(), any()}|all.
 -type slimmed_key() ::
-        {binary(), binary()|null}|binary()|null|all.
+        {binary()|null, binary()|null}|binary()|null|all.
 -type ledger_value() ::
         ledger_value_v1()|ledger_value_v2().
 -type ledger_value_v1() ::
@@ -376,6 +376,8 @@ endkey_passed({K1, K2, K3, null}, {K1, K2, K3, _}) ->
 endkey_passed({K1, null}, {K1, _}) ->
     % See leveled_sst SlotIndex implementation.  Here keys may be slimmed to
     % single binaries or two element tuples before forming the index.
+    false;
+endkey_passed({null, _QK1}, {_RK1, _RK2}) ->
     false;
 endkey_passed(null, _) ->
     false;

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -149,8 +149,7 @@
         {info, "Completion of update to levelzero"
                     ++ " with cache_size=~w level0_due=~w"
                     ++ " change_pending=~w"
-                    ++ " MinSQN=~w MaxSQN=~w"
-                    ++ " CacheTime_us=~w RollTime_us=~w"}},
+                    ++ " MinSQN=~w MaxSQN=~w"}},
     {"P0032",
         {info, "Fetch head timing with sample_count=~w and level timings of"
                     ++ " foundmem_time=~w found0_time=~w found1_time=~w" 

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -95,8 +95,6 @@
         {debug, "Remaining ledger snapshots are ~w"}},
     {"P0005",
         {debug, "Delete confirmed as file ~s is removed from Manifest"}},
-    {"P0006",
-        {info, "Orphaned reply after timeout on L0 file write ~s"}},
     {"P0007",
         {debug, "Sent release message for cloned Penciller following close for "
                 ++ "reason ~w"}},
@@ -119,28 +117,14 @@
     {"P0017",
         {info, "No L0 file found"}},
     {"P0018",
-        {info, "Response to push_mem of ~w with "
-                    ++ "L0 pending ~w and merge backlog ~w"}},
+        {info,
+        "Response to push_mem of returned with cache_size=~w "
+        ++ "L0_pending=~w merge_backlog=~w cachelines_full=~w"}},
     {"P0019",
         {info, "Rolling level zero to filename ~s at ledger sqn ~w"}},
-    {"P0021",
-        {info, "Allocation of work blocked as L0 pending"}},
-    {"P0022",
-        {info, "Manifest at Level ~w"}},
-    {"P0023",
-        {info, "Manifest entry of startkey ~s ~s ~s endkey ~s ~s ~s "
-                ++ "filename=~s~n"}},
     {"P0024",
         {info, "Outstanding compaction work items of ~w with backlog status "
                     ++ "of ~w"}},
-    {"P0025",
-        {info, "Merge to sqn ~w from Level ~w completed"}},
-    {"P0026",
-        {info, "Merge has been commmitted at sequence number ~w"}},
-    {"P0027",
-        {info, "Rename of manifest from ~s ~w to ~s ~w"}},
-    {"P0028",
-        {debug, "Adding cleared file ~s to deletion list"}},
     {"P0029",
         {info, "L0 completion confirmed and will transition to not pending"}},
     {"P0030",
@@ -162,13 +146,8 @@
     {"P0033",
         {error, "Corrupted manifest file at path ~s to be ignored "
                     ++ "due to error ~w"}},
-    {"P0034",
-        {warn, "Snapshot with pid ~w timed out and so deletion will "
-                    ++ "continue regardless"}},
     {"P0035",
         {info, "Startup with Manifest SQN of ~w"}},
-    {"P0036",
-        {info, "Garbage collection on manifest removes key for filename ~s"}},
     {"P0037",
         {debug, "Merging of penciller L0 tree from size ~w complete"}},
     {"P0038",
@@ -181,8 +160,6 @@
         {info, "Archiving filename ~s as unused at startup"}},
     {"P0041",
         {info, "Penciller manifest switched from SQN ~w to ~w"}},
-    {"P0042",
-        {warn, "Cache full so attempting roll memory with l0_size=~w"}},
         
     {"PC001",
         {info, "Penciller's clerk ~w started with owner ~w"}},

--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -122,7 +122,7 @@ handle_cast({push_work, Work}, State) ->
     {ManifestSQN, Deletions} = handle_work(Work, State),
     PDs = dict:store(ManifestSQN, Deletions, State#state.pending_deletions),
     leveled_log:log("PC022", [ManifestSQN]),
-    {noreply, State#state{pending_deletions = PDs}, ?MAX_TIMEOUT};
+    {noreply, State#state{pending_deletions = PDs}, ?MIN_TIMEOUT};
 handle_cast({prompt_deletions, ManifestSQN}, State) ->
     {Deletions, UpdD} = return_deletions(ManifestSQN,
                                             State#state.pending_deletions),

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -710,10 +710,11 @@ handle_call({push_mem, {LedgerTable, PushedIdx, MinSQN, MaxSQN}},
                             State#state.ledger_sqn,
                             State#state.levelzero_cache,
                             State#state.levelzero_index),
-                    leveled_log:log_timer(
+                    leveled_log:log_randomtimer(
                         "P0031", 
                         [NewL0Size, true, true, MinSQN, MaxSQN],
-                        SW),
+                        SW,
+                        0.1),
                     {reply,
                         ok,
                         State#state{

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -64,7 +64,7 @@
             compact_and_wait/1]).
 
 -define(RETURN_TERMS, {true, undefined}).
--define(SLOWOFFER_DELAY, 5).
+-define(SLOWOFFER_DELAY, 10).
 -define(V1_VERS, 1).
 -define(MAGIC, 53). % riak_kv -> riak_object
 -define(MD_VTAG,     <<"X-Riak-VTag">>).


### PR DESCRIPTION
Extend Patch C to ensure that both an excess bookie ledger cache, and an over-size penciller in-memory cache will be persisted to disk even where no traffic is present