### PR TITLE
Extend perf_SUITE

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,9 +23,9 @@
    ]},
   {test, [{extra_src_dirs, ["test/end_to_end", "test/property"]}
    ]},
-  {perf_full, [{erl_opts, [{d, perf_full}]}]},
-  {perf_mini, [{erl_opts, [{d, perf_mini}]}]},
-  {perf_prof, [{erl_opts, [{d, perf_prof}]}]}
+  {perf_full, [{erl_opts, [{d, performance, riak_fullperf}]}]},
+  {perf_mini, [{erl_opts, [{d, performance, riak_miniperf}]}]},
+  {perf_prof, [{erl_opts, [{d, performance, riak_profileperf}]}]}
  ]}.
 
 {deps, [

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,10 @@
     {plugins, [rebar_eqc]}
    ]},
   {test, [{extra_src_dirs, ["test/end_to_end", "test/property"]}
-   ]}
+   ]},
+  {perf_full, [{erl_opts, [{d, perf_full}]}]},
+  {perf_mini, [{erl_opts, [{d, perf_mini}]}]},
+  {perf_prof, [{erl_opts, [{d, perf_prof}]}]}
  ]}.
 
 {deps, [

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -213,11 +213,12 @@ breaking_folds(_Config) ->
     % Find all keys index, and then same again but stop at a midpoint using a
     % throw
     {async, IdxFolder} =
-        leveled_bookie:book_indexfold(Bookie1,
-                                        list_to_binary("Bucket"), 
-                                        {fun testutil:foldkeysfun/3, []}, 
-                                        {"idx1_bin", "#", "|"},
-                                        {true, undefined}),
+        leveled_bookie:book_indexfold(
+            Bookie1,
+            list_to_binary("Bucket"), 
+            {fun testutil:foldkeysfun/3, []}, 
+            {<<"idx1_bin">>, <<"#">>, <<"|">>},
+            {true, undefined}),
     KeyList1 = lists:reverse(IdxFolder()),
     io:format("Index fold with result size ~w~n", [length(KeyList1)]),
     true = KeyCount == length(KeyList1),
@@ -235,11 +236,12 @@ breaking_folds(_Config) ->
             end
         end,
     {async, IdxFolderToMidK} =
-        leveled_bookie:book_indexfold(Bookie1,
-                                        list_to_binary("Bucket"), 
-                                        {FoldKeyThrowFun, []}, 
-                                        {"idx1_bin", "#", "|"},
-                                        {true, undefined}),
+        leveled_bookie:book_indexfold(
+            Bookie1,
+            list_to_binary("Bucket"), 
+            {FoldKeyThrowFun, []}, 
+            {<<"idx1_bin">>, <<"#">>, <<"|">>},
+            {true, undefined}),
     CatchingFold =
         fun(AsyncFolder) ->
             try
@@ -261,10 +263,8 @@ breaking_folds(_Config) ->
             [{K, Size}|Acc]
         end,
     {async, HeadFolder} = 
-        leveled_bookie:book_headfold(Bookie1,
-                                        ?RIAK_TAG, 
-                                        {HeadFoldFun, []}, 
-                                        true, true, false),
+        leveled_bookie:book_headfold(
+            Bookie1, ?RIAK_TAG,  {HeadFoldFun, []}, true, true, false),
     KeySizeList1 = lists:reverse(HeadFolder()),
     io:format("Head fold with result size ~w~n", [length(KeySizeList1)]),
     true = KeyCount == length(KeySizeList1),
@@ -472,11 +472,9 @@ small_load_with2i(_Config) ->
     testutil:check_forobject(Bookie1, TestObject),
     ObjectGen = testutil:get_compressiblevalue_andinteger(),
     IndexGen = testutil:get_randomindexes_generator(8),
-    ObjL1 = testutil:generate_objects(10000,
-                                        uuid,
-                                        [],
-                                        ObjectGen,
-                                        IndexGen),
+    ObjL1 =
+        testutil:generate_objects(
+            10000, uuid, [], ObjectGen, IndexGen),
     testutil:riakload(Bookie1, ObjL1),
     ChkList1 = lists:sublist(lists:sort(ObjL1), 100),
     testutil:check_forlist(Bookie1, ChkList1),
@@ -486,7 +484,7 @@ small_load_with2i(_Config) ->
     IdxQ1 = {index_query,
                 "Bucket",
                 {fun testutil:foldkeysfun/3, []},
-                {"idx1_bin", "#", "|"},
+                {<<"idx1_bin">>, <<"#">>, <<"|">>},
                 {true, undefined}},
     {async, IdxFolder} = leveled_bookie:book_returnfolder(Bookie1, IdxQ1),
     KeyList1 = lists:usort(IdxFolder()),
@@ -495,7 +493,7 @@ small_load_with2i(_Config) ->
     IdxQ2 = {index_query,
                 {"Bucket", LastKey},
                 {fun testutil:foldkeysfun/3, []},
-                {"idx1_bin", LastTerm, "|"},
+                {<<"idx1_bin">>, LastTerm, <<"|">>},
                 {false, undefined}},
     {async, IdxFolderLK} = leveled_bookie:book_returnfolder(Bookie1, IdxQ2),
     KeyList2 = lists:usort(IdxFolderLK()),
@@ -530,12 +528,14 @@ small_load_with2i(_Config) ->
                                                       {FoldObjectsFun, []},
                                                       false),
     KeyHashList2 = HTreeF2(),
-    {async, HTreeF3} = leveled_bookie:book_objectfold(Bookie1,
-                                                      ?RIAK_TAG,
-                                                      "Bucket",
-                                                      {"idx1_bin", "#", "|"},
-                                                      {FoldObjectsFun, []},
-                                                      false),
+    {async, HTreeF3} =
+        leveled_bookie:book_objectfold(
+            Bookie1,
+            ?RIAK_TAG,
+            "Bucket",
+            {<<"idx1_bin">>, <<"#">>, <<"|">>},
+            {FoldObjectsFun, []},
+            false),
     KeyHashList3 = HTreeF3(),
     true = 9901 == length(KeyHashList1), % also includes the test object
     true = 9900 == length(KeyHashList2),
@@ -585,96 +585,86 @@ small_load_with2i(_Config) ->
 
 query_count(_Config) ->
     RootPath = testutil:reset_filestructure(),
-    {ok, Book1} = leveled_bookie:book_start(RootPath,
-                                            2000,
-                                            50000000,
-                                            testutil:sync_strategy()),
+    {ok, Book1} =
+        leveled_bookie:book_start(
+            RootPath, 2000, 50000000, testutil:sync_strategy()),
     BucketBin = list_to_binary("Bucket"),
-    {TestObject, TestSpec} = testutil:generate_testobject(BucketBin,
-                                                            term_to_binary("Key1"),
-                                                            "Value1",
-                                                            [],
-                                                            [{"MDK1", "MDV1"}]),
+    {TestObject, TestSpec} =
+        testutil:generate_testobject(
+            BucketBin, term_to_binary("Key1"), "Value1", [], [{"MDK1", "MDV1"}]),
     ok = testutil:book_riakput(Book1, TestObject, TestSpec),
     testutil:check_forobject(Book1, TestObject),
     testutil:check_formissingobject(Book1, "Bucket1", "Key2"),
     testutil:check_forobject(Book1, TestObject),
-    lists:foreach(fun(_X) ->
-                        V = testutil:get_compressiblevalue(),
-                        Indexes = testutil:get_randomindexes_generator(8),
-                        SW = os:timestamp(),
-                        ObjL1 = testutil:generate_objects(10000,
-                                                            binary_uuid,
-                                                            [],
-                                                            V,
-                                                            Indexes),
-                        testutil:riakload(Book1, ObjL1),
-                        io:format("Put of 10000 objects with 8 index entries "
-                                        ++
-                                        "each completed in ~w microseconds~n",
-                                    [timer:now_diff(os:timestamp(), SW)])
-                        end,
-                        lists:seq(1, 8)),
+    lists:foreach(
+        fun(_X) ->
+            V = testutil:get_compressiblevalue(),
+            Indexes = testutil:get_randomindexes_generator(8),
+            SW = os:timestamp(),
+            ObjL1 = testutil:generate_objects(10000,
+                                                binary_uuid,
+                                                [],
+                                                V,
+                                                Indexes),
+            testutil:riakload(Book1, ObjL1),
+            io:format(
+                "Put of 10000 objects with 8 index entries "
+                "each completed in ~w microseconds~n",
+                [timer:now_diff(os:timestamp(), SW)])
+        end,
+        lists:seq(1, 8)),
     testutil:check_forobject(Book1, TestObject),
-    Total = lists:foldl(fun(X, Acc) ->
-                                IdxF = "idx" ++ integer_to_list(X) ++ "_bin",
-                                T = count_termsonindex(BucketBin,
-                                                        IdxF,
-                                                        Book1,
-                                                        ?KEY_ONLY),
-                                io:format("~w terms found on index ~s~n",
-                                            [T, IdxF]),
-                                Acc + T
-                                end,
-                            0,
-                            lists:seq(1, 8)),
-    ok = case Total of
-                640000 ->
-                    ok
+    Total =
+        lists:foldl(
+            fun(X, Acc) ->
+                IdxF = "idx" ++ integer_to_list(X) ++ "_bin",
+                T =
+                    count_termsonindex(
+                        BucketBin, list_to_binary(IdxF), Book1, ?KEY_ONLY),
+                io:format("~w terms found on index ~s~n", [T, IdxF]),
+                Acc + T
             end,
-    Index1Count = count_termsonindex(BucketBin,
-                                        "idx1_bin",
-                                        Book1,
-                                        ?KEY_ONLY),
+            0,
+            lists:seq(1, 8)),
+    true = Total == 640000,
+    Index1Count =
+        count_termsonindex(
+            BucketBin, <<"idx1_bin">>, Book1, ?KEY_ONLY),
     ok = leveled_bookie:book_close(Book1),
-    {ok, Book2} = leveled_bookie:book_start(RootPath,
-                                            1000,
-                                            50000000,
-                                            testutil:sync_strategy()),
-    Index1Count = count_termsonindex(BucketBin,
-                                        "idx1_bin",
-                                        Book2,
-                                        ?KEY_ONLY),
+    {ok, Book2} =
+        leveled_bookie:book_start(
+            RootPath, 1000, 50000000, testutil:sync_strategy()),
+    Index1Count =
+        count_termsonindex(
+            BucketBin, <<"idx1_bin">>, Book2, ?KEY_ONLY),
     NameList = testutil:name_list(),
-    TotalNameByName = lists:foldl(fun({_X, Name}, Acc) ->
-                                        {ok, Regex} = re:compile("[0-9]+" ++
-                                                                    Name),
-                                        SW = os:timestamp(),
-                                        T = count_termsonindex(BucketBin,
-                                                                "idx1_bin",
-                                                                Book2,
-                                                                {false,
-                                                                    Regex}),
-                                        TD = timer:now_diff(os:timestamp(),
-                                                                SW),
-                                        io:format("~w terms found on " ++
-                                                    "index idx1 with a " ++
-                                                    "regex in ~w " ++
-                                                    "microseconds~n",
-                                                    [T, TD]),
-                                        Acc + T
-                                        end,
-                                    0,
-                                    NameList),
-    ok = case TotalNameByName of
-                Index1Count ->
-                    ok
+    TotalNameByName =
+        lists:foldl(
+            fun({_X, Name}, Acc) ->
+                {ok, Regex} =
+                    re:compile("[0-9]+" ++ Name),
+                SW = os:timestamp(),
+                T =
+                    count_termsonindex(
+                        BucketBin,
+                        list_to_binary("idx1_bin"),
+                        Book2,
+                        {false, Regex}),
+                TD = timer:now_diff(os:timestamp(), SW),
+                io:format(
+                    "~w terms found on  index idx1 with a "
+                    "regex in ~w  microseconds~n",
+                    [T, TD]),
+                Acc + T
             end,
+            0,
+            NameList),
+    true = TotalNameByName == Index1Count,
     {ok, RegMia} = re:compile("[0-9]+Mia"),
     Query1 = {index_query,
                 BucketBin,
                 {fun testutil:foldkeysfun/3, []},
-                {"idx2_bin", "2000", "2000|"},
+                {<<"idx2_bin">>, <<"2000">>, <<"2000|">>},
                 {false, RegMia}},
     {async,
         Mia2KFolder1} = leveled_bookie:book_returnfolder(Book2, Query1),
@@ -682,7 +672,7 @@ query_count(_Config) ->
     Query2 = {index_query,
                 BucketBin,
                 {fun testutil:foldkeysfun/3, []},
-                {"idx2_bin", "2000", "2001"},
+                {<<"idx2_bin">>, <<"2000">>, <<"2001">>},
                 {true, undefined}},
     {async,
         Mia2KFolder2} = leveled_bookie:book_returnfolder(Book2, Query2),
@@ -705,7 +695,7 @@ query_count(_Config) ->
     Query3 = {index_query,
                 BucketBin,
                 {fun testutil:foldkeysfun/3, []},
-                {"idx2_bin", "1980", "2100"},
+                {<<"idx2_bin">>, <<"1980">>, <<"2100">>},
                 {false, RxMia2K}},
     {async,
         Mia2KFolder3} = leveled_bookie:book_returnfolder(Book2, Query3),
@@ -713,26 +703,26 @@ query_count(_Config) ->
     
     V9 = testutil:get_compressiblevalue(),
     Indexes9 = testutil:get_randomindexes_generator(8),
-    [{_RN, Obj9, Spc9}] = testutil:generate_objects(1,
-                                                    binary_uuid,
-                                                    [],
-                                                    V9,
-                                                    Indexes9),
+    [{_RN, Obj9, Spc9}] =
+        testutil:generate_objects(
+            1, binary_uuid, [], V9, Indexes9),
     ok = testutil:book_riakput(Book2, Obj9, Spc9),
-    R9 = lists:map(fun({add, IdxF, IdxT}) ->
-                        Q = {index_query,
-                                BucketBin,
-                                {fun testutil:foldkeysfun/3, []},
-                                {IdxF, IdxT, IdxT},
-                                ?KEY_ONLY},
-                        R = leveled_bookie:book_returnfolder(Book2, Q),
-                        {async, Fldr} = R,
-                        case length(Fldr()) of
-                            X when X > 0 ->
-                                {IdxF, IdxT, X}
-                        end
-                        end,
-                    Spc9),
+    R9 =
+        lists:map(
+            fun({add, IdxF, IdxT}) ->
+                Q = {index_query,
+                        BucketBin,
+                        {fun testutil:foldkeysfun/3, []},
+                        {IdxF, IdxT, IdxT},
+                        ?KEY_ONLY},
+                R = leveled_bookie:book_returnfolder(Book2, Q),
+                {async, Fldr} = R,
+                case length(Fldr()) of
+                    X when X > 0 ->
+                        {IdxF, IdxT, X}
+                end
+            end,
+            Spc9),
     Spc9Del = lists:map(fun({add, IdxF, IdxT}) -> {remove, IdxF, IdxT} end,
                         Spc9),
     ok = testutil:book_riakput(Book2, Obj9, Spc9Del),
@@ -751,44 +741,44 @@ query_count(_Config) ->
                         end,
                     R9),
     ok = leveled_bookie:book_close(Book2),
