### PR TITLE
Mas d31 nhskv16sstpclv2

### DIFF
--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -107,7 +107,7 @@ clerk_removelogs(Pid, ForcedLogs) ->
 
 -spec clerk_close(pid()) -> ok.
 clerk_close(Pid) ->
-    gen_server:call(Pid, close, 20000).
+    gen_server:call(Pid, close, 60000).
 
 %%%============================================================================
 %%% gen_server callbacks

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -1734,9 +1734,10 @@ fetch_size(unlimited, W) -> W;
 fetch_size(MaxKeys, W) -> min(MaxKeys, W).
 
 -spec scan_size(max_keys()) -> pos_integer().
-scan_size(unlimited) -> ?ITERATOR_SCANWIDTH;
-scan_size(MaxKeys) when MaxKeys < 256 -> ?ITERATOR_MINSCANWIDTH;
-scan_size(_MaxKeys) -> ?ITERATOR_SCANWIDTH.
+scan_size(unlimited) ->
+    ?ITERATOR_SCANWIDTH;
+scan_size(MaxKeys) ->
+    min(?ITERATOR_SCANWIDTH, max(?ITERATOR_MINSCANWIDTH, MaxKeys div 256)).
 
 -spec find_nextkeys(
     sst_iterator(),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -79,8 +79,6 @@
 -define(DELETE_TIMEOUT, 10000).
 -define(TREE_TYPE, idxt).
 -define(TREE_SIZE, 16).
--define(TIMING_SAMPLECOUNTDOWN, 20000).
--define(TIMING_SAMPLESIZE, 100).
 -define(BLOCK_LENGTHS_LENGTH, 20).
 -define(LMD_LENGTH, 4).
 -define(FLIPPER32, 4294967295).

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -1396,15 +1396,7 @@ fetch_range(StartKey, EndKey, Summary, FilterFun, true) ->
             end;
         N ->
             {LSlot, MidSlots, RSlot} =
-                case N of
-                    2 ->
-                        [Slot1, Slot2] = Slots,
-                        {Slot1, [], Slot2};
-                    N ->
-                        [Slot1|_Rest] = Slots,
-                        SlotN = lists:last(Slots),
-                        {Slot1, lists:sublist(Slots, 2, N - 2), SlotN}
-                end,
+                {hd(Slots), lists:sublist(Slots, 2, N - 2), lists:last(Slots)},
             MidSlotPointers =
                 lists:map(
                     fun(S) -> {pointer, Self, S, all, all} end,

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -33,7 +33,8 @@ riak_profileperf(_Config) ->
     riak_load_tester(<<"B0">>, 2000000, 1024, query, native),
     riak_load_tester(<<"B0">>, 2000000, 1024, guess, native),
     riak_load_tester(<<"B0">>, 2000000, 1024, estimate, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, full, native).
+    riak_load_tester(<<"B0">>, 2000000, 1024, full, native),
+    riak_load_tester(<<"B0">>, 2000000, 1024, update, native).
 
 % For standard ct test runs
 riak_ctperf(_Config) ->
@@ -49,7 +50,7 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
 
     GetFetches = KeyCount div 4,
     HeadFetches = KeyCount div 2,
-    IndexesReturned = KeyCount * 20,
+    IndexesReturned = KeyCount * 10,
 
     RootPath = testutil:reset_filestructure("riakLoad"),
     StartOpts1 =
@@ -100,19 +101,36 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
         (TC1 + TC2 + TC3 + TC4 + TC5 + TC6 + TC7 + TC8 + TC9 + TC10) div 1000,
     ct:log(?INFO, "Total load time ~w ms", [TotalLoadTime]),
 
+    {MT0, MP0, MB0} = memory_usage(),
+
     TotalHeadTime = 
         random_fetches(head, Bookie1, Bucket, KeyCount, HeadFetches),
+    
+    {MT1, MP1, MB1} = memory_usage(),
+
     TotalGetTime = 
         random_fetches(get, Bookie1, Bucket, KeyCount, GetFetches),
+
+    {MT2, MP2, MB2} = memory_usage(),
+
     TotalQueryTime =
         random_queries(Bookie1, Bucket, 10, IndexCount, IndexesReturned),
-    WeightedFoldTime = size_estimate_summary(Bookie1),
+
+    {MT3, MP3, MB3} = memory_usage(),
+
+    {FullFoldTime, SegFoldTime} = size_estimate_summary(Bookie1),
+
+    {MT4, MP4, MB4} = memory_usage(),
+
+    TotalUpdateTime = rotate_chunk(Bookie1, <<"UpdBucket">>, KeyCount div 50),
+
+    {MT5, MP5, MB5} = memory_usage(),
 
     DiskSpace = lists:nth(1, string:tokens(os:cmd("du -sh riakLoad"), "\t")),
     ct:log(?INFO, "Disk space taken by test ~s", [DiskSpace]),
 
     MemoryUsage = erlang:memory(),
-    ct:log(?INFO, "Memory used in test ~p", [MemoryUsage]),
+    ct:log(?INFO, "Memory in use at end of test ~p", [MemoryUsage]),
 
     ct:log(?INFO, "Profile of ~w", [Profile]),
     ProfiledFun =
@@ -143,6 +161,10 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
                 fun() ->
                     testutil:riakload(Bookie1, ObjList11)
                 end;
+            update ->
+                fun() ->
+                    rotate_chunk(Bookie1, <<"ProfileB">>, KeyCount div 50)
+                end;
             CounterFold ->
                 fun() ->
                     lists:foreach(
@@ -168,17 +190,25 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
     
     {KeyCount, ObjSize, PressMethod,
         TotalLoadTime,
-        WeightedFoldTime, TotalHeadTime, TotalGetTime, TotalQueryTime,
-        DiskSpace, MemoryUsage,
+        TotalHeadTime, TotalGetTime,
+        TotalQueryTime, FullFoldTime, SegFoldTime,
+        TotalUpdateTime,
+        DiskSpace,
+        {(MT0 + MT1 + MT2 + MT3 + MT4 + MT5) div 6000000,
+            (MP0 + MP1 + MP2 + MP3 + MP4 + MP5) div 6000000,
+            (MB0 + MB1 + MB2 + MB3 + MB4 + MB5) div 6000000},
         SSTPids, CDBPids}.
 
 
 output_result(
     {KeyCount, ObjSize, PressMethod,
-    TotalLoadTime,
-    WeightedFoldTime, TotalHeadTime, TotalGetTime, TotalQueryTime,
-    DiskSpace, MemoryUsage,
-    SSTPids, CDBPids}
+        TotalLoadTime,
+        TotalHeadTime, TotalGetTime,
+        TotalQueryTime, TotalFullFoldTime, TotalSegFoldTime,
+        TotalUpdateTime,
+        DiskSpace,
+        {TotalMemoryMB, ProcessMemoryMB, BinaryMemoryMB},
+        SSTPids, CDBPids}
 ) ->
     %% TODO ct:pal not working?  even with rebar3 ct --verbose?
     io:format(
@@ -186,23 +216,31 @@ output_result(
         "~n"
         "Outputs from profiling with KeyCount ~w ObjSize ~w Compression ~w:~n"
         "TotalLoadTime - ~w ms~n"
-        "TotalFoldTime - ~w ms~n"
         "TotalHeadTime - ~w ms~n"
         "TotalGetTime - ~w ms~n"
         "TotalQueryTime - ~w ms~n"
+        "TotalFullFoldTime - ~w ms~n"
+        "TotalSegFoldTime - ~w ms~n"
+        "TotalUpdateTime - ~w ms~n"
         "Disk space required for test - ~s~n"
-        "Memory usage for test - ~p ~p ~p~n"
+        "Average Memory usage for test - Total ~p Proc ~p Bin ~p MB~n"
         "Closing count of SST Files - ~w~n"
         "Closing count of CDB Files - ~w~n",
         [KeyCount, ObjSize, PressMethod,
-            TotalLoadTime, 
-            WeightedFoldTime, TotalHeadTime, TotalGetTime, TotalQueryTime,
+            TotalLoadTime, TotalHeadTime, TotalGetTime,
+            TotalQueryTime, TotalFullFoldTime, TotalSegFoldTime,
+            TotalUpdateTime,
             DiskSpace,
-            lists:keyfind(total, 1, MemoryUsage),
-            lists:keyfind(processes, 1, MemoryUsage),
-            lists:keyfind(binary, 1, MemoryUsage),
+            TotalMemoryMB, ProcessMemoryMB, BinaryMemoryMB,
             length(SSTPids), length(CDBPids)]
     ).
+
+memory_usage() ->
+    garbage_collect(), % GC the test process
+    MemoryUsage = erlang:memory(),
+    {element(2, lists:keyfind(total, 1, MemoryUsage)),
+        element(2, lists:keyfind(processes, 1, MemoryUsage)),
+        element(2, lists:keyfind(binary, 1, MemoryUsage))}.
 
 profile_app(Pids, ProfiledFun) ->
 
@@ -226,7 +264,6 @@ size_estimate_summary(Bookie) ->
             {TotalEstimateVariance, TotalGuessVariance}} =
         lists:foldl(
             fun(_I, {{GT, ET, CT}, {AET, AGT}}) ->
-                timer:sleep(1000),
                 {{GT0, ET0, CT0}, {AE0, AG0}} = size_estimate_tester(Bookie),
                 {{GT + GT0, ET + ET0, CT + CT0}, {AET + AE0, AGT + AG0}}
             end,
@@ -246,8 +283,21 @@ size_estimate_summary(Bookie) ->
         [TotalEstimateVariance div Loops, TotalGuessVariance div Loops]
     ),
     %% Assume that segment-list folds are 10 * as common as all folds
-    ((TotalCountTime div 10) + (TotalGuessTime + TotalEstimateTime)) div 1000.
+    {TotalCountTime div 1000, (TotalGuessTime + TotalEstimateTime) div 1000}.
 
+
+rotate_chunk(Bookie, Bucket, KeyCount) ->
+    ct:log(
+        ?INFO,
+        "Rotating an ObjList ~w - "
+        "time includes object generation",
+        [KeyCount]),
+    {TC, ok} = 
+        timer:tc(
+            fun() ->
+                testutil:rotation_withnocheck(Bookie, Bucket, KeyCount)
+            end),
+    TC div 1000.
 
 load_chunk(Bookie, CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
     ct:log(?INFO, "Generating and loading ObjList ~w", [Chunk]),
@@ -378,21 +428,16 @@ random_queries(Bookie, Bucket, IDs, IdxCnt, IndexesReturned) ->
             BinIndex =
                 list_to_binary("binary" ++ integer_to_list(ID) ++ "_bin"),
             Twenty = IdxCnt div 5,
+            MaxRange = max(5, IdxCnt div 100),
+            RI = leveled_rand:uniform(MaxRange),
             [Start, End] =
-                case leveled_rand:uniform(5) of
-                    1 ->
-                        lists:sort(
-                            [
-                                leveled_rand:uniform(IdxCnt - Twenty) + Twenty,
-                                leveled_rand:uniform(IdxCnt - Twenty) + Twenty
-                            ]);
+                case RI of
+                    RI when RI < (MaxRange div 5) ->
+                        R0 = leveled_rand:uniform(IdxCnt - (Twenty + RI)),
+                        [R0 + Twenty, R0 + Twenty + RI];
                     _ ->
-                        lists:sort(
-                            [
-                                leveled_rand:uniform(Twenty),
-                                leveled_rand:uniform(Twenty)
-                            ]
-                        )
+                        R0 = leveled_rand:uniform(Twenty - RI),
+                        [R0, R0 + RI]
                 end,
             FoldKeysFun =  fun(_B, _K, Cnt) -> Cnt + 1 end,
             {async, R} =

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -7,7 +7,7 @@
     riak_ctperf/1, riak_fullperf/1, riak_profileperf/1
 ]).
 
-all() -> [riak_ctperf].
+all() -> [riak_fullperf].
 suite() -> [{timetrap, {hours, 8}}].
     
 

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -7,7 +7,7 @@
     riak_ctperf/1, riak_fullperf/1, riak_profileperf/1
 ]).
 
