### PR TITLE
Close in stages - waiting for releases

### DIFF
--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -132,6 +132,8 @@
             {info, <<"Archiving filename ~s as unused at startup">>},
         p0041 =>
             {info, <<"Penciller manifest switched from SQN ~w to ~w">>},
+        p0042 =>
+            {info, <<"Deferring shutdown due to snapshot_count=~w">>},
         pc001 =>
             {info, <<"Penciller's clerk ~w started with owner ~w">>},
         pc005 =>
@@ -244,6 +246,8 @@
             {info, <<"Prompted roll at NewSQN=~w">>},
         i0025 =>
             {warn, <<"Journal SQN of ~w is below Ledger SQN of ~w anti-entropy will be required">>},
+        i0026 =>
+            {info, <<"Deferring shutdown due to snapshot_count=~w">>},
         ic001 =>
             {info, <<"Closed for reason ~w so maybe leaving garbage">>},
         ic002 =>

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -222,6 +222,11 @@
 -define(TIMING_SAMPLECOUNTDOWN, 10000).
 -define(TIMING_SAMPLESIZE, 100).
 -define(OPEN_LASTMOD_RANGE, {0, infinity}).
+-define(SHUTDOWN_PAUSE, 10000).
+    % How long to wait for snapshots to be released on shutdown
+    % before forcing closure of snapshots
+    % 10s may not be long enough for all snapshots, but avoids crashes of
+    % short-lived queries racing with the shutdown
 
 -record(state, {manifest ::
                     leveled_pmanifest:manifest() | undefined | redacted,
@@ -566,7 +571,7 @@ pcl_persistedsqn(Pid) ->
 %% @doc
 %% Close the penciller neatly, trying to persist to disk anything in the memory
 pcl_close(Pid) ->
-    gen_server:call(Pid, close, 60000).
+    gen_server:call(Pid, close, infinity).
 
 -spec pcl_doom(pid()) -> {ok, list()}.
 %% @doc
@@ -574,7 +579,7 @@ pcl_close(Pid) ->
 %% Return a list of filepaths from where files exist for this penciller (should
 %% the calling process which to erase the store).
 pcl_doom(Pid) ->
-    gen_server:call(Pid, doom, 60000).
+    gen_server:call(Pid, doom, infinity).
 
 -spec pcl_checkbloomtest(pid(), tuple()) -> boolean().
 %% @doc
@@ -906,7 +911,7 @@ handle_call({register_snapshot, Snapshot, Query, BookiesMem, LongRunning},
 handle_call(close, _From, State=#state{is_snapshot=Snap}) when Snap == true ->
     ok = pcl_releasesnapshot(State#state.source_penciller, self()),
     {stop, normal, ok, State};
-handle_call(close, _From, State) ->
+handle_call(close, From, State) ->
     % Level 0 files lie outside of the manifest, and so if there is no L0
     % file present it is safe to write the current contents of memory.  If
     % there is a L0 file present - then the memory can be dropped (it is
@@ -935,17 +940,13 @@ handle_call(close, _From, State) ->
         false ->
             leveled_log:log(p0010, [State#state.levelzero_size])
     end,
-    shutdown_manifest(State#state.manifest, State#state.levelzero_constructor),
-    {stop, normal, ok, State};
-handle_call(doom, _From, State) ->
+    gen_server:cast(self(), {maybe_defer_shutdown, close, From}),
+    {noreply, State};
+handle_call(doom, From, State) ->
     leveled_log:log(p0030, []),
     ok = leveled_pclerk:clerk_close(State#state.clerk),
-    
-    shutdown_manifest(State#state.manifest,  State#state.levelzero_constructor),
-    
-    ManifestFP = State#state.root_path ++ "/" ++ ?MANIFEST_FP ++ "/",
-    FilesFP = State#state.root_path ++ "/" ++ ?FILES_FP ++ "/",
-    {stop, normal, {ok, [ManifestFP, FilesFP]}, State};
+    gen_server:cast(self(), {maybe_defer_shutdown, doom, From}),
+    {noreply, State};
 handle_call({checkbloom_fortest, Key, Hash}, _From, State) ->
     Manifest = State#state.manifest,
     FoldFun = 
@@ -995,8 +996,8 @@ handle_cast({manifest_change, Manifest}, State) ->
                 work_ongoing=false}}
     end;
 handle_cast({release_snapshot, Snapshot}, State) ->
-    Manifest0 = leveled_pmanifest:release_snapshot(State#state.manifest,
-                                                   Snapshot),
+    Manifest0 =
+        leveled_pmanifest:release_snapshot(State#state.manifest, Snapshot),
     leveled_log:log(p0003, [Snapshot]),
     {noreply, State#state{manifest=Manifest0}};
 handle_cast({confirm_delete, PDFN, FilePid}, State=#state{is_snapshot=Snap})
@@ -1156,7 +1157,36 @@ handle_cast({remove_logs, ForcedLogs}, State) ->
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
-    {noreply, State#state{sst_options = SSTopts0}}.
+    {noreply, State#state{sst_options = SSTopts0}};
+handle_cast({maybe_defer_shutdown, ShutdownType, From}, State) ->
+    case length(leveled_pmanifest:snapshot_pids(State#state.manifest)) of
+        0 ->
+            ok;
+        N ->
+            % Whilst this process sleeps, then any remaining snapshots may
+            % release and have their release messages queued before the
+            % complete_shutdown cast is sent
+            leveled_log:log(p0042, [N]),
+            timer:sleep(?SHUTDOWN_PAUSE)
+    end,
+    gen_server:cast(self(), {complete_shutdown, ShutdownType, From}),
+    {noreply, State};
+handle_cast({complete_shutdown, ShutdownType, From}, State) ->
+    lists:foreach(
+        fun(Snap) -> ok = pcl_close(Snap) end,
+        lists:filter(
+            fun is_process_alive/1,
+            leveled_pmanifest:snapshot_pids(State#state.manifest))),
+    shutdown_manifest(State#state.manifest, State#state.levelzero_constructor),
+    case ShutdownType of
+        doom ->
+            ManifestFP = State#state.root_path ++ "/" ++ ?MANIFEST_FP ++ "/",
+            FilesFP = State#state.root_path ++ "/" ++ ?FILES_FP ++ "/",
+            gen_server:reply(From, {ok, [ManifestFP, FilesFP]});
+        close ->
+            gen_server:reply(From, ok)
+    end,
+    {stop, normal, State}.
 
 
 %% handle the bookie stopping and stop this snapshot
@@ -1195,8 +1225,8 @@ sst_rootpath(RootPath) ->
     FP.
 
 sst_filename(ManSQN, Level, Count) ->
-    lists:flatten(io_lib:format("./~w_~w_~w" ++ ?SST_FILEX, 
-                                    [ManSQN, Level, Count])).
+    lists:flatten(
+        io_lib:format("./~w_~w_~w" ++ ?SST_FILEX, [ManSQN, Level, Count])).
     
 
 %%%============================================================================

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -103,9 +103,8 @@
                     blooms :: dict:dict()
                     }).      
 
--type fake_pid() :: pid_a1|pid_a2|pid_a3|pid_a4.
 -type snapshot() ::
-    {pid()|fake_pid(), non_neg_integer(), pos_integer(), pos_integer()}.
+    {pid(), non_neg_integer(), pos_integer(), pos_integer()}.
 -type manifest() :: #manifest{}.
 -type manifest_entry() :: #manifest_entry{}.
 -type manifest_owner() :: pid()|list().
@@ -537,7 +536,7 @@ mergefile_selector(Manifest, LevelIdx, {grooming, ScoringFun}) ->
 %% @doc
 %% When the clerk returns an updated manifest to the penciller, the penciller
 %% should restore its view of the snapshots to that manifest.  Snapshots can
-%% be received in parallel to the manifest ebing updated, so the updated
+%% be received in parallel to the manifest being updated, so the updated
 %% manifest must not trample over any accrued state in the manifest.
 merge_snapshot(PencillerManifest, ClerkManifest) ->
     ClerkManifest#manifest{
@@ -1389,6 +1388,10 @@ ready_to_delete_combined(Manifest, Filename) ->
     end.
 
 snapshot_release_test() ->
+    PidA1 = spawn(fun() -> ok end),
+    PidA2 = spawn(fun() -> ok end),
+    PidA3 = spawn(fun() -> ok end),
+    PidA4 = spawn(fun() -> ok end),
     Man6 = element(7, initial_setup()),
     E1 = #manifest_entry{start_key={i, "Bucket1", {"Idx1", "Fld1"}, "K8"},
                             end_key={i, "Bucket1", {"Idx1", "Fld9"}, "K93"},
@@ -1406,35 +1409,35 @@ snapshot_release_test() ->
                             owner="pid_z3",
                             bloom=none},
     
-    Man7 = add_snapshot(Man6, pid_a1, 3600),
+    Man7 = add_snapshot(Man6, PidA1, 3600),
     Man8 = remove_manifest_entry(Man7, 2, 1, E1),
-    Man9 = add_snapshot(Man8, pid_a2, 3600),
+    Man9 = add_snapshot(Man8, PidA2, 3600),
     Man10 = remove_manifest_entry(Man9, 3, 1, E2),
-    Man11 = add_snapshot(Man10, pid_a3, 3600),
+    Man11 = add_snapshot(Man10, PidA3, 3600),
     Man12 = remove_manifest_entry(Man11, 4, 1, E3),
-    Man13 = add_snapshot(Man12, pid_a4, 3600),
+    Man13 = add_snapshot(Man12, PidA4, 3600),
     
     ?assertMatch(false, element(1, ready_to_delete_combined(Man8, "Z1"))),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man10, "Z2"))),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man12, "Z3"))),
     
-    Man14 = release_snapshot(Man13, pid_a1),
+    Man14 = release_snapshot(Man13, PidA1),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man14, "Z2"))),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man14, "Z3"))),
     {Bool14, Man15} = ready_to_delete_combined(Man14, "Z1"),
     ?assertMatch(true, Bool14),
     
     %This doesn't change anything - released snaphsot not the min
-    Man16 = release_snapshot(Man15, pid_a4),
+    Man16 = release_snapshot(Man15, PidA4),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man16, "Z2"))),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man16, "Z3"))),
     