-    {ok, Book3} = leveled_bookie:book_start(RootPath,
-                                            2000,
-                                            50000000,
-                                            testutil:sync_strategy()),
-    lists:foreach(fun({IdxF, IdxT, X}) ->
-                        Q = {index_query,
-                                BucketBin,
-                                {fun testutil:foldkeysfun/3, []},
-                                {IdxF, IdxT, IdxT},
-                                ?KEY_ONLY},
-                        R = leveled_bookie:book_returnfolder(Book3, Q),
-                        {async, Fldr} = R,
-                        case length(Fldr()) of
-                            Y ->
-                                Y = X - 1
-                        end
-                        end,
-                    R9),
+    {ok, Book3} =
+        leveled_bookie:book_start(
+            RootPath, 2000, 50000000, testutil:sync_strategy()),
+    lists:foreach(
+        fun({IdxF, IdxT, X}) ->
+            Q = {index_query,
+                    BucketBin,
+                    {fun testutil:foldkeysfun/3, []},
+                    {IdxF, IdxT, IdxT},
+                    ?KEY_ONLY},
+            R = leveled_bookie:book_returnfolder(Book3, Q),
+            {async, Fldr} = R,
+            case length(Fldr()) of
+                Y ->
+                    Y = X - 1
+            end
+        end,
+        R9),
     ok = testutil:book_riakput(Book3, Obj9, Spc9),
     ok = leveled_bookie:book_close(Book3),
