### PR TITLE
Mas d31 i413

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -1531,28 +1531,40 @@ handle_call(Msg, _From, State) ->
 handle_cast({log_level, LogLevel}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_loglevel(PCL, LogLevel),
     ok = leveled_inker:ink_loglevel(INK, LogLevel),
-    ok = leveled_monitor:log_level(Monitor, LogLevel),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_level(Monitor, LogLevel)
+    end,
     ok = leveled_log:set_loglevel(LogLevel),
     {noreply, State};
 handle_cast({add_logs, ForcedLogs}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_addlogs(PCL, ForcedLogs),
     ok = leveled_inker:ink_addlogs(INK, ForcedLogs),
-    ok = leveled_monitor:log_add(Monitor, ForcedLogs),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_add(Monitor, ForcedLogs)
+    end,
     ok = leveled_log:add_forcedlogs(ForcedLogs),
     {noreply, State};
 handle_cast({remove_logs, ForcedLogs}, State) ->
     PCL = State#state.penciller,
     INK = State#state.inker,
-    Monitor = element(1, State#state.monitor),
     ok = leveled_penciller:pcl_removelogs(PCL, ForcedLogs),
     ok = leveled_inker:ink_removelogs(INK, ForcedLogs),
-    ok = leveled_monitor:log_remove(Monitor, ForcedLogs),
+    case element(1, State#state.monitor) of
+        no_monitor ->
+            ok;
+        Monitor ->
+            leveled_monitor:log_remove(Monitor, ForcedLogs)
+    end,
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     {noreply, State}.
 

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -182,6 +182,7 @@
                 head_only = false :: boolean(),
                 head_lookup = true :: boolean(),
                 ink_checking = ?MAX_KEYCHECK_FREQUENCY :: integer(),
+                bookie_monref :: reference() | undefined,
                 monitor = {no_monitor, 0} :: leveled_monitor:monitor()}).
 
 
@@ -1262,6 +1263,7 @@ init([Opts]) ->
         {Bookie, undefined} ->
             {ok, Penciller, Inker} = 
                 book_snapshot(Bookie, store, undefined, true),
+            BookieMonitor = erlang:monitor(process, Bookie),
             NewETS = ets:new(mem, [ordered_set]),
             {HeadOnly, Lookup} = leveled_bookie:book_headstatus(Bookie),
             leveled_log:log(b0002, [Inker, Penciller]),
@@ -1271,6 +1273,7 @@ init([Opts]) ->
                         ledger_cache = #ledger_cache{mem = NewETS},
                         head_only = HeadOnly,
                         head_lookup = Lookup,
+                        bookie_monref = BookieMonitor,
                         is_snapshot = true}}
     end.
 
@@ -1569,8 +1572,14 @@ handle_cast({remove_logs, ForcedLogs}, State) ->
     {noreply, State}.
 
 
+%% handle the bookie stopping and stop this snapshot
+handle_info({'DOWN', BookieMonRef, process, BookiePid, Info},
+	    State=#state{bookie_monref = BookieMonRef, is_snapshot = true}) ->
+    leveled_log:log(b0004, [BookiePid, Info]),
+    {stop, normal, State};
 handle_info(_Info, State) ->
     {noreply, State}.
+
 
 terminate(Reason, _State) ->
     leveled_log:log(b0003, [Reason]).

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -403,18 +403,20 @@ inker_reload_strategy(AltList) ->
                     lists:ukeysort(1, DefaultList)).
 
 
--spec get_tagstrategy(ledger_key()|tag()|dummy, compaction_strategy()) 
-                                                    -> compaction_method().
+-spec get_tagstrategy(
+    ledger_key()|tag()|dummy, compaction_strategy()) -> compaction_method().
 %% @doc
 %% Work out the compaction strategy for the key
 get_tagstrategy({Tag, _, _, _}, Strategy) ->
     get_tagstrategy(Tag, Strategy);
-get_tagstrategy(dummy, _Strategy) ->
-    retain;
 get_tagstrategy(Tag, Strategy) ->
     case lists:keyfind(Tag, 1, Strategy) of
         {Tag, TagStrat} ->
             TagStrat;