-all() -> [riak_fullperf].
+all() -> [riak_ctperf].
 suite() -> [{timetrap, {hours, 8}}].
     
 

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -1,56 +1,54 @@
 -module(perf_SUITE).
--include_lib("common_test/include/ct.hrl").
--include("include/leveled.hrl").
+-include("../include/leveled.hrl").
 -define(INFO, info).
 -export([all/0, suite/0]).
 -export([
     riak_ctperf/1, riak_fullperf/1, riak_profileperf/1
 ]).
 
-all() -> [riak_ctperf].
+all() -> [riak_fullperf].
 suite() -> [{timetrap, {hours, 8}}].
     
 
 % For full performance test
 riak_fullperf(_Config) ->
-    R2A = riak_load_tester(<<"B0">>, 2000000, 2048, false, native),
+    R2A = riak_load_tester(<<"B0">>, 2000000, 2048, [], native),
     output_result(R2A),
-    R2B = riak_load_tester(<<"B0">>, 2000000, 2048, false, native),
+    R2B = riak_load_tester(<<"B0">>, 2000000, 2048, [], native),
     output_result(R2B),
-    R2C = riak_load_tester(<<"B0">>, 2000000, 2048, false, native),
+    R2C = riak_load_tester(<<"B0">>, 2000000, 2048, [], native),
     output_result(R2C),