-    {ok, Book4} = leveled_bookie:book_start(RootPath,
-                                            2000,
-                                            50000000,
-                                            testutil:sync_strategy()),
-    lists:foreach(fun({IdxF, IdxT, X}) ->
-                        Q = {index_query,
-                                BucketBin,
-                                {fun testutil:foldkeysfun/3, []},
-                                {IdxF, IdxT, IdxT},
-                                ?KEY_ONLY},
-                        R = leveled_bookie:book_returnfolder(Book4, Q),
-                        {async, Fldr} = R,
-                        case length(Fldr()) of
-                            X ->
-                                ok
-                        end
-                        end,
-                    R9),
+    {ok, Book4} =
+        leveled_bookie:book_start(
+            RootPath, 2000, 50000000, testutil:sync_strategy()),
+    lists:foreach(
+        fun({IdxF, IdxT, X}) ->
+            Q = {index_query,
+                    BucketBin,
+                    {fun testutil:foldkeysfun/3, []},
+                    {IdxF, IdxT, IdxT},
+                    ?KEY_ONLY},
+            R = leveled_bookie:book_returnfolder(Book4, Q),
+            {async, Fldr} = R,
+            case length(Fldr()) of
+                X ->
+                    ok
+            end
+        end,
+        R9),
     testutil:check_forobject(Book4, TestObject),
     
     FoldBucketsFun = fun(B, Acc) -> sets:add_element(B, Acc) end,
