### PR TITLE
Switch to re2 library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cover
 cover_*
 .eqc-info
 leveled_data/*
+compile_commands.json

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,8 @@
 
 {deps, [
   {lz4, ".*", {git, "https://github.com/nhs-riak/erlang-lz4", {branch, "nhse-develop"}}},
-  {zstd, ".*", {git, "https://github.com/nhs-riak/zstd-erlang", {branch, "nhse-develop"}}}
+  {zstd, ".*", {git, "https://github.com/nhs-riak/zstd-erlang", {branch, "nhse-develop"}}},
+  {re2, ".*", {git, "https://github.com/nhs-riak/re2", {branch, "nhse-develop"}}}
         ]}.
 
 {ct_opts, [{dir, ["test/end_to_end"]}]}.

--- a/src/leveled.app.src
+++ b/src/leveled.app.src
@@ -6,6 +6,7 @@
   {applications, [
                   lz4,
                   zstd,
+                  re2,
                   kernel,
                   stdlib
                  ]},

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -2707,7 +2707,7 @@ ttl_test() ->
     KeyList = IndexFolder(),
     ?assertMatch(20, length(KeyList)),
 
-    {ok, Regex} = re:compile("f8"),
+    {ok, Regex} = leveled_util:regex_compile("f8"),
     {async,
         IndexFolderTR} = book_returnfolder(Bookie1,
                                             {index_query,

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -304,7 +304,7 @@ accumulate_index({true, undefined}, FoldKeysFun) ->
     end;
 accumulate_index({AddTerm, TermRegex}, FoldKeysFun) ->
     fun({?IDX_TAG, Bucket, {_IdxFld, IdxValue}, ObjKey}, _Value, Acc) ->
-        case re:run(IdxValue, TermRegex) of
+        case leveled_util:regex_run(IdxValue, TermRegex) of
             nomatch ->
                 Acc;
             _ ->

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -63,7 +63,7 @@
 -type acc_fun()
     :: fun((leveled_codec:key(), any(), foldacc()) -> foldacc()).
 -type mp()
-    :: {re_pattern, term(), term(), term(), term()}.
+    :: any().
 
 -export_type([acc_fun/0, mp/0]).
 
@@ -681,7 +681,7 @@ accumulate_keys(FoldKeysFun, undefined) ->
 accumulate_keys(FoldKeysFun, TermRegex) ->
     fun(Key, _Value, Acc) ->
         {B, K} = leveled_codec:from_ledgerkey(Key),
-        case re:run(K, TermRegex) of
+        case leveled_util:regex_run(K, TermRegex) of
             nomatch ->
                 Acc;
             _ ->

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -10,7 +10,10 @@
             integer_time/1,
             magic_hash/1,
             t2b/1,
-            safe_rename/4]).
+            safe_rename/4,
+            regex_run/2,
+            regex_compile/1
+        ]).
 
 -define(WRITE_OPS, [binary, raw, read, write]).
 
@@ -39,6 +42,15 @@ integer_time(TS) ->
     DT = calendar:now_to_universal_time(TS),
     calendar:datetime_to_gregorian_seconds(DT).
 
+-spec regex_run(
+    iodata(), any()) ->
+        match | nomatch | {match, list()} | {error, atom()}.
+regex_run(Subject, CompiledRegex) ->
+    re2:run(Subject, CompiledRegex).
+
+-spec regex_compile(iodata()) -> any().
+regex_compile(PlainRegex) ->
+    re2:compile(PlainRegex).
 
 -spec magic_hash(any()) -> 0..16#FFFFFFFF.
 %% @doc 

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -45,10 +45,12 @@ integer_time(TS) ->
 -spec regex_run(
     iodata(), any()) ->
         match | nomatch | {match, list()} | {error, atom()}.
-regex_run(Subject, CompiledRegex) ->
-    re2:run(Subject, CompiledRegex).
+regex_run(Subject, CompiledRE2) when is_reference(CompiledRE2) ->
+    re2:run(Subject, CompiledRE2);
+regex_run(Subject, CompiledPCRE) ->
+    re:run(Subject, CompiledPCRE).
 
--spec regex_compile(iodata()) -> any().
+-spec regex_compile(iodata()) -> reference().
 regex_compile(PlainRegex) ->
     re2:compile(PlainRegex).
 

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -698,9 +698,18 @@ query_count(_Config) ->
                 {fun testutil:foldkeysfun/3, []},
                 {<<"idx2_bin">>, <<"1980">>, <<"2100">>},
                 {false, RxMia2K}},
-    {async,
-        Mia2KFolder3} = leveled_bookie:book_returnfolder(Book2, Query3),
+    {async,  Mia2KFolder3} = leveled_bookie:book_returnfolder(Book2, Query3),
     Mia2000Count1 = length(Mia2KFolder3()),
+    {ok, RxMia2KPCRE} = re:compile("^2000[0-9]+Mia"),
+    Query3PCRE =
+        {index_query,
+            BucketBin,
+            {fun testutil:foldkeysfun/3, []},
+            {<<"idx2_bin">>, <<"1980">>, <<"2100">>},
+            {false, RxMia2KPCRE}},
+    {async, Mia2KFolder3PCRE} =
+        leveled_bookie:book_returnfolder(Book2, Query3PCRE),
+    Mia2000Count1 = length(Mia2KFolder3PCRE()),
     
     V9 = testutil:get_compressiblevalue(),
     Indexes9 = testutil:get_randomindexes_generator(8),

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -522,7 +522,7 @@ random_people_queries(Bookie, Bucket, IndexesReturned) ->
             },
             %% born in the 70s with Willow as a given name
             {ok, TermRegex} =
-                re:compile(
+                leveled_util:regex_compile(
                     "[^\\|]*\\|197[0-9]{5}\\|[^\\|]*\\|[^\\|]*#Willow[^\\|]*\\|[^\\|]*#LS[^\\|]*"
                 ),
             FoldKeysFun =  fun(_B, _K, Cnt) -> Cnt + 1 end,

--- a/test/end_to_end/riak_SUITE.erl
+++ b/test/end_to_end/riak_SUITE.erl
@@ -1419,8 +1419,8 @@ dollar_key_index(_Config) ->
     io:format("Length of Result of folder ~w~n", [ResLen]),
     true = 657 == ResLen,
 
-    {ok, REMatch} = re:compile("K.y"),
-    {ok, REMiss} = re:compile("key"),
+    {ok, REMatch} = leveled_util:regex_compile("K.y"),
+    {ok, REMiss} = leveled_util:regex_compile("key"),
     
     {async, FolderREMatch} = 
         leveled_bookie:book_keylist(Bookie1,
@@ -1527,9 +1527,9 @@ dollar_bucket_index(_Config) ->
     
     {<<"Bucket2">>, SampleKey} = lists:nth(100, Results),
     UUID = "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}",
-    {ok, RESingleMatch} = re:compile(SampleKey),
-    {ok, REAllMatch} = re:compile(UUID),
-    {ok, REMiss} = re:compile("no_key"),
+    {ok, RESingleMatch} = leveled_util:regex_compile(SampleKey),
+    {ok, REAllMatch} = leveled_util:regex_compile(UUID),
+    {ok, REMiss} = leveled_util:regex_compile("no_key"),
 
     {async, FolderREMiss} = 
         leveled_bookie:book_keylist(Bookie1,

--- a/test/property/leveled_statemeqc.erl
+++ b/test/property/leveled_statemeqc.erl
@@ -679,7 +679,7 @@ indexfold(Pid, Constraint, FoldAccT, Range, {_, undefined} = TermHandling, _Coun
     {async, Folder} = leveled_bookie:book_indexfold(Pid, Constraint, FoldAccT, Range, TermHandling),
     Folder;
 indexfold(Pid, Constraint, FoldAccT, Range, {ReturnTerms, RegExp}, _Counter) ->
-    {ok, RE} = re:compile(RegExp),
+    {ok, RE} = leveled_util:regex_compile(RegExp),
     {async, Folder} = leveled_bookie:book_indexfold(Pid, Constraint, FoldAccT, Range, {ReturnTerms, RE}),
     Folder.
 


### PR DESCRIPTION
The re2 library, though not offering the complete functionality of pcre, is known to be much faster in many scenarios.

Switch to re2 in preparation for the OTP switch to re2 in OTP28