### PR TITLE
Mas i389 rebuildledger

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -1,6 +1,7 @@
 % File paths
 -define(JOURNAL_FP, "journal").
 -define(LEDGER_FP, "ledger").
+-define(LOADING_BATCH, 1000).
 
 %% Tag to be used on standard Riak KV objects
 -define(RIAK_TAG, o_rkv).

--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -375,8 +375,9 @@ cdb_deletepending(Pid) ->
 cdb_deletepending(Pid, ManSQN, Inker) ->
     gen_fsm:send_event(Pid, {delete_pending, ManSQN, Inker}).
 
--spec cdb_scan(pid(), filter_fun(), any(), integer()|undefined) ->
-                                                    {integer()|eof, any()}.
+-spec cdb_scan(
+        pid(), filter_fun(), any(), integer()|undefined)
+            -> {integer()|eof, any()}.
 %% @doc
 %% cdb_scan returns {LastPosition, Acc}.  Use LastPosition as StartPosiiton to
 %% continue from that point (calling function has to protect against) double

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -133,7 +133,6 @@
 -define(WASTE_FP, "waste").
 -define(JOURNAL_FILEX, "cdb").
 -define(PENDING_FILEX, "pnd").
--define(LOADING_BATCH, 1000).
 -define(TEST_KC, {[], infinity}).
 
 -record(state, {manifest = [] :: list(),
@@ -337,11 +336,14 @@ ink_fold(Pid, MinSQN, FoldFuns, Acc) ->
                     {fold, MinSQN, FoldFuns, Acc, by_runner},
                     infinity).
 
--spec ink_loadpcl(pid(),
-                    integer(),
-                    leveled_bookie:initial_loadfun(),
-                    fun((string(), non_neg_integer()) -> any()),
-                    fun((any(), any()) -> ok)) -> ok.
+-spec ink_loadpcl(
+    pid(),
+    integer(),
+    leveled_bookie:initial_loadfun(),
+    fun((string(), non_neg_integer()) -> any()),
+    fun((any(), leveled_bookie:ledger_cache())
+        -> leveled_bookie:ledger_cache()))
+            -> leveled_bookie:ledger_cache().
 %%
 %% Function to prompt load of the Ledger at startup.  The Penciller should
 %% have determined the lowest SQN not present in the Ledger, and the inker
@@ -355,7 +357,7 @@ ink_loadpcl(Pid, MinSQN, LoadFun, InitAccFun, BatchFun) ->
                     {fold, 
                         MinSQN, 
                         {LoadFun, InitAccFun, BatchFun}, 
-                        ok,
+                        leveled_bookie:empty_ledgercache(),
                         as_ink},
                     infinity).
 

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -54,8 +54,6 @@
             {info, <<"LedgerSQN=~w at startup">>},
         b0006 =>
             {info, <<"Reached end of load batch with SQN ~w">>},
-        b0007 =>
-            {info, <<"Skipping as exceeded MaxSQN ~w with SQN ~w">>},
         b0008 =>
             {info, <<"Bucket list finds no more results">>},
         b0009 =>

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -46,6 +46,7 @@
             put_indexed_objects/3,
             put_altered_indexed_objects/3,
             put_altered_indexed_objects/4,
+            put_altered_indexed_objects/5,
             check_indexed_objects/4,
             rotating_object_check/3,
             corrupt_journal/5,
@@ -786,8 +787,12 @@ put_altered_indexed_objects(Book, Bucket, KSpecL) ->
     put_altered_indexed_objects(Book, Bucket, KSpecL, true).
 
 put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i) ->
-    IndexGen = get_randomindexes_generator(1),
     V = get_compressiblevalue(),
+    put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V).
+
+put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V) ->
+    IndexGen = get_randomindexes_generator(1),
+    
     FindAdditionFun = fun(SpcItem) -> element(1, SpcItem) == add end,
     MapFun = 
         fun({K, Spc}) ->

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -730,60 +730,55 @@ foldkeysfun_returnbucket(Bucket, Key, Acc) ->
 check_indexed_objects(Book, B, KSpecL, V) ->
     % Check all objects match, return what should be the results of an all
     % index query