-    Man17 = release_snapshot(Man16, pid_a2),
+    Man17 = release_snapshot(Man16, PidA2),
     ?assertMatch(false, element(1, ready_to_delete_combined(Man17, "Z3"))),
     {Bool17, Man18} = ready_to_delete_combined(Man17, "Z2"),
     ?assertMatch(true, Bool17),
     
-    Man19 = release_snapshot(Man18, pid_a3),
+    Man19 = release_snapshot(Man18, PidA3),
     
     io:format("MinSnapSQN ~w~n", [Man19#manifest.min_snapshot_sqn]),
     
@@ -1443,12 +1446,13 @@ snapshot_release_test() ->
     
 
 snapshot_timeout_test() ->
+    PidA1 = spawn(fun() -> ok end),
     Man6 = element(7, initial_setup()),
-    Man7 = add_snapshot(Man6, pid_a1, 3600),
+    Man7 = add_snapshot(Man6, PidA1, 3600),
     ?assertMatch(1, length(Man7#manifest.snapshots)),
-    Man8 = release_snapshot(Man7, pid_a1),
+    Man8 = release_snapshot(Man7, PidA1),
     ?assertMatch(0, length(Man8#manifest.snapshots)),
-    Man9 = add_snapshot(Man8, pid_a1, 1),
+    Man9 = add_snapshot(Man8, PidA1, 1),
     timer:sleep(2001),
     ?assertMatch(1, length(Man9#manifest.snapshots)),
     Man10 = release_snapshot(Man9, ?PHANTOM_PID),

--- a/test/leveled_eqc.erl
+++ b/test/leveled_eqc.erl
@@ -41,7 +41,8 @@
                 start_opts = []
                }).
 
--define(NUMTESTS, 1000).
+-define(NUMTESTS, 10000).
+-define(TIME_BUDGET, 300).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
@@ -49,7 +50,12 @@
 -type state() :: #state{}.
 
 eqc_test_() ->
-    {timeout, 60, ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(50, ?QC_OUT(prop_db()))))}.
+    {timeout,
+        ?TIME_BUDGET + 10,
+        ?_assertEqual(
+            true,
+            eqc:quickcheck(
+                eqc:testing_time(?TIME_BUDGET, ?QC_OUT(prop_db()))))}.
 
 run() ->
     run(?NUMTESTS).


### PR DESCRIPTION
[Related issue](https://github.com/martinsumner/leveled/issues/410)

Have a consistent approach to closing the inker and the penciller - so that the close can be interrupted by releasing of snapshots.  Then any unreleased snapshots are closed before shutdown - with a 10s pause to give queries a short opportunity to finish.

This should address some issues, primarily seen (but very rarely) in test whereby post-rebuild destruction of parallel AAE keystores cause the crashing of aae_folds.

The primary benefit is to stop an attempt to release a snapshot that has in fact already finished, from causing a crash of the database on normal stop - which in Riak may prevent other closing actions from completing normally.  This was primarily an issue when shutdown is delayed by an ongoing journal compaction job.