-    R5A = riak_load_tester(<<"B0">>, 5000000, 2048, false, native),
+    R5A = riak_load_tester(<<"B0">>, 5000000, 2048, [], native),
     output_result(R5A),
-    R5B = riak_load_tester(<<"B0">>, 5000000, 2048, false, native),
+    R5B = riak_load_tester(<<"B0">>, 5000000, 2048, [], native),
     output_result(R5B),
-    R10 = riak_load_tester(<<"B0">>, 10000000, 2048, false, native),
-    output_result(R10).
+    R10 = riak_load_tester(<<"B0">>, 10000000, 2048, [], native),
+    output_result(R10)
+    .
 
 riak_profileperf(_Config) ->
-    riak_load_tester(<<"B0">>, 2000000, 1024, load, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, head, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, get, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, query, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, guess, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, estimate, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, full, native),
-    riak_load_tester(<<"B0">>, 2000000, 1024, update, native).
+    riak_load_tester(
+        <<"B0">>,
+        2000000,
+        2048,
+        [load, head, get, query, mini_query, full, guess, estimate, update],
+        native).
 
 % For standard ct test runs
 riak_ctperf(_Config) ->
-    riak_load_tester(<<"B0">>, 400000, 1024, false, native).
+    riak_load_tester(<<"B0">>, 400000, 1024, [], native).
 
-riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
+riak_load_tester(Bucket, KeyCount, ObjSize, ProfileList, PressMethod) ->
     ct:log(
         ?INFO,
         "Basic riak test with KeyCount ~w ObjSize ~w",
         [KeyCount, ObjSize]
     ),
-    IndexCount = 1000,
+    IndexCount = 100000,
 
     GetFetches = KeyCount div 4,
     HeadFetches = KeyCount div 2,
-    IndexesReturned = KeyCount * 10,
+    IndexesReturned = KeyCount * 2,
 
     RootPath = testutil:reset_filestructure("riakLoad"),
     StartOpts1 =
@@ -113,8 +111,24 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
 
     {MT2, MP2, MB2} = memory_usage(),
 
+    QuerySize = max(10, IndexCount div 1000),
+    MiniQuerySize = max(1, IndexCount div 50000),
     TotalQueryTime =
-        random_queries(Bookie1, Bucket, 10, IndexCount, IndexesReturned),
+        random_queries(
+            Bookie1,
+            Bucket,
+            10,
+            IndexCount,
+            QuerySize,
+            IndexesReturned),
+    TotalMiniQueryTime =
+        random_queries(
+            Bookie1,
+            Bucket,
+            10,
+            IndexCount,
+            MiniQuerySize,
+            IndexesReturned div 8),
 
     {MT3, MP3, MB3} = memory_usage(),
 