@@ -803,24 +793,15 @@ query_count(_Config) ->
     
     true = sets:size(BucketSet1) == 1, 
     
-    ObjList10A = testutil:generate_objects(5000,
-                                            binary_uuid,
-                                            [],
-                                            V9,
-                                            Indexes9,
-                                            "BucketA"),
-    ObjList10B = testutil:generate_objects(5000,
-                                            binary_uuid,
-                                            [],
-                                            V9,
-                                            Indexes9,
-                                            "BucketB"),
-    ObjList10C = testutil:generate_objects(5000,
-                                            binary_uuid,
-                                            [],
-                                            V9,
-                                            Indexes9,
-                                            "BucketC"),
+    ObjList10A =
+        testutil:generate_objects(
+            5000, binary_uuid, [], V9, Indexes9, "BucketA"),
+    ObjList10B =
+        testutil:generate_objects(
+            5000, binary_uuid, [], V9, Indexes9, "BucketB"),
+    ObjList10C =
+        testutil:generate_objects(
+            5000, binary_uuid, [], V9, Indexes9, "BucketC"),
     testutil:riakload(Book4, ObjList10A),
     testutil:riakload(Book4, ObjList10B),
     testutil:riakload(Book4, ObjList10C),
@@ -847,31 +828,30 @@ query_count(_Config) ->
     ok = leveled_bookie:book_close(Book5),
     
     testutil:reset_filestructure().
-    
 
 
 count_termsonindex(Bucket, IdxField, Book, QType) ->
-    lists:foldl(fun(X, Acc) ->
-                        SW = os:timestamp(),
-                        ST = integer_to_list(X),
-                        ET = ST ++ "|",
-                        Q = {index_query,
-                                Bucket,
-                                {fun testutil:foldkeysfun/3, []},
-                                {IdxField, ST, ET},
-                                QType},
-                        R = leveled_bookie:book_returnfolder(Book, Q),
-                        {async, Folder} = R,
-                        Items = length(Folder()),
-                        io:format("2i query from term ~s on index ~s took " ++
-                                        "~w microseconds~n",
-                                    [ST,
-                                        IdxField,
-                                        timer:now_diff(os:timestamp(), SW)]),
-                        Acc + Items
-                        end,
-                    0,
-                    lists:seq(190, 221)).
+    lists:foldl(
+        fun(X, Acc) ->
+            SW = os:timestamp(),
+            ST = list_to_binary(integer_to_list(X)),
+            Pipe = <<"|">>,
+            ET = <<ST/binary, Pipe/binary>>,
+            Q = {index_query,
+                    Bucket,
+                    {fun testutil:foldkeysfun/3, []},
+                    {IdxField, ST, ET},
+                    QType},
+            R = leveled_bookie:book_returnfolder(Book, Q),
+            {async, Folder} = R,
+            Items = length(Folder()),
+            io:format(
+                "2i query from term ~s on index ~s took ~w microseconds~n",
+                [ST, IdxField, timer:now_diff(os:timestamp(), SW)]),
+            Acc + Items
+        end,
+        0,
+        lists:seq(190, 221)).
 
 multibucket_fold(_Config) ->
     RootPath = testutil:reset_filestructure(),

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -10,29 +10,16 @@
 -define(MINI_QUERY_DIVISOR, 8).
 -define(RGEX_QUERY_DIVISOR, 32).
 
