### PR TITLE
Allow snapshots to be reused in queries

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1537,28 +1537,40 @@ handle_call(Msg, _From, State) ->
 handle_cast({log_level, LogLevel}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_loglevel(PCL, LogLevel),
     ok = leveled_inker:ink_loglevel(INK, LogLevel),
-    ok = leveled_monitor:log_level(Monitor, LogLevel),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_level(Monitor, LogLevel)
+    end,
     ok = leveled_log:set_loglevel(LogLevel),
     {noreply, State};
 handle_cast({add_logs, ForcedLogs}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_addlogs(PCL, ForcedLogs),
     ok = leveled_inker:ink_addlogs(INK, ForcedLogs),
-    ok = leveled_monitor:log_add(Monitor, ForcedLogs),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_add(Monitor, ForcedLogs)
+    end,
     ok = leveled_log:add_forcedlogs(ForcedLogs),
     {noreply, State};
 handle_cast({remove_logs, ForcedLogs}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_removelogs(PCL, ForcedLogs),
     ok = leveled_inker:ink_removelogs(INK, ForcedLogs),
-    ok = leveled_monitor:log_remove(Monitor, ForcedLogs),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_remove(Monitor, ForcedLogs)
+    end,
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     {noreply, State}.
 

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1259,10 +1259,12 @@ init([Opts]) ->
         {Bookie, undefined} ->
             {ok, Penciller, Inker} = 
                 book_snapshot(Bookie, store, undefined, true),
+            NewETS = ets:new(mem, [ordered_set]),
             leveled_log:log(b0002, [Inker, Penciller]),
             {ok,
                 #state{penciller = Penciller,
                         inker = Inker,
+                        ledger_cache = #ledger_cache{mem = NewETS},
                         is_snapshot = true}}
     end.
 
@@ -1849,10 +1851,11 @@ set_options(Opts, Monitor) ->
         }.
 
 
--spec return_snapfun(book_state(), store|ledger, 
-                        tuple()|no_lookup|undefined, 
-                        boolean(), boolean()) 
-                            -> fun(() -> {ok, pid(), pid()|null}).
+-spec return_snapfun(
+    book_state(), store|ledger,
+    tuple()|no_lookup|undefined,
+    boolean(), boolean()) 
+        -> fun(() -> {ok, pid(), pid()|null, fun(() -> ok)}).
 %% @doc
 %% Generates a function from which a snapshot can be created.  The primary
 %% factor here is the SnapPreFold boolean.  If this is true then the snapshot
@@ -1860,11 +1863,31 @@ set_options(Opts, Monitor) ->
 %% false then the snapshot will be taken when the Fold function is called.
 %%
 %% SnapPrefold is to be used when the intention is to queue the fold, and so
-%% claling of the fold may be delayed, but it is still desired that the fold
+%% calling of the fold may be delayed, but it is still desired that the fold
 %% represent the point in time that the query was requested.
+%% 
+%% Also returns a function which will close any snapshots to be used in the
+%% runners post-query cleanup action
+%% 
+%% When the bookie is a snapshot, a fresh snapshot should not be taken, the
+%% previous snapshot should be used instead.  Also the snapshot should not be
+%% closed as part of the post-query activity as the snapshot may be reused, and
+%% should be manually closed.
 return_snapfun(State, SnapType, Query, LongRunning, SnapPreFold) ->
-    case SnapPreFold of
-        true ->
+    CloseFun =
+        fun(LS0, JS0) ->
+            fun() ->
+                ok = leveled_penciller:pcl_close(LS0),
+                case JS0 of
+                    JS0 when is_pid(JS0) ->
+                        leveled_inker:ink_close(JS0);
+                    _ ->
+                        ok
+                end
+            end
+        end,
+    case {SnapPreFold, State#state.is_snapshot} of
+        {true, false} ->
             {ok, LS, JS} =
                 snapshot_store(
                     State#state.ledger_cache,
@@ -1874,15 +1897,23 @@ return_snapfun(State, SnapType, Query, LongRunning, SnapPreFold) ->
                     SnapType,
                     Query,
                     LongRunning),
-            fun() -> {ok, LS, JS} end;
-        false ->
+            fun() -> {ok, LS, JS, CloseFun(LS, JS)} end;
+        {false, false} ->
             Self = self(),
             % Timeout will be ignored, as will Requestor
             %
             % This uses the external snapshot - as the snapshot will need
             % to have consistent state between Bookie and Penciller when
             % it is made.
-            fun() -> book_snapshot(Self, SnapType, Query, LongRunning) end
+            fun() -> 
+                {ok, LS, JS} = 
+                    book_snapshot(Self, SnapType, Query, LongRunning),
+                {ok, LS, JS, CloseFun(LS, JS)}
+            end;
+        {_ , true} ->
+            LS = State#state.penciller,
+            JS = State#state.inker,
+            fun() -> {ok, LS, JS, fun() -> ok end} end
     end.
 
 -spec snaptype_by_presence(boolean()) -> store|ledger.
@@ -2213,14 +2244,7 @@ fetch_head(Key, Penciller, LedgerCache) ->
 %% The L0Index needs to be bypassed when running head_only
 fetch_head(Key, Penciller, LedgerCache, HeadOnly) ->
     SW = os:timestamp(),
-    CacheResult =
-        case LedgerCache#ledger_cache.mem of
-            undefined ->
-                [];
-            Tab ->
-                ets:lookup(Tab, Key)
-        end,
-    case CacheResult of
+    case ets:lookup(LedgerCache#ledger_cache.mem, Key) of
         [{Key, Head}] ->
             {Head, true};
         [] ->

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -74,7 +74,9 @@
         book_logsettings/1,
         book_loglevel/2,
         book_addlogs/2,
-        book_removelogs/2]).
+        book_removelogs/2,
+        book_headstatus/1
+    ]).
 
 %% folding API
 -export([
@@ -1153,11 +1155,18 @@ book_addlogs(Pid, ForcedLogs) ->
 book_removelogs(Pid, ForcedLogs) ->
     gen_server:cast(Pid, {remove_logs, ForcedLogs}).
 
+-spec book_returnactors(pid()) -> {ok, pid(), pid()}.
 %% @doc
 %% Return the Inker and Penciller - {ok, Inker, Penciller}.  Used only in tests
 book_returnactors(Pid) ->
-    gen_server:call(Pid, return_actors).
+    gen_server:call(Pid, return_actors, infinity).
 
+-spec book_headstatus(pid()) -> {boolean(), boolean()}.
+%% @doc
+%% Return booleans to state the bookie is in head_only mode, and supporting
+%% lookups
+book_headstatus(Pid) ->
+    gen_server:call(Pid, head_status, infinity).
 
 %%%============================================================================
 %%% gen_server callbacks
@@ -1260,11 +1269,14 @@ init([Opts]) ->
             {ok, Penciller, Inker} = 
                 book_snapshot(Bookie, store, undefined, true),
             NewETS = ets:new(mem, [ordered_set]),
+            {HeadOnly, Lookup} = leveled_bookie:book_headstatus(Bookie),
             leveled_log:log(b0002, [Inker, Penciller]),
             {ok,
                 #state{penciller = Penciller,
                         inker = Inker,
                         ledger_cache = #ledger_cache{mem = NewETS},
+                        head_only = HeadOnly,
+                        head_lookup = Lookup,
                         is_snapshot = true}}
     end.
 
@@ -1516,6 +1528,8 @@ handle_call(destroy, _From, State=#state{is_snapshot=Snp}) when Snp == false ->
     {stop, normal, ok, State};
 handle_call(return_actors, _From, State) ->
     {reply, {ok, State#state.inker, State#state.penciller}, State};
+handle_call(head_status, _From, State) ->
+    {reply, {State#state.head_only, State#state.head_lookup}, State};
 handle_call(Msg, _From, State) ->
     {reply, {unsupported_message, element(1, Msg)}, State}.
 

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -403,18 +403,20 @@ inker_reload_strategy(AltList) ->
                     lists:ukeysort(1, DefaultList)).
 
 
--spec get_tagstrategy(ledger_key()|tag()|dummy, compaction_strategy()) 
-                                                    -> compaction_method().
+-spec get_tagstrategy(
+    ledger_key()|tag()|dummy, compaction_strategy()) -> compaction_method().
 %% @doc
 %% Work out the compaction strategy for the key
 get_tagstrategy({Tag, _, _, _}, Strategy) ->
     get_tagstrategy(Tag, Strategy);
-get_tagstrategy(dummy, _Strategy) ->
-    retain;
 get_tagstrategy(Tag, Strategy) ->
     case lists:keyfind(Tag, 1, Strategy) of
         {Tag, TagStrat} ->
             TagStrat;
+        false when Tag == dummy ->
+            %% dummy is not a strategy, but this is expected to see this when
+            %% running in head_only mode - so don't warn
+            retain;
         false ->
             leveled_log:log(ic012, [Tag, Strategy]),
             retain

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -409,6 +409,8 @@ inker_reload_strategy(AltList) ->
 %% Work out the compaction strategy for the key
 get_tagstrategy({Tag, _, _, _}, Strategy) ->
     get_tagstrategy(Tag, Strategy);
+get_tagstrategy(dummy, _Strategy) ->
+    retain;
 get_tagstrategy(Tag, Strategy) ->
     case lists:keyfind(Tag, 1, Strategy) of
         {Tag, TagStrat} ->

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -95,7 +95,7 @@
         p0012 =>
             {info, <<"Store to be started based on manifest sequence number of ~w">>},
         p0013 =>
-            {warn, <<"Seqence number of 0 indicates no valid manifest">>},
+            {info, <<"Seqence number of 0 indicates no valid manifest">>},
         p0014 =>
             {info, <<"Maximum sequence number of ~w found in nonzero levels">>},
         p0015 =>

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -50,6 +50,8 @@
             {info, <<"Snapshot starting with Ink ~w Pcl ~w">>},
         b0003 =>
             {info, <<"Bookie closing for reason ~w">>},
+        b0004 =>
+            {warn, <<"Bookie snapshot exiting as master store ~w is down for reason ~p">>},
         b0005 =>
             {info, <<"LedgerSQN=~w at startup">>},
         b0006 =>

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -85,13 +85,13 @@
         p0005 =>
             {debug, <<"Delete confirmed as file ~s is removed from Manifest">>},
         p0007 =>
-            {debug, <<"Sent release message for cloned Penciller following close for reason ~w">>},
+            {debug, <<"Shutdown complete for cloned Penciller for reason ~w">>},
         p0008 =>
             {info, <<"Penciller closing for reason ~w">>},
         p0010 =>
             {info, <<"level zero discarded_count=~w on close of Penciller">>},
         p0011 =>
-            {info, <<"Shutdown complete for Penciller for reason ~w">>},
+            {debug, <<"Shutdown complete for Penciller for reason ~w">>},
         p0012 =>
             {info, <<"Store to be started based on manifest sequence number of ~w">>},
         p0013 =>
@@ -248,6 +248,10 @@
             {warn, <<"Journal SQN of ~w is below Ledger SQN of ~w anti-entropy will be required">>},
         i0026 =>
             {info, <<"Deferring shutdown due to snapshot_count=~w">>},
+        i0027 =>
+            {debug, <<"Shutdown complete for cloned Inker for reason ~w">>},
+        i0028 =>
+            {debug, <<"Shutdown complete for Inker for reason ~w">>},
         ic001 =>
             {info, <<"Closed for reason ~w so maybe leaving garbage">>},
         ic002 =>

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -647,19 +647,16 @@ init([LogOpts, PCLopts]) ->
             %% exits
 	        BookieMonitor = 
                 erlang:monitor(process, PCLopts#penciller_options.bookies_pid),
-
-            {ok, State} = pcl_registersnapshot(SrcPenciller, 
-                                                self(), 
-                                                Query, 
-                                                BookiesMem, 
-                                                LongRunning),
+            {ok, State} =
+                pcl_registersnapshot(
+                    SrcPenciller, self(), Query, BookiesMem, LongRunning),
             leveled_log:log(p0001, [self()]),
             {ok,
                 State#state{
                     is_snapshot = true,
                     clerk = undefined,
-			        bookie_monref = BookieMonitor,
-			        source_penciller = SrcPenciller}};
+                    bookie_monref = BookieMonitor,
+                    source_penciller = SrcPenciller}};
         {_RootPath, _Snapshot=false, _Q, _BM} ->
             start_from_file(PCLopts)
     end.    
@@ -1153,33 +1150,21 @@ handle_cast({fetch_levelzero, Slot, ReturnFun}, State) ->
     ReturnFun(lists:nth(Slot, State#state.levelzero_cache)),
     {noreply, State};
 handle_cast({log_level, LogLevel}, State) ->
-    case State#state.clerk of
-        undefined ->
-            ok;
-        PC when is_pid(PC) ->
-            leveled_pclerk:clerk_loglevel(PC, LogLevel)
-        end,
+    update_clerk(
+        State#state.clerk, fun leveled_pclerk:clerk_loglevel/2, LogLevel),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({add_logs, ForcedLogs}, State) ->
-    case State#state.clerk of
-        undefined ->
-            ok;
-        PC when is_pid(PC) ->
-            leveled_pclerk:clerk_addlogs(PC, ForcedLogs)
-    end,
+    update_clerk(
+        State#state.clerk, fun leveled_pclerk:clerk_addlogs/2, ForcedLogs),
     ok = leveled_log:add_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({remove_logs, ForcedLogs}, State) ->
-    case State#state.clerk of
-        undefined ->
-            ok;
-        PC when is_pid(PC) ->
-            leveled_pclerk:clerk_removelogs(PC, ForcedLogs)
-        end,
+    update_clerk(
+        State#state.clerk, fun leveled_pclerk:clerk_removelogs/2, ForcedLogs),
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
@@ -1256,6 +1241,12 @@ sst_filename(ManSQN, Level, Count) ->
 %%%============================================================================
 %%% Internal functions
 %%%============================================================================
+
+-spec update_clerk(pid()|undefined, fun((pid(), term()) -> ok), term()) -> ok.
+update_clerk(undefined, _F, _T) ->
+    ok;
+update_clerk(Clerk, F, T) when is_pid(Clerk) ->
+    F(Clerk, T).
 
 -spec start_from_file(penciller_options()) -> {ok, pcl_state()}.
 %% @doc

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -654,9 +654,12 @@ init([LogOpts, PCLopts]) ->
                                                 BookiesMem, 
                                                 LongRunning),
             leveled_log:log(p0001, [self()]),
-            {ok, State#state{is_snapshot = true,
-			     bookie_monref = BookieMonitor,
-			     source_penciller = SrcPenciller}};
+            {ok,
+                State#state{
+                    is_snapshot = true,
+                    clerk = undefined,
+			        bookie_monref = BookieMonitor,
+			        source_penciller = SrcPenciller}};
         {_RootPath, _Snapshot=false, _Q, _BM} ->
             start_from_file(PCLopts)
     end.    
@@ -1150,22 +1153,33 @@ handle_cast({fetch_levelzero, Slot, ReturnFun}, State) ->
     ReturnFun(lists:nth(Slot, State#state.levelzero_cache)),
     {noreply, State};
 handle_cast({log_level, LogLevel}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_loglevel(PC, LogLevel),
-    ok = leveled_log:set_loglevel(LogLevel),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_loglevel(PC, LogLevel)
+        end,
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({add_logs, ForcedLogs}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_addlogs(PC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_addlogs(PC, ForcedLogs)
+    end,
     ok = leveled_log:add_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({remove_logs, ForcedLogs}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_removelogs(PC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_removelogs(PC, ForcedLogs)
+        end,
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -112,13 +112,14 @@ bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc, MaxBuckets) ->
         fun() ->
             {ok, LedgerSnapshot, _JournalSnapshot, AfterFun} = SnapFun(),
             BucketAcc = 
-                get_nextbucket(null, null, 
-                                Tag, LedgerSnapshot, [], {0, MaxBuckets}),
+                get_nextbucket(
+                    null, null, Tag, LedgerSnapshot, [], {0, MaxBuckets}),
             FoldRunner =
                 fun() ->
-                    lists:foldr(fun({B, _K}, Acc) -> FoldBucketsFun(B, Acc) end,
-                                    InitAcc,
-                                    BucketAcc)
+                    lists:foldr(
+                        fun({B, _K}, Acc) -> FoldBucketsFun(B, Acc) end,
+                        InitAcc,
+                        BucketAcc)
                         % Buckets in reverse alphabetical order so foldr
                 end,
             % For this fold, the fold over the store is actually completed
@@ -154,17 +155,18 @@ index_query(SnapFun, {StartKey, EndKey, TermHandling}, FoldAccT) ->
             _ ->
                 fun add_keys/2
         end,
-    AccFun = accumulate_index(TermRegex, AddFun, FoldKeysFun),
 
     Runner = 
         fun() ->
             {ok, LedgerSnapshot, _JournalSnapshot, AfterFun} = SnapFun(),
-            Folder = leveled_penciller:pcl_fetchkeys(LedgerSnapshot,
-                                                        StartKey,
-                                                        EndKey,
-                                                        AccFun,
-                                                        InitAcc,
-                                                        by_runner),
+            Folder =
+                leveled_penciller:pcl_fetchkeys(
+                    LedgerSnapshot,
+                    StartKey,
+                    EndKey,
+                    accumulate_index(TermRegex, AddFun, FoldKeysFun),
+                    InitAcc,
+                    by_runner),
             wrap_runner(Folder, AfterFun)
         end,
     {async, Runner}.
@@ -269,12 +271,8 @@ tictactree(SnapFun, {Tag, Bucket, Query}, JournalCheck, TreeSize, Filter) ->
             AccFun = 
                 accumulate_tree(Filter, JournalCheck, JournalSnap, ExtractFun),
             Acc = 
-                leveled_penciller:pcl_fetchkeys(LedgerSnap, 
-                                                StartKey, EndKey,
-                                                AccFun, Tree),
-
-            % Close down snapshot when complete so as not to hold removed
-            % files open
+                leveled_penciller:pcl_fetchkeys(
+                    LedgerSnap,  StartKey, EndKey, AccFun, Tree),
             AfterFun(),
             Acc
         end,
@@ -326,17 +324,16 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
                 % initial accumulator
                 FoldObjectsFun;
             false ->
-                % no initial accumulatr passed, and so should be just a list
+                % no initial accumulator passed, and so should be just a list
                 {FoldObjectsFun, []}
         end,
     
     FilterFun =
         fun(JKey, JVal, _Pos, Acc, ExtractFun) ->
-            
             {SQN, InkTag, LedgerKey} = JKey,
             case {InkTag, leveled_codec:from_ledgerkey(Tag, LedgerKey)} of 
                 {?INKT_STND, {B, K}} ->
-                    % Ignore tombstones and non-matching Tags and Key changes 
+                    % Ignore tombstones and non-matching Tags and Key changes
                     % objects.  
                     {MinSQN, MaxSQN, BatchAcc} = Acc,
                     case SQN of
@@ -346,7 +343,8 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
                             {stop, Acc};
                         _ ->
                             {VBin, _VSize} = ExtractFun(JVal),
-                            {Obj, _IdxSpecs} = leveled_codec:split_inkvalue(VBin),
+                            {Obj, _IdxSpecs} =
+                                leveled_codec:split_inkvalue(VBin),
                             ToLoop = 
                                 case SQN  of 
                                     MaxSQN -> stop;
@@ -364,7 +362,6 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
 
     Folder =
         fun() ->
-
             {ok, LedgerSnapshot, JournalSnapshot, AfterFun} = SnapFun(),
             {ok, JournalSQN} = leveled_inker:ink_getjournalsqn(JournalSnapshot),
             IsValidFun = 
@@ -459,7 +456,6 @@ foldobjects_byindex(SnapFun, {Tag, Bucket, Field, FromTerm, ToTerm}, FoldFun) ->
                 FoldFun, 
                 false, 
                 false).
-
 
 
 

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -82,14 +82,11 @@ bucket_sizestats(SnapFun, Bucket, Tag) ->
     AccFun = accumulate_size(),
     Runner = 
         fun() ->
-            {ok, LedgerSnap, _JournalSnap} = SnapFun(),
-            Acc = leveled_penciller:pcl_fetchkeys(LedgerSnap,
-                                                        StartKey,
-                                                        EndKey,
-                                                        AccFun,
-                                                        {0, 0},
-                                                        as_pcl),
-            ok = leveled_penciller:pcl_close(LedgerSnap),
+            {ok, LedgerSnap, _JournalSnap, AfterFun} = SnapFun(),
+            Acc = 
+                leveled_penciller:pcl_fetchkeys(
+                    LedgerSnap, StartKey, EndKey, AccFun, {0, 0}, as_pcl),
+            AfterFun(),
             Acc
         end,
     {async, Runner}.
@@ -113,14 +110,10 @@ bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc) ->
 bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc, MaxBuckets) ->
     Runner = 
         fun() ->
-            {ok, LedgerSnapshot, _JournalSnapshot} = SnapFun(),
+            {ok, LedgerSnapshot, _JournalSnapshot, AfterFun} = SnapFun(),
             BucketAcc = 
                 get_nextbucket(null, null, 
                                 Tag, LedgerSnapshot, [], {0, MaxBuckets}),
-            AfterFun =
-                fun() ->
-                    ok = leveled_penciller:pcl_close(LedgerSnapshot)
-                end,
             FoldRunner =
                 fun() ->
                     lists:foldr(fun({B, _K}, Acc) -> FoldBucketsFun(B, Acc) end,
@@ -165,17 +158,13 @@ index_query(SnapFun, {StartKey, EndKey, TermHandling}, FoldAccT) ->
 
     Runner = 
         fun() ->
-            {ok, LedgerSnapshot, _JournalSnapshot} = SnapFun(),
+            {ok, LedgerSnapshot, _JournalSnapshot, AfterFun} = SnapFun(),
             Folder = leveled_penciller:pcl_fetchkeys(LedgerSnapshot,
                                                         StartKey,
                                                         EndKey,
                                                         AccFun,
                                                         InitAcc,
                                                         by_runner),
-            AfterFun = 
-                fun() ->
-                    ok = leveled_penciller:pcl_close(LedgerSnapshot)
-                end,
             wrap_runner(Folder, AfterFun)
         end,
     {async, Runner}.
@@ -198,17 +187,10 @@ bucketkey_query(SnapFun, Tag, Bucket,
     AccFun = accumulate_keys(FoldKeysFun, TermRegex),
     Runner =
         fun() ->
-            {ok, LedgerSnapshot, _JournalSnapshot} = SnapFun(),
-            Folder = leveled_penciller:pcl_fetchkeys(LedgerSnapshot,
-                                                        SK,
-                                                        EK,
-                                                        AccFun,
-                                                        InitAcc,
-                                                        by_runner),
-            AfterFun = 
-                fun() ->
-                    ok = leveled_penciller:pcl_close(LedgerSnapshot)
-                end,
+            {ok, LedgerSnapshot, _JournalSnapshot, AfterFun} = SnapFun(),
+            Folder =
+                leveled_penciller:pcl_fetchkeys(
+                    LedgerSnapshot, SK, EK, AccFun, InitAcc, by_runner),
             wrap_runner(Folder, AfterFun)
         end,
     {async, Runner}.
@@ -232,20 +214,12 @@ hashlist_query(SnapFun, Tag, JournalCheck) ->
     EndKey = leveled_codec:to_ledgerkey(null, null, Tag),
     Runner = 
         fun() ->
-            {ok, LedgerSnapshot, JournalSnapshot} = SnapFun(),
+            {ok, LedgerSnapshot, JournalSnapshot, AfterFun} = SnapFun(),
             AccFun = accumulate_hashes(JournalCheck, JournalSnapshot),    
-            Acc = leveled_penciller:pcl_fetchkeys(LedgerSnapshot,
-                                                        StartKey,
-                                                        EndKey,
-                                                        AccFun,
-                                                        []),
-            ok = leveled_penciller:pcl_close(LedgerSnapshot),
-            case JournalCheck of
-                false ->
-                    ok;
-                true ->
-                    leveled_inker:ink_close(JournalSnapshot)
-            end,
+            Acc =
+                leveled_penciller:pcl_fetchkeys(
+                    LedgerSnapshot, StartKey, EndKey, AccFun, []),
+            AfterFun(),
             Acc
         end,
     {async, Runner}.
@@ -263,7 +237,7 @@ tictactree(SnapFun, {Tag, Bucket, Query}, JournalCheck, TreeSize, Filter) ->
     Tree = leveled_tictac:new_tree(temp, TreeSize),
     Runner =
         fun() ->
-            {ok, LedgerSnap, JournalSnap} = SnapFun(),
+            {ok, LedgerSnap, JournalSnap, AfterFun} = SnapFun(),
             % The start key and end key will vary depending on whether the
             % fold is to fold over an index or a key range
             EnsureKeyBinaryFun = 
@@ -301,13 +275,7 @@ tictactree(SnapFun, {Tag, Bucket, Query}, JournalCheck, TreeSize, Filter) ->
 
             % Close down snapshot when complete so as not to hold removed
             % files open
-            ok = leveled_penciller:pcl_close(LedgerSnap),
-            case JournalCheck of
-                false ->
-                    ok;
-                true ->
-                    leveled_inker:ink_close(JournalSnap)
-            end,
+            AfterFun(),
             Acc
         end,
     {async, Runner}.
@@ -397,19 +365,17 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
     Folder =
         fun() ->
 
-            {ok, LedgerSnapshot, JournalSnapshot} = SnapFun(),
+            {ok, LedgerSnapshot, JournalSnapshot, AfterFun} = SnapFun(),
             {ok, JournalSQN} = leveled_inker:ink_getjournalsqn(JournalSnapshot),
             IsValidFun = 
                 fun(Bucket, Key, SQN) ->
                     LedgerKey = leveled_codec:to_ledgerkey(Bucket, Key, Tag),
                     CheckSQN =
-                        leveled_penciller:pcl_checksequencenumber(LedgerSnapshot, 
-                                                                    LedgerKey, 
-                                                                    SQN),
+                        leveled_penciller:pcl_checksequencenumber(
+                            LedgerSnapshot, LedgerKey, SQN),
                     % Need to check that we have not folded past the point
                     % at which the snapshot was taken
                     (JournalSQN >= SQN) and (CheckSQN == current)
-                        
                 end,
 
             BatchFoldFun = 
@@ -428,17 +394,11 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
                 end,
             
             InkFolder = 
-                leveled_inker:ink_fold(JournalSnapshot, 
-                                            0,
-                                            {FilterFun,
-                                                InitAccFun,
-                                                BatchFoldFun},
-                                            InitAcc),
-            AfterFun = 
-                fun() ->
-                    ok = leveled_penciller:pcl_close(LedgerSnapshot),
-                    ok = leveled_inker:ink_close(JournalSnapshot)
-                end,
+                leveled_inker:ink_fold(
+                    JournalSnapshot, 
+                    0,
+                    {FilterFun, InitAccFun, BatchFoldFun},
+                    InitAcc),
             wrap_runner(InkFolder, AfterFun) 
         end,
     {async, Folder}.
@@ -452,12 +412,8 @@ foldobjects_allkeys(SnapFun, Tag, FoldObjectsFun, sqn_order) ->
 %% @doc
 %% Fold over all objects within a given key range in a bucket
 foldobjects_bybucket(SnapFun, Tag, KeyRanges, FoldFun) ->
-    foldobjects(SnapFun, 
-                Tag, 
-                KeyRanges, 
-                FoldFun, 
-                false, 
-                false).
+    foldobjects(
+        SnapFun, Tag, KeyRanges, FoldFun, false, false).
 
 -spec foldheads_bybucket(snap_fun(), 
                             leveled_codec:tag(), 
@@ -585,12 +541,10 @@ foldobjects(SnapFun, Tag, KeyRanges, FoldObjFun, DeferredFetch,
     
     Folder =
         fun() ->
-            {ok, LedgerSnapshot, JournalSnapshot} = SnapFun(),
+            {ok, LedgerSnapshot, JournalSnapshot, AfterFun} = SnapFun(),
             AccFun =
-                accumulate_objects(FoldFun,
-                                    JournalSnapshot,
-                                    Tag,
-                                    DeferredFetch),
+                accumulate_objects(
+                    FoldFun, JournalSnapshot, Tag, DeferredFetch),
             FoldFunGen = 
                 fun({StartKey, EndKey}, FoldAcc) ->
                     leveled_penciller:pcl_fetchkeysbysegment(LedgerSnapshot,
@@ -601,16 +555,6 @@ foldobjects(SnapFun, Tag, KeyRanges, FoldObjFun, DeferredFetch,
                                                                 SegmentList,
                                                                 LastModRange,
                                                                 LimitByCount)
-                end,
-            AfterFun = 
-                fun() ->
-                    ok = leveled_penciller:pcl_close(LedgerSnapshot),
-                    case DeferredFetch of 
-                        {true, false} ->
-                            ok;
-                        _ ->
-                            ok = leveled_inker:ink_close(JournalSnapshot)
-                    end
                 end,
             ListFoldFun = 
                 fun(KeyRange, Acc) ->

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -395,6 +395,8 @@ fetchput_snapshot(_Config) ->
     testutil:check_forlist(Bookie1, ChkList1),
     testutil:check_forlist(SnapBookie1, ChkList1),
 
+    compare_foldwithsnap(Bookie1, SnapBookie1, ChkList1),
+
     % Close the snapshot, check the original store still has the objects
 
     ok = leveled_bookie:book_close(SnapBookie1),
@@ -471,6 +473,8 @@ fetchput_snapshot(_Config) ->
     testutil:check_forlist(SnapBookie3, ChkList2),
     testutil:check_forlist(SnapBookie2, ChkList1),
     io:format("Started new snapshot and check for new objects~n"),
+
+    compare_foldwithsnap(Bookie2, SnapBookie3, ChkList3),
     
     % Load yet more objects, these are replacement objects for the last load
 
@@ -552,6 +556,28 @@ fetchput_snapshot(_Config) ->
     false = is_process_alive(SnpPCL2),
     false = is_process_alive(SnpJrnl2),
     testutil:reset_filestructure().
+
+
+compare_foldwithsnap(Bookie, SnapBookie, ChkList) ->
+    HeadFoldFun = fun(B, K, _Hd, Acc) -> [{B, K}|Acc] end,
+    KeyFoldFun = fun(B, K, Acc) -> [{B, K}|Acc] end,
+    {async, HeadFoldDB} =
+        leveled_bookie:book_headfold(
+            Bookie, ?RIAK_TAG, {HeadFoldFun, []}, true, false, false
+        ),
+    {async, HeadFoldSnap} =
+        leveled_bookie:book_headfold(
+            SnapBookie, ?RIAK_TAG, {HeadFoldFun, []}, true, false, false
+        ),
+    true = HeadFoldDB() == HeadFoldSnap(),
+
+    testutil:check_forlist(SnapBookie, ChkList),
+
+    {async, KeyFoldSnap} =
+        leveled_bookie:book_keylist(
+            SnapBookie, ?RIAK_TAG, {KeyFoldFun, []}
+        ),
+    true = HeadFoldSnap() == KeyFoldSnap().
 
 
 load_and_count(_Config) ->

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -761,7 +761,22 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 [length(ObjectSpecL), Snapshot]),
             lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL),
             io:format("Closing snapshot ~w~n", [Snapshot]),
-            ok = leveled_bookie:book_close(Snapshot);
+            ok = leveled_bookie:book_close(Snapshot),
+            {ok, AltSnapshot} =
+                leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
+            ok =
+                leveled_bookie:book_addlogs(
+                    AltSnapshot, [b0001, b0002, b0003, b0004, i0027, p0007]
+                ),
+            true = is_process_alive(AltSnapshot),
+            io:format(
+                "Closing actual store ~w with snapshot ~w open~n",
+                [Bookie1, AltSnapshot]
+            ),
+            ok = leveled_bookie:book_close(Bookie1),
+            % Sleep a beat so as not to race with the 'DOWN' message
+            timer:sleep(10),
+            false = is_process_alive(AltSnapshot);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 
@@ -772,11 +787,11 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 leveled_bookie:book_headonly(Bookie1, 
                                                 SegmentID0, 
                                                 Bucket0, 
-                                                Key0)
+                                                Key0),
+            io:format("Closing actual store ~w~n", [Bookie1]),
+            ok = leveled_bookie:book_close(Bookie1)
     end,
-
-    io:format("Closing actual store ~w~n", [Bookie1]),
-    ok = leveled_bookie:book_close(Bookie1),
+    
     {ok, FinalJournals} = file:list_dir(JFP),
     io:format("Trim has reduced journal count from " ++ 
                     "~w to ~w and ~w after restart~n", 

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -747,7 +747,21 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
             lists:foreach(CheckHeadFun(Bookie1), ObjectSpecL),
             {ok, Snapshot} =
                 leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
-            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL);
+            ok = leveled_bookie:book_loglevel(Snapshot, warn),
+            ok =
+                leveled_bookie:book_addlogs(
+                    Snapshot, [b0001, b0002, b0003, i0027, p0007]
+                ),
+            ok =
+                leveled_bookie:book_removelogs(
+                    Snapshot, [b0019]
+                ),
+            io:format(
+                "Checking for ~w objects against Snapshot ~w~n",
+                [length(ObjectSpecL), Snapshot]),
+            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL),
+            io:format("Closing snapshot ~w~n", [Snapshot]),
+            ok = leveled_bookie:book_close(Snapshot);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 
@@ -761,7 +775,7 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                                                 Key0)
     end,
 
-
+    io:format("Closing actual store ~w~n", [Bookie1]),
     ok = leveled_bookie:book_close(Bookie1),
     {ok, FinalJournals} = file:list_dir(JFP),
     io:format("Trim has reduced journal count from " ++ 

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -738,11 +738,16 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                                                 Bucket0, 
                                                 Key0),
             CheckHeadFun = 
-                fun({add, SegID, B, K, H}) ->
-                    {ok, H} = 
-                        leveled_bookie:book_headonly(Bookie1, SegID, B, K)
+                fun(DB) ->
+                    fun({add, SegID, B, K, H}) ->
+                        {ok, H} = 
+                            leveled_bookie:book_headonly(DB, SegID, B, K)
+                    end
                 end,
-            lists:foreach(CheckHeadFun, ObjectSpecL);
+            lists:foreach(CheckHeadFun(Bookie1), ObjectSpecL),
+            {ok, Snapshot} =
+                leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
+            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 


### PR DESCRIPTION
Allow for a full bookie snapshot to be re-used for multiple queries, not just KV fetches.