+        false when Tag == dummy ->
+            %% dummy is not a strategy, but this is expected to see this when
+            %% running in head_only mode - so don't warn
+            retain;
         false ->
             leveled_log:log(ic012, [Tag, Strategy]),
             retain

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -409,6 +409,8 @@ inker_reload_strategy(AltList) ->
 %% Work out the compaction strategy for the key
 get_tagstrategy({Tag, _, _, _}, Strategy) ->
     get_tagstrategy(Tag, Strategy);
+get_tagstrategy(dummy, _Strategy) ->
+    retain;
 get_tagstrategy(Tag, Strategy) ->
     case lists:keyfind(Tag, 1, Strategy) of
         {Tag, TagStrat} ->

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -754,25 +754,34 @@ handle_cast({release_snapshot, Snapshot}, State) ->
             {noreply, State#state{registered_snapshots=Rs}}
     end;
 handle_cast({log_level, LogLevel}, State) ->
-    INC = State#state.clerk,
-    ok = leveled_iclerk:clerk_loglevel(INC, LogLevel),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        INC ->
+            leveled_iclerk:clerk_loglevel(INC, LogLevel)
+        end,
     ok = leveled_log:set_loglevel(LogLevel),
-    CDBopts = State#state.cdb_options,
-    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    CDBopts0 = update_cdb_logoptions(State#state.cdb_options),
     {noreply, State#state{cdb_options = CDBopts0}};
 handle_cast({add_logs, ForcedLogs}, State) ->
-    INC = State#state.clerk,
-    ok = leveled_iclerk:clerk_addlogs(INC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        INC ->
+            leveled_iclerk:clerk_addlogs(INC, ForcedLogs)
+    end,
     ok = leveled_log:add_forcedlogs(ForcedLogs),
-    CDBopts = State#state.cdb_options,
-    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    CDBopts0 = update_cdb_logoptions(State#state.cdb_options),
     {noreply, State#state{cdb_options = CDBopts0}};
 handle_cast({remove_logs, ForcedLogs}, State) ->
-    INC = State#state.clerk,
-    ok = leveled_iclerk:clerk_removelogs(INC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        INC ->
+            leveled_iclerk:clerk_removelogs(INC, ForcedLogs)
+        end,
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
-    CDBopts = State#state.cdb_options,
-    CDBopts0 = CDBopts#cdb_options{log_options = leveled_log:get_opts()},
+    CDBopts0 = update_cdb_logoptions(State#state.cdb_options),
     {noreply, State#state{cdb_options = CDBopts0}};
 handle_cast({maybe_defer_shutdown, ShutdownType, From}, State) ->
     case length(State#state.registered_snapshots) of
@@ -816,8 +825,10 @@ handle_info({'DOWN', BookieMonRef, process, _BookiePid, _Info},
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, _State) ->
-    ok.
+terminate(Reason, _State=#state{is_snapshot=Snap}) when Snap == true ->
+    leveled_log:log(i0027, [Reason]);
+terminate(Reason, _State) ->
+    leveled_log:log(i0028, [Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -1290,6 +1301,14 @@ wrap_checkfilterfun(CheckFilterFun) ->
                 false
         end
     end.
+
+
+-spec update_cdb_logoptions(
+    #cdb_options{}|undefined) -> #cdb_options{}|undefined.
+update_cdb_logoptions(undefined) ->
+    undefined;
+update_cdb_logoptions(CDBopts) ->
+    CDBopts#cdb_options{log_options = leveled_log:get_opts()}.
 
 %%%============================================================================
 %%% Test

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -83,13 +83,13 @@
         p0005 =>
             {debug, <<"Delete confirmed as file ~s is removed from Manifest">>},
         p0007 =>
-            {debug, <<"Sent release message for cloned Penciller following close for reason ~w">>},
+            {debug, <<"Shutdown complete for cloned Penciller for reason ~w">>},
         p0008 =>
             {info, <<"Penciller closing for reason ~w">>},
         p0010 =>
             {info, <<"level zero discarded_count=~w on close of Penciller">>},
         p0011 =>
-            {info, <<"Shutdown complete for Penciller for reason ~w">>},
+            {debug, <<"Shutdown complete for Penciller for reason ~w">>},
         p0012 =>
             {info, <<"Store to be started based on manifest sequence number of ~w">>},
         p0013 =>
@@ -246,6 +246,10 @@
             {warn, <<"Journal SQN of ~w is below Ledger SQN of ~w anti-entropy will be required">>},
         i0026 =>
             {info, <<"Deferring shutdown due to snapshot_count=~w">>},
+        i0027 =>
+            {debug, <<"Shutdown complete for cloned Inker for reason ~w">>},
+        i0028 =>
+            {debug, <<"Shutdown complete for Inker for reason ~w">>},
         ic001 =>
             {info, <<"Closed for reason ~w so maybe leaving garbage">>},
         ic002 =>

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -48,6 +48,8 @@
             {info, <<"Snapshot starting with Ink ~w Pcl ~w">>},
         b0003 =>
             {info, <<"Bookie closing for reason ~w">>},
+        b0004 =>
+            {warn, <<"Bookie snapshot exiting as master store ~w is down for reason ~p">>},
         b0005 =>
             {info, <<"LedgerSQN=~w at startup">>},
         b0006 =>

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -93,7 +93,7 @@
         p0012 =>
             {info, <<"Store to be started based on manifest sequence number of ~w">>},
         p0013 =>
-            {warn, <<"Seqence number of 0 indicates no valid manifest">>},
+            {info, <<"Seqence number of 0 indicates no valid manifest">>},
         p0014 =>
             {info, <<"Maximum sequence number of ~w found in nonzero levels">>},
         p0015 =>

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -636,9 +636,12 @@ init([LogOpts, PCLopts]) ->
                                                 BookiesMem, 
                                                 LongRunning),
             leveled_log:log(p0001, [self()]),
-            {ok, State#state{is_snapshot = true,
-			     bookie_monref = BookieMonitor,
-			     source_penciller = SrcPenciller}};
+            {ok,
+                State#state{
+                    is_snapshot = true,
+                    clerk = undefined,
+			        bookie_monref = BookieMonitor,
+			        source_penciller = SrcPenciller}};
         {_RootPath, _Snapshot=false, _Q, _BM} ->
             start_from_file(PCLopts)
     end.    
@@ -1132,22 +1135,33 @@ handle_cast({fetch_levelzero, Slot, ReturnFun}, State) ->
     ReturnFun(lists:nth(Slot, State#state.levelzero_cache)),
     {noreply, State};
 handle_cast({log_level, LogLevel}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_loglevel(PC, LogLevel),
-    ok = leveled_log:set_loglevel(LogLevel),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_loglevel(PC, LogLevel)
+        end,
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({add_logs, ForcedLogs}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_addlogs(PC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_addlogs(PC, ForcedLogs)
+    end,
     ok = leveled_log:add_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},
     {noreply, State#state{sst_options = SSTopts0}};
 handle_cast({remove_logs, ForcedLogs}, State) ->
-    PC = State#state.clerk,
-    ok = leveled_pclerk:clerk_removelogs(PC, ForcedLogs),
+    case State#state.clerk of
+        undefined ->
+            ok;
+        PC when is_pid(PC) ->
+            leveled_pclerk:clerk_removelogs(PC, ForcedLogs)
+        end,
     ok = leveled_log:remove_forcedlogs(ForcedLogs),
     SSTopts = State#state.sst_options,
     SSTopts0 = SSTopts#sst_options{log_options = leveled_log:get_opts()},

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -398,6 +398,8 @@ fetchput_snapshot(_Config) ->
     testutil:check_forlist(Bookie1, ChkList1),
     testutil:check_forlist(SnapBookie1, ChkList1),
 
+    compare_foldwithsnap(Bookie1, SnapBookie1, ChkList1),
+
     % Close the snapshot, check the original store still has the objects
 
     ok = leveled_bookie:book_close(SnapBookie1),
@@ -474,6 +476,8 @@ fetchput_snapshot(_Config) ->
     testutil:check_forlist(SnapBookie3, ChkList2),
     testutil:check_forlist(SnapBookie2, ChkList1),
     io:format("Started new snapshot and check for new objects~n"),
+
+    compare_foldwithsnap(Bookie2, SnapBookie3, ChkList3),
     
     % Load yet more objects, these are replacement objects for the last load
 
@@ -555,6 +559,28 @@ fetchput_snapshot(_Config) ->
     false = is_process_alive(SnpPCL2),
     false = is_process_alive(SnpJrnl2),
     testutil:reset_filestructure().
+
+
+compare_foldwithsnap(Bookie, SnapBookie, ChkList) ->
+    HeadFoldFun = fun(B, K, _Hd, Acc) -> [{B, K}|Acc] end,
+    KeyFoldFun = fun(B, K, Acc) -> [{B, K}|Acc] end,
+    {async, HeadFoldDB} =
+        leveled_bookie:book_headfold(
+            Bookie, ?RIAK_TAG, {HeadFoldFun, []}, true, false, false
+        ),
+    {async, HeadFoldSnap} =
+        leveled_bookie:book_headfold(
+            SnapBookie, ?RIAK_TAG, {HeadFoldFun, []}, true, false, false
+        ),
+    true = HeadFoldDB() == HeadFoldSnap(),
+
+    testutil:check_forlist(SnapBookie, ChkList),
+
+    {async, KeyFoldSnap} =
+        leveled_bookie:book_keylist(
+            SnapBookie, ?RIAK_TAG, {KeyFoldFun, []}
+        ),
+    true = HeadFoldSnap() == KeyFoldSnap().
 
 
 load_and_count(_Config) ->

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -74,7 +74,21 @@ replace_everything(_Config) ->
     compact_and_wait(Book1, 1000),
     {ok, FileList2} =  file:list_dir(CompPath),
     io:format("Number of files after compaction ~w~n", [length(FileList2)]),
-    true = FileList1 == FileList2,
+    true = FileList1 =< FileList2,
+        %% There will normally be 5 journal files after 50K write then alter
+        %% That may be two files with entirely altered objects - which will be
+        %% compacted, and will be compacted to nothing.
+        %% The "middle" file - which will be 50% compactable may be scored to
+        %% be part of the first run, or may end up in the second run.  If in
+        %% the first run, the second run will not compact and FL1 == FL2.
+        %% Otherwise FL1 could be 0 and FL2 1.  Hard to control this as there
+        %% is randomisation in both the scoring and the journal size (due to
+        %% jittering of parameters).
+    compact_and_wait(Book1, 1000),
+    {ok, FileList3} =  file:list_dir(CompPath),
+    io:format("Number of files after compaction ~w~n", [length(FileList3)]),
+        %% By the third compaction there should be no further changes
+    true = FileList2 == FileList3,
     {async, BackupFun} = leveled_bookie:book_hotbackup(Book1),
     ok = BackupFun(BackupPath),
 
@@ -131,9 +145,9 @@ replace_everything(_Config) ->
     {OSpcL6, RSpcL6} = lists:split(200, lists:ukeysort(1, KSpcL6)),
     {KSpcL7, V7} = 
         testutil:put_altered_indexed_objects(Book6, BKT3, RSpcL6),
-    {ok, FileList3} =  file:list_dir(CompPath),
-    compact_and_wait(Book6),
     {ok, FileList4} =  file:list_dir(CompPath),
+    compact_and_wait(Book6),
+    {ok, FileList5} =  file:list_dir(CompPath),
     {OSpcL6A, V7} = 
         testutil:put_altered_indexed_objects(Book6, BKT3, OSpcL6, true, V7),
     {async, BackupFun6} = leveled_bookie:book_hotbackup(Book6),
@@ -141,7 +155,7 @@ replace_everything(_Config) ->
     ok = leveled_bookie:book_close(Book6),
 
     io:format("Checking object count in newly compacted journal files~n"),
-    NewlyCompactedFiles = lists:subtract(FileList4, FileList3),
+    NewlyCompactedFiles = lists:subtract(FileList5, FileList4),
     true = length(NewlyCompactedFiles) >= 1,
     CDBFilterFun = fun(_K, _V, _P, Acc, _EF) -> {loop, Acc + 1} end,
     CheckLengthFun =

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -761,7 +761,22 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 [length(ObjectSpecL), Snapshot]),
             lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL),
             io:format("Closing snapshot ~w~n", [Snapshot]),
-            ok = leveled_bookie:book_close(Snapshot);
+            ok = leveled_bookie:book_close(Snapshot),
+            {ok, AltSnapshot} =
+                leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
+            ok =
+                leveled_bookie:book_addlogs(
+                    AltSnapshot, [b0001, b0002, b0003, b0004, i0027, p0007]
+                ),
+            true = is_process_alive(AltSnapshot),
+            io:format(
+                "Closing actual store ~w with snapshot ~w open~n",
+                [Bookie1, AltSnapshot]
+            ),
+            ok = leveled_bookie:book_close(Bookie1),
+            % Sleep a beat so as not to race with the 'DOWN' message
+            timer:sleep(10),
+            false = is_process_alive(AltSnapshot);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 
@@ -772,11 +787,11 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                 leveled_bookie:book_headonly(Bookie1, 
                                                 SegmentID0, 
                                                 Bucket0, 
-                                                Key0)
+                                                Key0),
+            io:format("Closing actual store ~w~n", [Bookie1]),
+            ok = leveled_bookie:book_close(Bookie1)
     end,
-
-    io:format("Closing actual store ~w~n", [Bookie1]),
-    ok = leveled_bookie:book_close(Bookie1),
+    
     {ok, FinalJournals} = file:list_dir(JFP),
     io:format("Trim has reduced journal count from " ++ 
                     "~w to ~w and ~w after restart~n", 

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -747,7 +747,21 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
             lists:foreach(CheckHeadFun(Bookie1), ObjectSpecL),
             {ok, Snapshot} =
                 leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
-            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL);
+            ok = leveled_bookie:book_loglevel(Snapshot, warn),
+            ok =
+                leveled_bookie:book_addlogs(
+                    Snapshot, [b0001, b0002, b0003, i0027, p0007]
+                ),
+            ok =
+                leveled_bookie:book_removelogs(
+                    Snapshot, [b0019]
+                ),
+            io:format(
+                "Checking for ~w objects against Snapshot ~w~n",
+                [length(ObjectSpecL), Snapshot]),
+            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL),
+            io:format("Closing snapshot ~w~n", [Snapshot]),
+            ok = leveled_bookie:book_close(Snapshot);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 
@@ -761,7 +775,7 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                                                 Key0)
     end,
 
-
+    io:format("Closing actual store ~w~n", [Bookie1]),
     ok = leveled_bookie:book_close(Bookie1),
     {ok, FinalJournals} = file:list_dir(JFP),
     io:format("Trim has reduced journal count from " ++ 

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -738,11 +738,16 @@ basic_headonly_test(ObjectCount, RemoveCount, HeadOnly) ->
                                                 Bucket0, 
                                                 Key0),
             CheckHeadFun = 
-                fun({add, SegID, B, K, H}) ->
-                    {ok, H} = 
-                        leveled_bookie:book_headonly(Bookie1, SegID, B, K)
+                fun(DB) ->
+                    fun({add, SegID, B, K, H}) ->
+                        {ok, H} = 
+                            leveled_bookie:book_headonly(DB, SegID, B, K)
+                    end
                 end,
-            lists:foreach(CheckHeadFun, ObjectSpecL);
+            lists:foreach(CheckHeadFun(Bookie1), ObjectSpecL),
+            {ok, Snapshot} =
+                leveled_bookie:book_start([{snapshot_bookie, Bookie1}]),
+            lists:foreach(CheckHeadFun(Snapshot), ObjectSpecL);
         no_lookup ->
             {unsupported_message, head} = 
                 leveled_bookie:book_head(Bookie1, 


### PR DESCRIPTION
Improve usability of snapshots.

Full snapshots of a store would only work for basic GET requests previously.  No support for the query API f for head-only mode.

This allows a snapshot bookie to be taken which works as a normal Bookie, for all read-only operations. 