--ifdef(perf_full).
-    all() -> [riak_fullperf].
--else.
-    -ifdef(perf_mini).
-        all() -> [riak_miniperf].
-    -else.
-        -ifdef(perf_prof).
-            all() -> [riak_profileperf].
-        -else.
-            all() -> [riak_ctperf].
-        -endif.
-    -endif.
+-ifndef(performance).
+  -define(performance, riak_ctperf).
 -endif.
+all() -> [?performance].
 
--ifdef(perf_prof).
-    -if(?OTP_RELEASE >= 24).
-        -define(ACCOUNTING, true).
-    -else.
-        % Requires map functions from OTP 24
-        -define(ACCOUNTING, false).
-    -endif.
+-if(?performance == riak_profileperf andalso ?OTP_RELEASE >= 24).
+   % Requires map functions from OTP 24
+   -define(ACCOUNTING, true).
 -else.
-    -define(ACCOUNTING, false).
+   -define(ACCOUNTING, false).
 -endif.
 
 suite() -> [{timetrap, {hours, 16}}].

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -36,11 +36,11 @@ riak_fullperf(ObjSize, PM, LC) ->
     output_result(R2B),
     R2C = riak_load_tester(Bucket, 2000000, ObjSize, [], PM, LC),
     output_result(R2C),
-    R5A = riak_load_tester(Bucket, 4000000, ObjSize, [], PM, LC),
+    R5A = riak_load_tester(Bucket, 5000000, ObjSize, [], PM, LC),
     output_result(R5A),
-    R5B = riak_load_tester(Bucket, 4000000, ObjSize, [], PM, LC),
+    R5B = riak_load_tester(Bucket, 5000000, ObjSize, [], PM, LC),
     output_result(R5B),
-    R10 = riak_load_tester(Bucket, 6000000, ObjSize, [], PM, LC),
+    R10 = riak_load_tester(Bucket, 8000000, ObjSize, [], PM, LC),
     output_result(R10)
     .
 
@@ -352,15 +352,6 @@ rotate_chunk(Bookie, Bucket, KeyCount, ObjSize) ->
             end),
     TC div 1000.
 
