### PR TITLE
Ensure backlog is tackled

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -109,7 +109,7 @@
         p0019 =>
             {info, <<"Rolling level zero to filename ~s at ledger sqn ~w">>},
         p0024 =>
-            {info, <<"Outstanding compaction work items of ~w with backlog status of ~w">>},
+            {info, <<"Outstanding compaction work items of ~w with backlog status of ~w L0 full ~w">>},
         p0029 =>
             {info, <<"L0 completion confirmed and will transition to not pending">>},
         p0030 =>


### PR DESCRIPTION
Even when level 0 work is continuous.

The backlog tolerance has been reduced by 1 as part of the change.  A backlog is not tolerated now if it is >= ?WORKQUEUE_BACKLOG_TOLERANCE, rather than requiring it to be > ?WORKQUEUE_BACKLOG_TOLERANCE