@@ -122,7 +136,8 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
 
     {MT4, MP4, MB4} = memory_usage(),
 
-    TotalUpdateTime = rotate_chunk(Bookie1, <<"UpdBucket">>, KeyCount div 50),
+    TotalUpdateTime =
+        rotate_chunk(Bookie1, <<"UpdBucket">>, KeyCount div 50, ObjSize),
 
     {MT5, MP5, MB5} = memory_usage(),
 
@@ -132,66 +147,38 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
     MemoryUsage = erlang:memory(),
     ct:log(?INFO, "Memory in use at end of test ~p", [MemoryUsage]),
 
-    ct:log(?INFO, "Profile of ~w", [Profile]),
-    ProfiledFun =
-        case Profile of
-            false ->
-                fun() -> ok end;
-            query ->
-                % As penciller snapshot is started not spawned - profiling
-                % only covers SST/Bookie
-                fun() ->
-                    random_queries(
-                        Bookie1, Bucket, 10, IndexCount, IndexesReturned)
-                end;
-            head ->
-                fun() ->
-                    random_fetches(
-                        head, Bookie1, Bucket, KeyCount, HeadFetches)
-                end;
-            get ->
-                fun() ->
-                    random_fetches(
-                        get, Bookie1, Bucket, KeyCount, GetFetches)
-                end;
-            load ->
-                ObjList11 =
-                    generate_chunk(
-                        CountPerList, ObjSize, IndexGenFun, Bucket, 11),
-                fun() ->
-                    testutil:riakload(Bookie1, ObjList11)
-                end;
-            update ->
-                fun() ->
-                    rotate_chunk(Bookie1, <<"ProfileB">>, KeyCount div 50)
-                end;
-            CounterFold ->
-                fun() ->
-                    lists:foreach(
-                        fun(_I) ->
-                            _ = counter(Bookie1, CounterFold)
-                        end,
-                        lists:seq(1, 10)
-                    )
-                end
-            end,
+    ProfileData =
+        {Bookie1, Bucket, KeyCount, ObjSize, IndexCount, IndexesReturned},
+    lists:foreach(
+        fun(P) ->
+            ct:log(?INFO, "Profile of ~w", [P]),
+            P0 =
+                case P of
+                    mini_query ->
+                        {mini_query, MiniQuerySize};
+                    query ->
+                        {query, QuerySize};
+                    head ->
+                        {head, HeadFetches};
+                    get ->
+                        {get, GetFetches};
+                    load ->
+                        {load, IndexGenFun};
+                    P ->
+                        P
+                end,
+            ProFun = profile_fun(P0, ProfileData),
+            profile_test(Bookie1, ProFun)
+        end,
+        ProfileList),
 