-load_chunk(Bookie, CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
-    ct:log(?INFO, "Generating and loading ObjList ~w", [Chunk]),
-    ObjList =
-        generate_chunk(CountPerList, ObjSize, IndexGenFun, Bucket, Chunk),
-    {TC, ok} = timer:tc(fun() -> testutil:riakload(Bookie, ObjList) end),
-    garbage_collect(),
-    timer:sleep(2000),
-    TC.
-
 generate_chunk(CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
     testutil:generate_objects(
         CountPerList, 
@@ -369,6 +360,49 @@ generate_chunk(CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
         IndexGenFun(Chunk),
         Bucket
     ).
+
+load_chunk(Bookie, CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
+    ct:log(?INFO, "Generating and loading ObjList ~w", [Chunk]),
+    time_load_chunk(
+        Bookie,
+        {Bucket, base64:encode(leveled_rand:rand_bytes(ObjSize)), IndexGenFun(Chunk)},
+        (Chunk - 1) * CountPerList + 1,
+        Chunk * CountPerList,
+        0
+    ).
+
+time_load_chunk(_Bookie, _ObjDetails, KeyNumber, TopKey, TotalTime) when KeyNumber > TopKey ->
+    garbage_collect(),
+    timer:sleep(2000),
+    TotalTime;
+time_load_chunk(Bookie, {Bucket, Value, IndexGen}, KeyNumber, TopKey, TotalTime) ->
+    ThisProcess = self(),
+    spawn(
+        fun() ->
+            {RiakObj, IndexSpecs} =
+                testutil:set_object(
+                    Bucket, testutil:fixed_bin_key(KeyNumber), Value, IndexGen, []),
+            {TC, R} =
+                timer:tc(
+                    testutil, book_riakput, [Bookie, RiakObj, IndexSpecs]
+                ),
+            case R of
+                ok -> ok;
+                pause -> timer:sleep(40)
+            end,
+            ThisProcess ! TC
+        end
+    ),
+    receive
+        PutTime ->
+            time_load_chunk(
+                Bookie, 
+                {Bucket, Value, IndexGen},
+                KeyNumber + 1,
+                TopKey,
+                TotalTime + PutTime)
+    end.
+            
 
 size_estimate_tester(Bookie) ->
     %% Data size test - calculate data size, then estimate data size

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -756,11 +756,7 @@ memory_tracking(Phase, Timeout, {TAcc, PAcc, BAcc}, Loops) ->
             TAvg = (T + TAcc) div ((Loops + 1) * 1000000),
             PAvg = (P + PAcc) div ((Loops + 1) * 1000000),
             BAvg = (B + BAcc) div ((Loops + 1) * 1000000),
-            io:format(
-                user,
-                "~nFor ~w memory stats: total ~wMB process ~wMB binary ~wMB~n",
-                [Phase, TAvg, PAvg, BAvg]
-            ),
+            print_memory_stats(Phase, TAvg, PAvg, BAvg),
             Caller ! {TAvg, PAvg, BAvg}
     after Timeout ->
         {T, P, B} = memory_usage(),
@@ -768,6 +764,18 @@ memory_tracking(Phase, Timeout, {TAcc, PAcc, BAcc}, Loops) ->
             Phase, Timeout, {TAcc + T, PAcc + P, BAcc + B}, Loops + 1)
     end.
 
+
+-if(?performance == riak_ctperf).
+print_memory_stats(_Phase, _TAvg, _PAvg, _BAvg) ->
+    ok.
+-else.
+print_memory_stats(Phase, TAvg, PAvg, BAvg) ->
+    io:format(
+        user,
+        "~nFor ~w memory stats: total ~wMB process ~wMB binary ~wMB~n",
+        [Phase, TAvg, PAvg, BAvg]
+    ).
+-endif.
 
 dummy_accountant() ->
     spawn(fun() -> receive {stop, Caller} -> Caller ! ok end end).

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -483,12 +483,14 @@ rotate_wipe_compact(Strategy1, Strategy2) ->
     {ok, Book3} = leveled_bookie:book_start(BookOptsAlt),
 
     {KSpcL2, _V2} = testutil:put_indexed_objects(Book3, "AltBucket6", 3000),
-    Q2 = fun(RT) -> {index_query,
-                        "AltBucket6",
-                        {fun testutil:foldkeysfun/3, []},
-                        {"idx1_bin", "#", "|"},
-                        {RT, undefined}}
-                    end,
+    Q2 =
+        fun(RT) -> 
+            {index_query,
+                "AltBucket6",
+                {fun testutil:foldkeysfun/3, []},
+                {<<"idx1_bin">>, <<"#">>, <<"|">>},
+                {RT, undefined}}
+        end,
     {async, KFolder2A} = leveled_bookie:book_returnfolder(Book3, Q2(false)),
     KeyList2A = lists:usort(KFolder2A()),
     true = length(KeyList2A) == 3000,
@@ -629,12 +631,14 @@ recovr_strategy(_Config) ->
                         true = VCH == VCG
                         end,
                     lists:nthtail(6400, AllSpcL)),
-    Q = fun(RT) -> {index_query,
-                        "Bucket6",
-                        {fun testutil:foldkeysfun/3, []},
-                        {"idx1_bin", "#", "|"},
-                        {RT, undefined}}
-                    end,
+    Q =
+        fun(RT) ->
+            {index_query,
+                "Bucket6",
+                {fun testutil:foldkeysfun/3, []},
+                {<<"idx1_bin">>, <<"#">>, <<"|">>},
+                {RT, undefined}}
+        end,
     {async, TFolder} = leveled_bookie:book_returnfolder(Book1, Q(true)),
     KeyTermList = TFolder(),
     {async, KFolder} = leveled_bookie:book_returnfolder(Book1, Q(false)),
@@ -660,12 +664,14 @@ recovr_strategy(_Config) ->
     KeyList2 = lists:usort(KFolder2()),
     true = length(KeyList2) == 6400,
 
-    Q2 = fun(RT) -> {index_query,
-                        "AltBucket6",
-                        {fun testutil:foldkeysfun/3, []},
-                        {"idx1_bin", "#", "|"},
-                        {RT, undefined}}
-                    end,
+    Q2 =
+        fun(RT) ->
+            {index_query,
+                "AltBucket6",
+                {fun testutil:foldkeysfun/3, []},
+                {<<"idx1_bin">>, <<"#">>, <<"|">>},
+                {RT, undefined}}
+        end,
     {async, KFolder2A} = leveled_bookie:book_returnfolder(Book2, Q2(false)),
     KeyList2A = lists:usort(KFolder2A()),
     true = length(KeyList2A) == 3000,

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -68,7 +68,7 @@
             compact_and_wait/1]).
 
 -define(RETURN_TERMS, {true, undefined}).
--define(SLOWOFFER_DELAY, 10).
+-define(SLOWOFFER_DELAY, 40).
 -define(V1_VERS, 1).
 -define(MAGIC, 53). % riak_kv -> riak_object
 -define(MD_VTAG,     <<"X-Riak-VTag">>).
@@ -829,8 +829,11 @@ put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V) ->
                     % loops if RemoveOld2i is false
                     R =
                         case book_riakput(Book, O, DeltaSpecs) of
-                            ok -> ok;
-                            pause -> timer:sleep(?SLOWOFFER_DELAY)
+                            ok ->
+                                ok;
+                            pause ->
+                                timer:sleep(?SLOWOFFER_DELAY),
+                                pause
                         end,
                     ThisProcess ! {R, DeltaSpecs}
                 end,

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -691,21 +691,24 @@ load_objects(ChunkSize, GenList, Bookie, TestObject, Generator, SubListL) ->
 
 
 get_randomindexes_generator(Count) ->