-    IdxR = lists:map(fun({K, Spc}) ->
-                            {ok, O} = book_riakget(Book, B, K),
-                            V = testutil:get_value(O),
-                            {add,
-                                "idx1_bin",
-                                IdxVal} = lists:keyfind(add, 1, Spc),
-                            {IdxVal, K} end,
-                        KSpecL),
+    IdxR =
+        lists:map(
+            fun({K, Spc}) ->
+                {ok, O} = book_riakget(Book, B, K),
+                V = testutil:get_value(O),
+                {add, "idx1_bin", IdxVal} = lists:keyfind(add, 1, Spc),
+                {IdxVal, K}
+            end,
+            KSpecL),
     % Check the all index query matches expectations
-    R = leveled_bookie:book_returnfolder(Book,
-                                            {index_query,
-                                                B,
-                                                {fun foldkeysfun/3, []},
-                                                {"idx1_bin",
-                                                    "0",
-                                                    "|"},
-                                                ?RETURN_TERMS}),
+    R = 
+        leveled_bookie:book_returnfolder(
+            Book,
+            {index_query,
+                B,
+                {fun foldkeysfun/3, []},
+                {"idx1_bin", "0", "|"},
+                ?RETURN_TERMS}),
     SW = os:timestamp(),
     {async, Fldr} = R,
     QR0 = Fldr(),
-    io:format("Query match found of length ~w in ~w microseconds " ++
-                    "expected ~w ~n",
-                [length(QR0),
-                    timer:now_diff(os:timestamp(), SW),
-                    length(IdxR)]),
+    io:format(
+        "Query match found of length ~w in ~w microseconds "
+        "expected ~w ~n",
+        [length(QR0), timer:now_diff(os:timestamp(), SW), length(IdxR)]),
     QR = lists:sort(QR0),
     ER = lists:sort(IdxR),
     
-    ok = if
-                ER == QR ->
-                    ok
-            end,
+    ok = if ER == QR -> ok end,
     ok.
 
 
 put_indexed_objects(Book, Bucket, Count) ->
-    V = testutil:get_compressiblevalue(),
-    IndexGen = testutil:get_randomindexes_generator(1),
+    V = get_compressiblevalue(),
+    IndexGen = get_randomindexes_generator(1),
     SW = os:timestamp(),
-    ObjL1 = testutil:generate_objects(Count,
-                                        uuid,
-                                        [],
-                                        V,
-                                        IndexGen,
-                                        Bucket),
-    KSpecL = lists:map(fun({_RN, Obj, Spc}) ->
-                            book_riakput(Book, Obj, Spc),
-                            {testutil:get_key(Obj), Spc}
-                            end,
-                        ObjL1),
-    io:format("Put of ~w objects with ~w index entries "
-                    ++
-                    "each completed in ~w microseconds~n",
-                [Count, 1, timer:now_diff(os:timestamp(), SW)]),
+    ObjL1 = 
+        generate_objects(Count, uuid, [], V, IndexGen, Bucket),
+    KSpecL =
+        lists:map(
+            fun({_RN, Obj, Spc}) ->
+                book_riakput(Book, Obj, Spc),
+                {testutil:get_key(Obj), Spc}
+            end,
+            ObjL1),
+    io:format(
+        "Put of ~w objects with ~w index entries "
+        "each completed in ~w microseconds~n",
+        [Count, 1, timer:now_diff(os:timestamp(), SW)]),
     {KSpecL, V}.
 
 


### PR DESCRIPTION
Protect the penciller from receiving empty ledger cache updates, where it might otherwise write an empty L0 file (which will lead to the store crashing).

See https://github.com/martinsumner/leveled/issues/389