-    {ok, Inker, Pcl} = leveled_bookie:book_returnactors(Bookie1),
-    SSTPids = leveled_penciller:pcl_getsstpids(Pcl),
-    PClerk = leveled_penciller:pcl_getclerkpid(Pcl),
-    CDBPids = leveled_inker:ink_getcdbpids(Inker),
-    IClerk = leveled_inker:ink_getclerkpid(Inker),
-    TestPid = self(),
-    profile_app(
-        [TestPid, Bookie1, Inker, IClerk, Pcl, PClerk] ++ SSTPids ++ CDBPids,
-        ProfiledFun),
-
+    {_Inker, _Pcl, SSTPids, _PClerk, CDBPids, _IClerk} = get_pids(Bookie1),
     leveled_bookie:book_destroy(Bookie1),
     
     {KeyCount, ObjSize, PressMethod,
         TotalLoadTime,
         TotalHeadTime, TotalGetTime,
-        TotalQueryTime, FullFoldTime, SegFoldTime,
+        TotalQueryTime, TotalMiniQueryTime, FullFoldTime, SegFoldTime,
         TotalUpdateTime,
         DiskSpace,
         {(MT0 + MT1 + MT2 + MT3 + MT4 + MT5) div 6000000,
@@ -200,11 +187,26 @@ riak_load_tester(Bucket, KeyCount, ObjSize, Profile, PressMethod) ->
         SSTPids, CDBPids}.
 
 
+profile_test(Bookie, ProfileFun) ->
+    {Inker, Pcl, SSTPids, PClerk, CDBPids, IClerk} = get_pids(Bookie),
+    TestPid = self(),
+    profile_app(
+        [TestPid, Bookie, Inker, IClerk, Pcl, PClerk] ++ SSTPids ++ CDBPids,
+        ProfileFun).
+
+get_pids(Bookie) ->
+    {ok, Inker, Pcl} = leveled_bookie:book_returnactors(Bookie),
+    SSTPids = leveled_penciller:pcl_getsstpids(Pcl),
+    PClerk = leveled_penciller:pcl_getclerkpid(Pcl),
+    CDBPids = leveled_inker:ink_getcdbpids(Inker),
+    IClerk = leveled_inker:ink_getclerkpid(Inker),
+    {Inker, Pcl, SSTPids, PClerk, CDBPids, IClerk}.
+
 output_result(
     {KeyCount, ObjSize, PressMethod,
         TotalLoadTime,
         TotalHeadTime, TotalGetTime,
-        TotalQueryTime, TotalFullFoldTime, TotalSegFoldTime,
+        TotalQueryTime, TotalMiniQueryTime, TotalFullFoldTime, TotalSegFoldTime,
         TotalUpdateTime,
         DiskSpace,
         {TotalMemoryMB, ProcessMemoryMB, BinaryMemoryMB},
@@ -219,6 +221,7 @@ output_result(
         "TotalHeadTime - ~w ms~n"
         "TotalGetTime - ~w ms~n"
         "TotalQueryTime - ~w ms~n"
+        "TotalMiniQueryTime - ~w ms~n"
         "TotalFullFoldTime - ~w ms~n"
         "TotalAAEFoldTime - ~w ms~n"
         "TotalUpdateTime - ~w ms~n"
@@ -228,7 +231,7 @@ output_result(
         "Closing count of CDB Files - ~w~n",
         [KeyCount, ObjSize, PressMethod,
             TotalLoadTime, TotalHeadTime, TotalGetTime,
-            TotalQueryTime, TotalFullFoldTime, TotalSegFoldTime,
+            TotalQueryTime, TotalMiniQueryTime, TotalFullFoldTime, TotalSegFoldTime,
             TotalUpdateTime,
             DiskSpace,
             TotalMemoryMB, ProcessMemoryMB, BinaryMemoryMB,
@@ -286,16 +289,20 @@ size_estimate_summary(Bookie) ->
     {TotalCountTime div 1000, (TotalGuessTime + TotalEstimateTime) div 1000}.
 
 
-rotate_chunk(Bookie, Bucket, KeyCount) ->
+rotate_chunk(Bookie, Bucket, KeyCount, ObjSize) ->
     ct:log(
         ?INFO,
         "Rotating an ObjList ~w - "
         "time includes object generation",
         [KeyCount]),
+    V1 = base64:encode(leveled_rand:rand_bytes(ObjSize)),
+    V2 = base64:encode(leveled_rand:rand_bytes(ObjSize)),
+    V3 = base64:encode(leveled_rand:rand_bytes(ObjSize)),
     {TC, ok} = 
         timer:tc(
             fun() ->
-                testutil:rotation_withnocheck(Bookie, Bucket, KeyCount)
+                testutil:rotation_withnocheck(
+                    Bookie, Bucket, KeyCount, V1, V2, V3)
             end),
     TC div 1000.
 
@@ -421,14 +428,13 @@ random_fetches(FetchType, Bookie, Bucket, ObjCount, Fetches) ->
     ),
     TC div 1000.
     
-random_queries(Bookie, Bucket, IDs, IdxCnt, IndexesReturned) ->
+random_queries(Bookie, Bucket, IDs, IdxCnt, MaxRange, IndexesReturned) ->
     QueryFun =
         fun() ->
             ID = leveled_rand:uniform(IDs), 
             BinIndex =
                 list_to_binary("binary" ++ integer_to_list(ID) ++ "_bin"),
             Twenty = IdxCnt div 5,
-            MaxRange = max(5, IdxCnt div 100),
             RI = leveled_rand:uniform(MaxRange),
             [Start, End] =
                 case RI of
@@ -467,3 +473,57 @@ run_queries(QueryFun, QueryCount, EntriesFound, TargetEntries) ->
     Matches = QueryFun(),
     run_queries(
         QueryFun, QueryCount + 1, EntriesFound + Matches, TargetEntries).
+
+profile_fun(false, _ProfileData) ->
+    fun() -> ok end;
+profile_fun(
+        {mini_query, QuerySize},
+        {Bookie, Bucket, _KeyCount, _ObjSize, IndexCount, IndexesReturned}) ->
+    fun() ->
+        random_queries(
+            Bookie, Bucket, 10, IndexCount, QuerySize, IndexesReturned div 8)
+    end;
+profile_fun(
+        {query, QuerySize},
+        {Bookie, Bucket, _KeyCount, _ObjSize, IndexCount, IndexesReturned}) ->
+    fun() ->
+        random_queries(
+            Bookie, Bucket, 10, IndexCount, QuerySize, IndexesReturned)
+    end;
+profile_fun(
+        {head, HeadFetches},
+        {Bookie, Bucket, KeyCount, _ObjSize, _IndexCount, _IndexesReturned}) ->
+    fun() ->
+        random_fetches(head, Bookie, Bucket, KeyCount, HeadFetches)
+    end;
+profile_fun(
+        {get, GetFetches},
+        {Bookie, Bucket, KeyCount, _ObjSize, _IndexCount, _IndexesReturned}) ->
+    fun() ->
+        random_fetches(get, Bookie, Bucket, KeyCount, GetFetches)
+    end;
+profile_fun(
+        {load, IndexGenFun},
+        {Bookie, Bucket, KeyCount, ObjSize, _IndexCount, _IndexesReturned}) ->
+    ObjList11 =
+        generate_chunk(KeyCount div 10, ObjSize, IndexGenFun, Bucket, 11),
+    fun() ->
+        testutil:riakload(Bookie, ObjList11)
+    end;
+profile_fun(
+        update,
+        {Bookie, _Bucket, KeyCount, ObjSize, _IndexCount, _IndexesReturned}) ->
+    fun() ->
+        rotate_chunk(Bookie, <<"ProfileB">>, KeyCount div 50, ObjSize)
+    end;
+profile_fun(
+        CounterFold,
+        {Bookie, _Bucket, _KeyCount, _ObjSize, _IndexCount, _IndexesReturned}) ->
+    fun() ->
+        lists:foreach(
+            fun(_I) ->
+                _ = counter(Bookie, CounterFold)
+            end,
+            lists:seq(1, 10)
+        )
+    end.

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -220,7 +220,7 @@ output_result(
         "TotalGetTime - ~w ms~n"
         "TotalQueryTime - ~w ms~n"
         "TotalFullFoldTime - ~w ms~n"
-        "TotalSegFoldTime - ~w ms~n"
+        "TotalAAEFoldTime - ~w ms~n"
         "TotalUpdateTime - ~w ms~n"
         "Disk space required for test - ~s~n"
         "Average Memory usage for test - Total ~p Proc ~p Bin ~p MB~n"

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -6,8 +6,8 @@
     riak_ctperf/1, riak_fullperf/1, riak_profileperf/1
 ]).
 
-all() -> [riak_fullperf].
-suite() -> [{timetrap, {hours, 8}}].
+all() -> [riak_ctperf].
+suite() -> [{timetrap, {hours, 16}}].
     
 
 % For full performance test

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -49,6 +49,7 @@
             put_altered_indexed_objects/5,
             check_indexed_objects/4,
             rotating_object_check/3,
+            rotation_withnocheck/3,
             corrupt_journal/5,
             restore_file/2,
             restore_topending/2,
@@ -837,6 +838,12 @@ rotating_object_check(RootPath, B, NumberOfObjects) ->
     ok = leveled_bookie:book_close(Book2),
     ok.
     
+rotation_withnocheck(Book1, B, NumberOfObjects) ->
+    {KSpcL1, _V1} = put_indexed_objects(Book1, B, NumberOfObjects),
+    {KSpcL2, _V2} = put_altered_indexed_objects(Book1, B, KSpcL1),
+    {_KSpcL3, _V3} = put_altered_indexed_objects(Book1, B, KSpcL2),
+    ok.
+
 corrupt_journal(RootPath, FileName, Corruptions, BasePosition, GapSize) ->
     OriginalPath = RootPath ++ "/journal/journal_files/" ++ FileName,
     BackupPath = RootPath ++ "/journal/journal_files/" ++

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -44,12 +44,13 @@
             update_some_objects/3,
             delete_some_objects/3,
             put_indexed_objects/3,
+            put_indexed_objects/4,
             put_altered_indexed_objects/3,
             put_altered_indexed_objects/4,
             put_altered_indexed_objects/5,
             check_indexed_objects/4,
             rotating_object_check/3,
-            rotation_withnocheck/3,
+            rotation_withnocheck/6,
             corrupt_journal/5,
             restore_file/2,
             restore_topending/2,
@@ -755,6 +756,9 @@ check_indexed_objects(Book, B, KSpecL, V) ->
 
 put_indexed_objects(Book, Bucket, Count) ->
     V = get_compressiblevalue(),
+    put_indexed_objects(Book, Bucket, Count, V).
+
+put_indexed_objects(Book, Bucket, Count, V) ->
     IndexGen = get_randomindexes_generator(1),
     SW = os:timestamp(),
     ObjL1 = 
@@ -838,10 +842,10 @@ rotating_object_check(RootPath, B, NumberOfObjects) ->
     ok = leveled_bookie:book_close(Book2),
     ok.
     
-rotation_withnocheck(Book1, B, NumberOfObjects) ->
-    {KSpcL1, _V1} = put_indexed_objects(Book1, B, NumberOfObjects),
-    {KSpcL2, _V2} = put_altered_indexed_objects(Book1, B, KSpcL1),
-    {_KSpcL3, _V3} = put_altered_indexed_objects(Book1, B, KSpcL2),
+rotation_withnocheck(Book1, B, NumberOfObjects, V1, V2, V3) ->
+    {KSpcL1, _V1} = put_indexed_objects(Book1, B, NumberOfObjects, V1),
+    {KSpcL2, _V2} = put_altered_indexed_objects(Book1, B, KSpcL1, true, V2),
+    {_KSpcL3, _V3} = put_altered_indexed_objects(Book1, B, KSpcL2, true, V3),
     ok.
 
 corrupt_journal(RootPath, FileName, Corruptions, BasePosition, GapSize) ->


### PR DESCRIPTION
Further improvements to `leveled_sst`, to:
- reduce the use of `++` or `lists:append/2` where a BigList is prepended to a ShortList;
- reduce the duplication of functions, where the same thing is done differently in different paths through the code;
- be more specific about what blocks need to be deserialised when using a key range, and trimming prior to accumulation.