-    Generator = fun() ->
-            lists:map(fun(X) ->
-                                {add,
-                                    "idx" ++ integer_to_list(X) ++ "_bin",
-                                    get_randomdate() ++ get_randomname()} end,
-                        lists:seq(1, Count))
+    Generator =
+        fun() ->
+            lists:map(
+                fun(X) ->
+                    {add,
+                        list_to_binary("idx" ++ integer_to_list(X) ++ "_bin"),
+                        list_to_binary(get_randomdate() ++ get_randomname())}
+                end,
+                lists:seq(1, Count))
         end,
     Generator.
 
 name_list() ->
     [{1, "Sophia"}, {2, "Emma"}, {3, "Olivia"}, {4, "Ava"},
-            {5, "Isabella"}, {6, "Mia"}, {7, "Zoe"}, {8, "Lily"},
-            {9, "Emily"}, {10, "Madelyn"}, {11, "Madison"}, {12, "Chloe"},
-            {13, "Charlotte"}, {14, "Aubrey"}, {15, "Avery"},
-            {16, "Abigail"}].
+        {5, "Isabella"}, {6, "Mia"}, {7, "Zoe"}, {8, "Lily"},
+        {9, "Emily"}, {10, "Madelyn"}, {11, "Madison"}, {12, "Chloe"},
+        {13, "Charlotte"}, {14, "Aubrey"}, {15, "Avery"},
+        {16, "Abigail"}].
 
 get_randomname() ->
     NameList = name_list(),
@@ -738,7 +741,7 @@ check_indexed_objects(Book, B, KSpecL, V) ->
             fun({K, Spc}) ->
                 {ok, O} = book_riakget(Book, B, K),
                 V = testutil:get_value(O),
-                {add, "idx1_bin", IdxVal} = lists:keyfind(add, 1, Spc),
+                {add, <<"idx1_bin">>, IdxVal} = lists:keyfind(add, 1, Spc),
                 {IdxVal, K}
             end,
             KSpecL),
@@ -749,7 +752,7 @@ check_indexed_objects(Book, B, KSpecL, V) ->
             {index_query,
                 B,
                 {fun foldkeysfun/3, []},
-                {"idx1_bin", "0", "|"},
+                {<<"idx1_bin">>, <<"0">>, <<"|">>},
                 ?RETURN_TERMS}),
     SW = os:timestamp(),
     {async, Fldr} = R,
@@ -796,11 +799,12 @@ put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i) ->
     put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V).
 
 put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V) ->
+    SW = os:timestamp(),
     IndexGen = get_randomindexes_generator(1),
-    
+    ThisProcess = self(),
     FindAdditionFun = fun(SpcItem) -> element(1, SpcItem) == add end,
     MapFun = 
-        fun({K, Spc}) ->
+        fun({K, Spc}, Acc) ->
             OldSpecs = lists:filter(FindAdditionFun, Spc),
             {RemoveSpc, AddSpc} =
                 case RemoveOld2i of
@@ -809,26 +813,42 @@ put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V) ->
                     false ->
                         {[], OldSpecs}
                 end,
-            {O, DeltaSpecs} =
-                set_object(Bucket, K, V,
-                            IndexGen, RemoveSpc, AddSpc),
-            % DeltaSpecs should be new indexes added, and any old indexes which
-            % have been removed by this change where RemoveOld2i is true.
-            %
-            % The actual indexes within the object should reflect any history
-            % of indexes i.e. when RemoveOld2i is false.
-            %
-            % The [{Key, SpecL}] returned should accrue additions over loops if
-            % RemoveOld2i is false
-            case book_riakput(Book, O, DeltaSpecs) of
-                ok -> ok;
-                pause -> timer:sleep(?SLOWOFFER_DELAY)
-            end,
+            PutFun =
+                fun() ->
+                    {O, DeltaSpecs} =
+                        set_object(
+                            Bucket, K, V, IndexGen, RemoveSpc, AddSpc),
+                    % DeltaSpecs should be new indexes added, and any old
+                    % indexes which have been removed by this change where
+                    % RemoveOld2i is true.
+                    %
+                    % The actual indexes within the object should reflect any
+                    % history of indexes i.e. when RemoveOld2i is false.
+                    %
+                    % The [{Key, SpecL}] returned should accrue additions over
+                    % loops if RemoveOld2i is false
+                    R =
+                        case book_riakput(Book, O, DeltaSpecs) of
+                            ok -> ok;
+                            pause -> timer:sleep(?SLOWOFFER_DELAY)
+                        end,
+                    ThisProcess ! {R, DeltaSpecs}
+                end,
+            spawn(PutFun),
+            AccOut =
+                receive
+                    {ok, NewSpecs} -> Acc;
+                    {pause, NewSpecs} -> Acc + 1
+                end,
             % Note that order in the SpecL is important, as
             % check_indexed_objects, needs to find the latest item added
-            {K, DeltaSpecs ++ AddSpc}
+            {{K, NewSpecs ++ AddSpc}, AccOut}
         end,
-    RplKSpecL = lists:map(MapFun, KSpecL),
+    {RplKSpecL, Pauses} = lists:mapfoldl(MapFun, 0, KSpecL),
+    io:format(
+        "Altering ~w objects took ~w ms with ~w pauses~n",
+        [length(KSpecL), timer:now_diff(os:timestamp(), SW) div 1000, Pauses]
+    ),
     {RplKSpecL, V}.
 
 rotating_object_check(RootPath, B, NumberOfObjects) ->

