### PR TITLE
Test improvements

### DIFF
--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -86,8 +86,18 @@ replace_everything(_Config) ->
     compact_and_wait(Book1, 1000),
     {ok, FileList3} =  file:list_dir(CompPath),
     io:format("Number of files after compaction ~w~n", [length(FileList3)]),
-        %% By the third compaction there should be no further changes
-    true = FileList2 == FileList3,
+        %% By the third compaction there should be no further changes - but
+        %% maybe there is a need to wait for the fourth run
+    case FileList3 of
+        FileList2 ->
+            true;
+        FileList3 when FileList3 > FileList2 ->
+            compact_and_wait(Book1, 1000),
+            {ok, FileList3a} =  file:list_dir(CompPath),
+            io:format("Number of files after compaction ~w~n", [length(FileList3a)]),
+            %% By the fourth compaction there should be no further changes
+            true = FileList3 == FileList3a
+    end,
     {async, BackupFun} = leveled_bookie:book_hotbackup(Book1),
     ok = BackupFun(BackupPath),
 


### PR DESCRIPTION
Reliability fix to recovery_SUITE

Also riak_SUITE testing added for estimating data size (object count).  This is useful to provide updates during handoffs (with a data size estimate, it is possible to see handoff progress as a percentage).

Estimates, and guesses are measured - with the related time savings. Estimates are from counting 1 in 256 keys, Guesses from counting 1 in 1024.  Results from some runs comparing estimates with guesses:

- 80K keys
  - S1: Estimate 38400 of size 32000 with estimate taking 11 ms vs 117 ms
  - S1: Guess 45056 of size 32000 with guess taking 5 ms vs 117 ms
  - S2: Estimate 81408 of size 80000 with estimate taking 30 ms vs 448 ms
  - S2: Guess 87040 of size 80000 with guess taking 13 ms vs 448 ms
- 960K keys
  - S1: Estimate 394496 of size 384000 with estimate taking 141 ms vs 4501 ms
  - S1: Guess 399360 of size 384000 with guess taking 59 ms vs 4501 ms
  - S2: Estimate 979200 of size 960000 with estimate taking 365 ms vs 26362 ms
  - S2: Guess 990208 of size 960000 with guess taking 168 ms vs 26362 ms
- 2.56M keys
  - S1: Estimate 1051904 of size 1024000 with estimate taking 416 ms vs 20816 ms
  - S1: Guess 1077248 of size 1024000 with guess taking 198 ms vs 20816 ms
  - S2: Estimate 2584576 of size 2560000 with estimate taking 1190 ms vs 191221 ms
  - S2: Guess 2703360 of size 2560000 with guess taking 638 ms vs 191221 ms
- 3.84M keys:
  - S1: Estimate 1563648 of size 1536000 with estimate taking 677 ms vs 81591 ms
  - S1: Guess 1606656 of size 1536000 with guess taking 350 ms vs 81591 ms
  - S2: Estimate 3887616 of size 3840000 with estimate taking 1756 ms vs 672349 ms
  - S2: Guess 3897344 of size 3840000 with guess taking 1073 ms vs 672349 ms

Also of concern is that non-estimate approach appears not to scale linearly.  e.g. 960K size -> 26s, 1.5M size -> 82s, 2.6M size -> 191s. 3.8M -> 672s 