--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -378,10 +378,13 @@ index_compare(_Config) ->
     GetTicTacTreeFun =
         fun(X, Bookie) ->
             SW = os:timestamp(),
-            ST = "!",
-            ET = "|",
+            ST = <<"!">>,
+            ET = <<"|">>,
             Q = {tictactree_idx,
-                    {BucketBin, "idx" ++ integer_to_list(X) ++ "_bin", ST, ET},
+                    {BucketBin,
+                        list_to_binary("idx" ++ integer_to_list(X) ++ "_bin"),
+                        ST,
+                        ET},
                     TreeSize,
                     fun(_B, _K) -> accumulate end},
             {async, Folder} = leveled_bookie:book_returnfolder(Bookie, Q),
@@ -442,12 +445,14 @@ index_compare(_Config) ->
     true = DL2_0 == [],
     true = length(DL2_1) > 100,
 
-    IdxSpc = {add, "idx2_bin", "zz999"},
-    {TestObj, TestSpc} = testutil:generate_testobject(BucketBin,
-                                                        term_to_binary("K9.Z"),
-                                                        "Value1",
-                                                        [IdxSpc],
-                                                        [{"MDK1", "MDV1"}]),
+    IdxSpc = {add, <<"idx2_bin">>, <<"zz999">>},
+    {TestObj, TestSpc} =
+        testutil:generate_testobject(
+            BucketBin,
+            term_to_binary("K9.Z"),
+            "Value1",
+            [IdxSpc],
+            [{"MDK1", "MDV1"}]),
     ok = testutil:book_riakput(Book2C, TestObj, TestSpc),
     testutil:check_forobject(Book2C, TestObj),
 
@@ -457,25 +462,30 @@ index_compare(_Config) ->
     TicTacTree3_P3 = GetTicTacTreeFun(2, Book2D),
 
     % Merge the tree across the partitions
-    TicTacTree3_Joined = lists:foldl(fun leveled_tictac:merge_trees/2,
-                                        TicTacTree3_P1,
-                                        [TicTacTree3_P2, TicTacTree3_P3]),
+    TicTacTree3_Joined =
+        lists:foldl(
+            fun leveled_tictac:merge_trees/2,
+            TicTacTree3_P1,
+            [TicTacTree3_P2, TicTacTree3_P3]),
 
     % Find all keys index, and then just the last key
     IdxQ1 = {index_query,
                 BucketBin,
                 {fun testutil:foldkeysfun/3, []},
-                {"idx2_bin", "zz", "zz|"},
+                {<<"idx2_bin">>, <<"zz">>, <<"zz|">>},
                 {true, undefined}},
     {async, IdxFolder1} = leveled_bookie:book_returnfolder(Book2C, IdxQ1),
     true = IdxFolder1() >= 1,
 
-    DL_3to2B = leveled_tictac:find_dirtyleaves(TicTacTree2_P1,
-                                                TicTacTree3_P1),
-    DL_3to2C = leveled_tictac:find_dirtyleaves(TicTacTree2_P2,
-                                                TicTacTree3_P2),
-    DL_3to2D = leveled_tictac:find_dirtyleaves(TicTacTree2_P3,
-                                                TicTacTree3_P3),
+    DL_3to2B =
+        leveled_tictac:find_dirtyleaves(
+            TicTacTree2_P1, TicTacTree3_P1),
+    DL_3to2C =
+        leveled_tictac:find_dirtyleaves(
+            TicTacTree2_P2, TicTacTree3_P2),
+    DL_3to2D =
+        leveled_tictac:find_dirtyleaves(
+            TicTacTree2_P3, TicTacTree3_P3),
     io:format("Individual tree comparison found dirty leaves of ~w ~w ~w~n",
                 [DL_3to2B, DL_3to2C, DL_3to2D]),
 
@@ -509,7 +519,7 @@ index_compare(_Config) ->
     MismatchQ = {index_query,
                     BucketBin,
                     {FoldKeysIndexQFun, []},
-                    {"idx2_bin", "!", "|"},
+                    {<<"idx2_bin">>, <<"!">>, <<"|">>},
                     {true, undefined}},
     {async, MMFldr_2A} = leveled_bookie:book_returnfolder(Book2A, MismatchQ),
     {async, MMFldr_2B} = leveled_bookie:book_returnfolder(Book2B, MismatchQ),
@@ -531,7 +541,7 @@ index_compare(_Config) ->
     io:format("Differences between lists ~w~n", [Diffs]),
 
     % The actual difference is discovered
-    true = lists:member({"zz999", term_to_binary("K9.Z")}, Diffs),
+    true = lists:member({<<"zz999">>, term_to_binary("K9.Z")}, Diffs),
     % Without discovering too many others
     true = length(Diffs) < 20,
 


### PR DESCRIPTION
This is v6 of the perf_SUITE tests.  The test adds a complex index entry to every object, and then adds a new test phase to test regex queries.

There are three profiles added so the full, mini and profiling versions of perf_SUITE can be run without having to edit the file itself:

e.g. ./rebar3 as perf_mini do ct --suite=test/end_to_end/perf_SUITE

When testing as `perf_prof` summarised versions of the eprof results are now printed to screen.

The volume of keys within the full test suite has been dropped ... just to make life easier so that test run times are not excessively increase by the new features.