### PR TITLE
Mas d31 i433re2capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ cover_*
 .eqc-info
 leveled_data/*
 compile_commands.json
+*parser.erl
+*lexer.erl

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
     deprecated_function_calls, deprecated_functions]}.
 
 {cover_excl_mods,
-  [leveled_filterlexer, leveled_filterparser,
+  [leveled_filterlexer, leveled_filterparser, leveled_evallexer, leveled_evalparser,
     testutil,
     appdefined_SUITE, basic_SUITE, iterator_SUITE,
     perf_SUITE, recovery_SUITE, riak_SUITE, tictac_SUITE]}.

--- a/rebar.config
+++ b/rebar.config
@@ -4,11 +4,11 @@
 
 {xref_checks,
   [undefined_function_calls,undefined_functions,
-    locals_not_used,
     deprecated_function_calls, deprecated_functions]}.
 
 {cover_excl_mods,
-  [testutil,
+  [leveled_filterlexer, leveled_filterparser,
+    testutil,
     appdefined_SUITE, basic_SUITE, iterator_SUITE,
     perf_SUITE, recovery_SUITE, riak_SUITE, tictac_SUITE]}.
 
@@ -23,6 +23,7 @@
    ]},
   {test, [{extra_src_dirs, ["test/end_to_end", "test/property"]}
    ]},
+  {perf_fexp, [{erl_opts, [{d, test_filter_expression}]}]},
   {perf_full, [{erl_opts, [{d, performance, riak_fullperf}]}]},
   {perf_mini, [{erl_opts, [{d, performance, riak_miniperf}]}]},
   {perf_prof, [{erl_opts, [{d, performance, riak_profileperf}]}]}

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -696,7 +696,7 @@ book_returnfolder(Pid, RunnerType) ->
                                      IndexVal::term(),
                                      Start::IndexVal,
                                      End::IndexVal,
-                                     ReturnTerms::boolean(),
+                                     ReturnTerms::boolean()|binary(),
                                      TermRegex :: leveled_codec:regular_expression().
 
 book_indexfold(Pid, Constraint, FoldAccT, Range, TermHandling)

--- a/src/leveled_eval.erl
+++ b/src/leveled_eval.erl
@@ -5,11 +5,12 @@
 
 -module(leveled_eval).
 
--export([apply_eval/4]).
+-export([apply_eval/4, generate_eval_expression/2]).
 
 %%%============================================================================
 %%% External API
 %%%============================================================================
+
 
 apply_eval({eval, Eval}, Term, Key, AttrMap) ->
     apply_eval(Eval, Term, Key, AttrMap);
@@ -40,14 +41,15 @@ apply_eval(
         ),
     maps:put(OutKey, NewTerm, AttrMap);
 apply_eval({
-        split, {identifier, _, InKey}, {string, _, Delim}, {identifier, _, OutKey}},
+        split, {identifier, _, InKey}, DelimAttr, {identifier, _, OutKey}},
         Term, Key, AttrMap) ->
     TermToSplit = term_to_process(InKey, Term, Key, AttrMap),
-    TermList = string:split(TermToSplit, Delim, all),
+    TermList = string:split(TermToSplit, element(3, DelimAttr), all),
     maps:put(OutKey, TermList, AttrMap);
 apply_eval(
-        {slice, {identifier, _, InKey}, {integer, _, Width}, {identifier, _, OutKey}},
+        {slice, {identifier, _, InKey}, WidthAttr, {identifier, _, OutKey}},
         Term, Key, AttrMap) ->
+    {integer, _, Width} = WidthAttr,
     TermToSlice = term_to_process(InKey, Term, Key, AttrMap),
     TermCount = string:length(TermToSlice) div Width,
     TermList =
@@ -69,6 +71,24 @@ apply_eval(
             AttrMap
     end;
 apply_eval(
+        {kvsplit,
+            {identifier, _, InKey},
+            {string, _, DelimPair}, {string, _, DelimKV}},
+        Term, Key, AttrMap) ->
+    TermToSplit = term_to_process(InKey, Term, Key, AttrMap),
+    lists:foldl(
+        fun(S, AccMap) ->
+            case string:split(S, DelimKV, all) of
+                [K, V] ->
+                    maps:put(K, V, AccMap);
+                _ ->
+                    AccMap
+            end
+        end,
+        AttrMap,
+        string:split(TermToSplit, DelimPair, all)
+    );
+apply_eval(
         {to_integer, {identifier, _, InKey}, {identifier, _, OutKey}},
         Term, Key, AttrMap) ->
     TermToConvert = term_to_process(InKey, Term, Key, AttrMap),
@@ -77,11 +97,65 @@ apply_eval(
             maps:put(OutKey, I, AttrMap);
         _ ->
             AttrMap
+    end;
+apply_eval(
+        {to_string, {identifier, _, InKey}, {identifier, _, OutKey}},
+        Term, Key, AttrMap) ->
+    case term_to_process(InKey, Term, Key, AttrMap) of
+        TermToConvert when is_integer(TermToConvert) ->
+            maps:put(
+                OutKey,
+                list_to_binary(integer_to_list(TermToConvert)),
+                AttrMap);
+        _ ->
+            AttrMap
+    end;
+apply_eval(
+        {map, InID, Comparator, MapList, Default, OutID},
+        Term, Key, AttrMap) ->
+    {identifier, _, InKey} = InID,
+    {identifier, _, OutKey} = OutID,
+    TermToCompare = term_to_process(InKey, Term, Key, AttrMap),
+    F = reverse_compare_mapping(element(2, Comparator), TermToCompare),
+    case lists:dropwhile(F, MapList) of
+        [] ->
+            maps:put(OutKey, element(3, Default), AttrMap);
+        [{mapping, _T, Assignment}|_Rest] ->
+            maps:put(OutKey, element(3, Assignment), AttrMap)
+    end;
+apply_eval(
+        {MathOp, OperandX, OperandY, {identifier, _, OutKey}},
+        _Term, _Key, AttrMap)
+        when MathOp == add; MathOp == subtract ->
+    X = maybe_fetch_operand(OperandX, AttrMap),
+    Y = maybe_fetch_operand(OperandY, AttrMap),
+    case MathOp of
+        add when is_integer(X), is_integer(Y) ->
+            maps:put(OutKey, X + Y, AttrMap);
+        subtract when is_integer(X), is_integer(Y) ->
+            maps:put(OutKey, X - Y, AttrMap);
+        _ ->
+            AttrMap
     end.
+
+generate_eval_expression(EvalString, Substitutions) ->
+    {ok, Tokens, _EndLine} = leveled_evallexer:string(EvalString),
+    case leveled_filter:substitute_items(Tokens, Substitutions, []) of
+        {error, Error} ->
+            {error, Error};
+        UpdTokens ->
+            leveled_evalparser:parse(UpdTokens)
+    end.
+
 
 %%%============================================================================
 %%% Internal functions
 %%%============================================================================
+
+maybe_fetch_operand({identifier, _, ID}, AttrMap) ->
+    maps:get(ID, AttrMap, 0);
+maybe_fetch_operand(Op, _AttrMap) ->
+    element(3, Op).
 
 term_to_process(<<"term">>, Term, _Key, _AttrMap) ->
     Term;
@@ -89,6 +163,17 @@ term_to_process(<<"key">>, _Term, Key, _AttrMap) ->
     Key;
 term_to_process(AttrKey, _Term, _Key, AttrMap) ->
     maps:get(AttrKey, AttrMap, <<"">>).
+
+reverse_compare_mapping('<', Term) ->
+    fun({mapping, T, _A}) -> Term >= element(3, T) end;
+reverse_compare_mapping('<=', Term) ->
+    fun({mapping, T, _A}) -> Term > element(3, T) end;
+reverse_compare_mapping('>', Term) ->
+    fun({mapping, T, _A}) -> Term =< element(3, T) end;
+reverse_compare_mapping('>=', Term) ->
+    fun({mapping, T, _A}) -> Term < element(3, T) end;
+reverse_compare_mapping('=', Term) ->
+    fun({mapping, T, _A}) -> Term =/= element(3, T) end.
 
 %%%============================================================================
 %%% Test
@@ -232,7 +317,165 @@ basic_test() ->
         % Not changes as not starting with integer
     ?assertMatch(<<"SPURS">>, maps:get(<<"team">>, EvalOut9)),
     ?assertMatch(<<"00001">>, maps:get(<<"number">>, EvalOut9)),
-    ?assertNot(maps:is_key(<<"doh">>, EvalOut9))
+    ?assertNot(maps:is_key(<<"doh">>, EvalOut9)),
+
+    %% Age at 30 April 2024
+    EvalString10 =
+        EvalString5 ++ 
+        " | index($dob, 4, 4, $birthday)"
+        " | map($birthday, <=, ((\"0430\", 2024)), 2023, $yoc)"
+        " | subtract($yoc, $yob, $age)"
+        " | add($age, 1, $age_next)"
+        " | to_string($age, $age)"
+        ,
+    {ok, Tokens10, _EndLine10} = leveled_evallexer:string(EvalString10),
+    {ok, ParsedExp10} = leveled_evalparser:parse(Tokens10),
+    EvalOut10A =
+        apply_eval(
+                ParsedExp10,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"37">>, maps:get(<<"age">>, EvalOut10A)),
+    ?assertMatch(38, maps:get(<<"age_next">>, EvalOut10A)),
+    EvalOut10B =
+        apply_eval(
+                ParsedExp10,
+                <<"SMITH|19860216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"38">>, maps:get(<<"age">>, EvalOut10B)),
+    EvalString10F =
+        EvalString1 ++ 
+        " | index($dob, 0, 4, $yob)"
+        " | index($dob, 4, 4, $birthday)"
+        " | map($birthday, <=, ((\"0430\", 2024)), 2023, $yoc)"
+        " | subtract($yoc, $yob, $age)"
+            % yob has not been converted to an integer,
+            % so the age will not be set
+        " | to_string($age, $age)"
+        ,
+    {ok, Tokens10F, _EndLine10F} = leveled_evallexer:string(EvalString10F),
+    {ok, ParsedExp10F} = leveled_evalparser:parse(Tokens10F),
+    EvalOut10F =
+        apply_eval(
+                ParsedExp10F,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertNot(maps:is_key(<<"age">>, EvalOut10F)),
+
+    EvalString11A =
+        EvalString1 ++
+            " | map($dob, <, "
+                "((\"1946\", \"Silent\"), (\"1966\", \"Boomer\"),"
+                "(\"1980\", \"GenX\"), (\"1997\", \"Millenial\")), \"GenZ\","
+                " $generation)",
+    {ok, Tokens11A, _EndLine11A} = leveled_evallexer:string(EvalString11A),
+    {ok, ParsedExp11A} = leveled_evalparser:parse(Tokens11A),
+    EvalOut11A =
+        apply_eval(
+                ParsedExp11A,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"Millenial">>, maps:get(<<"generation">>, EvalOut11A)),
+    EvalString11B =
+        EvalString1 ++
+            " | map($dob, <=, "
+                "((\"1945\", \"Silent\"), (\"1965\", \"Boomer\"),"
+                "(\"1979\", \"GenX\"), (\"1996\", \"Millenial\")), \"GenZ\","
+                " $generation)",
+    {ok, Tokens11B, _EndLine11B} = leveled_evallexer:string(EvalString11B),
+    {ok, ParsedExp11B} = leveled_evalparser:parse(Tokens11B),
+    EvalOut11B =
+        apply_eval(
+                ParsedExp11B,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"Millenial">>, maps:get(<<"generation">>, EvalOut11B)),
+    EvalString11C =
+        EvalString1 ++
+            " | map($dob, >, "
+                "((\"1996\", \"GenZ\"), (\"1979\", \"Millenial\"),"
+                "(\"1965\", \"GenX\"), (\"1945\", \"Boomer\")), \"Silent\","
+                " $generation)",
+    {ok, Tokens11C, _EndLine11C} = leveled_evallexer:string(EvalString11C),
+    {ok, ParsedExp11C} = leveled_evalparser:parse(Tokens11C),
+    EvalOut11C =
+        apply_eval(
+                ParsedExp11C,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"Millenial">>, maps:get(<<"generation">>, EvalOut11C)),
+    EvalString11D =
+        EvalString1 ++
+            " | map($dob, >=, "
+                "((\"1997\", \"GenZ\"), (\"1980\", \"Millenial\"),"
+                "(\"1966\", \"GenX\"), (\"1946\", \"Boomer\")), \"Silent\","
+                " $generation)",
+    {ok, Tokens11D, _EndLine11D} = leveled_evallexer:string(EvalString11D),
+    {ok, ParsedExp11D} = leveled_evalparser:parse(Tokens11D),
+    EvalOut11D =
+        apply_eval(
+                ParsedExp11D,
+                <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+                <<"9000000001">>,
+                maps:new()
+            ),
+    ?assertMatch(<<"Millenial">>, maps:get(<<"generation">>, EvalOut11D)),
+
+    EvalString12 =
+        "kvsplit($term, \"|\", \"=\") | index($term, 0, 12, $ts) |"
+        " to_integer($ts, $ts) |"
+        " to_integer($DEBUG, $DEBUG) |"
+        " to_integer($INFO, $INFO) |"
+        " to_integer($WARN, $WARN) |"
+        " to_integer($ERROR, $ERROR) |"
+        " to_integer($CRITICAL, $CRITICAL) |"
+        " add($DEBUG, $INFO, $TOTAL) |"
+        " add($TOTAL, $WARN, $TOTAL) |"
+        " add($TOTAL, $ERROR, $TOTAL) |"
+        " add($TOTAL, $CRITICAL, $TOTAL)"
+        ,
+    {ok, Tokens12, _EndLine12} = leveled_evallexer:string(EvalString12),
+    {ok, ParsedExp12} = leveled_evalparser:parse(Tokens12),
+    EvalOut12 =
+        apply_eval(
+                ParsedExp12,
+                <<"063881703147|DEBUG=804|INFO=186|WARN=10">>,
+                <<"ABC1233">>,
+                maps:new()
+            ),
+    ?assertMatch(63881703147, maps:get(<<"ts">>, EvalOut12)),
+    ?assertMatch(1000, maps:get(<<"TOTAL">>, EvalOut12)),
+    ?assertNot(maps:is_key(<<"CRITICAL">>, EvalOut12)),
+
+    EvalString13 =
+        "kvsplit($term, \"|\", \":\") |"
+        " map($cup_year, =, "
+            "((\"1965\", \"bad\"), (\"1970\", \"bad\"), "
+            "(\"1972\", \"good\"), (\"1974\", \"bad\")), "
+            "\"indifferent\", $cup_happy) ",
+    {ok, Tokens13, _EndLine13} = leveled_evallexer:string(EvalString13),
+    {ok, ParsedExp13} = leveled_evalparser:parse(Tokens13),
+    EvalOut13A =
+        apply_eval(ParsedExp13, <<"cup_year:1972">>, <<"ABC1">>, maps:new()),
+    ?assertMatch(<<"good">>, maps:get(<<"cup_happy">>, EvalOut13A)),
+    EvalOut13B =
+        apply_eval(ParsedExp13, <<"cup_year:1970">>, <<"ABC1">>, maps:new()),
+    ?assertMatch(<<"bad">>, maps:get(<<"cup_happy">>, EvalOut13B)),
+    EvalOut13C =
+        apply_eval(ParsedExp13, <<"cup_year:2024">>, <<"ABC1">>, maps:new()),
+    ?assertMatch(<<"indifferent">>, maps:get(<<"cup_happy">>, EvalOut13C))
     .
 
 

--- a/src/leveled_eval.erl
+++ b/src/leveled_eval.erl
@@ -479,5 +479,22 @@ basic_test() ->
     .
 
 
+generate_test() ->
+    EvalString13 =
+        "kvsplit($term, \"|\", \":\") |"
+        " map($cup_year, =, "
+            "((\"1965\", \"bad\"), (\"1970\", \"bad\"), "
+            "(:clarke, \"good\"), (\"1974\", \"bad\")), "
+            "\"indifferent\", $cup_happy) ",
+    {ok, ParsedExp13} =
+        generate_eval_expression(EvalString13, #{<<"clarke">> => <<"1972">>}),
+    io:format("ParsedExp ~p~n", [ParsedExp13]),
+    EvalOut13A =
+        apply_eval(ParsedExp13, <<"cup_year:1972">>, <<"ABC1">>, maps:new()),
+    ?assertMatch(<<"good">>, maps:get(<<"cup_happy">>, EvalOut13A)),
+    ?assertMatch(
+        {error, "Substitution <<\"clarke\">> not found"},
+        generate_eval_expression(EvalString13, maps:new())
+    ).
 
 -endif.

--- a/src/leveled_eval.erl
+++ b/src/leveled_eval.erl
@@ -1,0 +1,240 @@
+%% -------- Eval Functions ---------
+%%
+%% Support for different eval expressions within leveled 
+%%
+
+-module(leveled_eval).
+
+-export([apply_eval/4]).
+
+%%%============================================================================
+%%% External API
+%%%============================================================================
+
+apply_eval({eval, Eval}, Term, Key, AttrMap) ->
+    apply_eval(Eval, Term, Key, AttrMap);
+apply_eval({'PIPE', Eval1, 'INTO', Eval2}, Term, Key, AttrMap) ->
+    apply_eval(Eval2, Term, Key, apply_eval(Eval1, Term, Key, AttrMap));
+apply_eval({
+        delim, {identifier, _, InKey}, {string, _, Delim}, ExpKeys},
+        Term, Key, AttrMap) ->
+    TermToSplit = term_to_process(InKey, Term, Key, AttrMap),
+    CptTerms = string:split(TermToSplit, Delim, all),
+    L = min(length(CptTerms), length(ExpKeys)),
+    maps:merge(
+        AttrMap,
+        maps:from_list(
+            lists:zip(lists:sublist(ExpKeys, L), lists:sublist(CptTerms, L)))
+    );
+apply_eval(
+        {join, InKeys, {string, _, Delim}, {identifier, _, OutKey}},
+        _Term, _Key, AttrMap) ->
+    NewTerm =
+        unicode:characters_to_binary(
+            lists:join(
+                Delim,
+                lists:map(
+                    fun(InKey) -> maps:get(InKey, AttrMap, <<"">>) end,
+                    InKeys)
+            )
+        ),
+    maps:put(OutKey, NewTerm, AttrMap);
+apply_eval({
+        split, {identifier, _, InKey}, {string, _, Delim}, {identifier, _, OutKey}},
+        Term, Key, AttrMap) ->
+    TermToSplit = term_to_process(InKey, Term, Key, AttrMap),
+    TermList = string:split(TermToSplit, Delim, all),
+    maps:put(OutKey, TermList, AttrMap);
+apply_eval(
+        {slice, {identifier, _, InKey}, {integer, _, Width}, {identifier, _, OutKey}},
+        Term, Key, AttrMap) ->
+    TermToSlice = term_to_process(InKey, Term, Key, AttrMap),
+    TermCount = string:length(TermToSlice) div Width,
+    TermList =
+        lists:map(
+            fun(S) -> string:slice(TermToSlice, S, Width) end,
+            lists:map(fun(I) -> Width * I end, lists:seq(0, TermCount - 1))),
+    maps:put(OutKey, TermList, AttrMap);
+apply_eval(
+        {index, {identifier, _, InKey},
+            {integer, _, Start}, {integer, _, Length},
+            {identifier, _, OutKey}},
+        Term, Key, AttrMap) ->
+    TermToIndex = term_to_process(InKey, Term, Key, AttrMap),
+    case string:length(TermToIndex) of
+        L when L >= (Start + Length) ->
+            maps:put(
+                OutKey, string:slice(TermToIndex, Start, Length), AttrMap);
+        _ ->
+            AttrMap
+    end;
+apply_eval(
+        {to_integer, {identifier, _, InKey}, {identifier, _, OutKey}},
+        Term, Key, AttrMap) ->
+    TermToConvert = term_to_process(InKey, Term, Key, AttrMap),
+    case string:to_integer(TermToConvert) of
+        {I, _Rest} when is_integer(I) ->
+            maps:put(OutKey, I, AttrMap);
+        _ ->
+            AttrMap
+    end.
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+term_to_process(<<"term">>, Term, _Key, _AttrMap) ->
+    Term;
+term_to_process(<<"key">>, _Term, Key, _AttrMap) ->
+    Key;
+term_to_process(AttrKey, _Term, _Key, AttrMap) ->
+    maps:get(AttrKey, AttrMap, <<"">>).
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+basic_test() ->
+    EvalString1 = "delim($term, \"|\", ($fn, $dob, $dod, $gns, $pcs))",
+    EvalString2 = "delim($gns, \"#\", ($gn1, $gn2, $gn3))",
+    
+    EvalString3 = EvalString1 ++ " | " ++ EvalString2,
+    {ok, Tokens3, _EndLine3} = leveled_evallexer:string(EvalString3),
+    {ok, ParsedExp3} = leveled_evalparser:parse(Tokens3),
+    EvalOut3 =
+        apply_eval(
+            ParsedExp3,
+            <<"SMITH|19861216||Willow#Mia|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut3)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut3)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut3)),
+    ?assertMatch(<<"Willow#Mia">>, maps:get(<<"gns">>, EvalOut3)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut3)),
+    ?assertMatch(<<"Willow">>, maps:get(<<"gn1">>, EvalOut3)),
+    ?assertMatch(<<"Mia">>, maps:get(<<"gn2">>, EvalOut3)),
+    ?assertNot(maps:is_key(<<"gn3">>, EvalOut3)),
+
+
+    EvalString4 = EvalString3 ++ " | join(($dob, $fn), \"|\", $dobfn)",
+    {ok, Tokens4, _EndLine4} = leveled_evallexer:string(EvalString4),
+    {ok, ParsedExp4} = leveled_evalparser:parse(Tokens4),
+    EvalOut4 =
+        apply_eval(
+            ParsedExp4,
+            <<"SMITH|19861216||Willow#Mia|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut4)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut4)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut4)),
+    ?assertMatch(<<"Willow#Mia">>, maps:get(<<"gns">>, EvalOut4)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut4)),
+    ?assertMatch(<<"Willow">>, maps:get(<<"gn1">>, EvalOut4)),
+    ?assertMatch(<<"Mia">>, maps:get(<<"gn2">>, EvalOut4)),
+    ?assertNot(maps:is_key(<<"gn3">>, EvalOut4)),
+    ?assertMatch(<<"19861216|SMITH">>, maps:get(<<"dobfn">>, EvalOut4)),
+
+
+    EvalString5 = EvalString4 ++ " | index($dob, 0, 4, $yob) | to_integer($yob, $yob)",
+    {ok, Tokens5, _EndLine5} = leveled_evallexer:string(EvalString5),
+    {ok, ParsedExp5} = leveled_evalparser:parse(Tokens5),
+    EvalOut5 =
+        apply_eval(
+            ParsedExp5,
+            <<"SMITH|19861216||Willow#Mia|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut5)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut5)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut5)),
+    ?assertMatch(<<"Willow#Mia">>, maps:get(<<"gns">>, EvalOut5)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut5)),
+    ?assertMatch(<<"Willow">>, maps:get(<<"gn1">>, EvalOut5)),
+    ?assertMatch(<<"Mia">>, maps:get(<<"gn2">>, EvalOut5)),
+    ?assertNot(maps:is_key(<<"gn3">>, EvalOut5)),
+    ?assertMatch(<<"19861216|SMITH">>, maps:get(<<"dobfn">>, EvalOut5)),
+    ?assertMatch(1986, maps:get(<<"yob">>, EvalOut5)),
+
+    EvalString6 = EvalString1 ++ " | slice($gns, 2, $gns)",
+    {ok, Tokens6, _EndLine6} = leveled_evallexer:string(EvalString6),
+    {ok, ParsedExp6} = leveled_evalparser:parse(Tokens6),
+    EvalOut6 =
+        apply_eval(
+            ParsedExp6,
+            <<"SMITH|19861216||MAN1Ve|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut6)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut6)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut6)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut6)),
+    ?assertMatch([<<"MA">>, <<"N1">>, <<"Ve">>], maps:get(<<"gns">>, EvalOut6)),
+
+    EvalOut7 =
+        apply_eval(
+            ParsedExp6,
+            <<"SMITH|19861216||MAN1VeZ|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut7)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut7)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut7)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut7)),
+    ?assertMatch([<<"MA">>, <<"N1">>, <<"Ve">>], maps:get(<<"gns">>, EvalOut7)),
+
+    EvalString8 = EvalString1 ++ " | split($gns, \"#\", $gns)",
+    {ok, Tokens8, _EndLine8} = leveled_evallexer:string(EvalString8),
+    {ok, ParsedExp8} = leveled_evalparser:parse(Tokens8),
+    EvalOut8 =
+        apply_eval(
+            ParsedExp8,
+            <<"SMITH|19861216||Willow#Mia#Vera|LS1 4BT#LS8 1ZZ">>,
+            <<"9000000001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"SMITH">>, maps:get(<<"fn">>, EvalOut8)),
+    ?assertMatch(<<"19861216">>, maps:get(<<"dob">>, EvalOut8)),
+    ?assertMatch(<<"">>, maps:get(<<"dod">>, EvalOut8)),
+    ?assertMatch(<<"LS1 4BT#LS8 1ZZ">>, maps:get(<<"pcs">>, EvalOut8)),
+    ?assertMatch([<<"Willow">>, <<"Mia">>, <<"Vera">>], maps:get(<<"gns">>, EvalOut8)),
+
+    EvalString9 =
+        "delim($term, \"|\", ($name, $height, $weight, $pick)) |"
+        " to_integer($height, $height) |"
+        " to_integer($weight, $weight) |"
+        " to_integer($pick, $pick) |"
+        " delim($key, \"|\", ($team, $number)) |"
+        " index($team, 0, 9, $doh)",
+    {ok, Tokens9, _EndLine9} = leveled_evallexer:string(EvalString9),
+    {ok, ParsedExp9} = leveled_evalparser:parse(Tokens9),
+    EvalOut9 =
+        apply_eval(
+            ParsedExp9,
+            <<"WEMBANYAMA|224cm|95kg|#1">>,
+            <<"SPURS|00001">>,
+            maps:new()
+        ),
+    ?assertMatch(<<"WEMBANYAMA">>, maps:get(<<"name">>, EvalOut9)),
+    ?assertMatch(224, maps:get(<<"height">>, EvalOut9)),
+    ?assertMatch(95, maps:get(<<"weight">>, EvalOut9)),
+    ?assertMatch(<<"#1">>, maps:get(<<"pick">>, EvalOut9)),
+        % Not changes as not starting with integer
+    ?assertMatch(<<"SPURS">>, maps:get(<<"team">>, EvalOut9)),
+    ?assertMatch(<<"00001">>, maps:get(<<"number">>, EvalOut9)),
+    ?assertNot(maps:is_key(<<"doh">>, EvalOut9))
+    .
+
+
+
+-endif.

--- a/src/leveled_evallexer.xrl
+++ b/src/leveled_evallexer.xrl
@@ -7,19 +7,32 @@ Rules.
 
 {WhiteSpace} : skip_token.
 
-\( : {token, {'(', TokenLine}}.
-\) : {token, {')', TokenLine}}.
-,  : {token, {',', TokenLine}}.
-\| : {token, {'PIPE', TokenLine}}.
+\(      : {token, {'(', TokenLine}}.
+\)      : {token, {')', TokenLine}}.
+,       : {token, {',', TokenLine}}.
+\|      : {token, {'PIPE', TokenLine}}.
 
-delim       : {token, {delim, TokenLine}}.
-join        : {token, {join, TokenLine}}.
-split       : {token, {split, TokenLine}}.
-slice       : {token, {slice, TokenLine}}.
-index       : {token, {index, TokenLine}}.
-to_integer  : {token, {to_integer, TokenLine}}.
+delim        : {token, {delim, TokenLine}}.
+join         : {token, {join, TokenLine}}.
+split        : {token, {split, TokenLine}}.
+slice        : {token, {slice, TokenLine}}.
+index        : {token, {index, TokenLine}}.
+kvsplit      : {token, {kvsplit, TokenLine}}.
+to_integer   : {token, {to_integer, TokenLine}}.
+to_string    : {token, {to_string, TokenLine}}.
+add          : {token, {add, TokenLine}}.
+subtract     : {token, {subtract, TokenLine}}.
+map          : {token, {map, TokenLine}}.
+
+=       : {token, {comparator, '=', TokenLine}}.
+<       : {token, {comparator, '<', TokenLine}}.
+>       : {token, {comparator, '>', TokenLine}}.
+<>      : {token, {comparator, '<>', TokenLine}}.
+<=      : {token, {comparator, '<=', TokenLine}}.
+>=      : {token, {comparator, '>=', TokenLine}}.
 
 \$[a-zA-Z_][a-zA-Z_0-9]* : {token, {identifier, TokenLine, strip_identifier(TokenChars)}}.
+\:[a-zA-Z_][a-zA-Z_0-9]* : {token, {substitution, TokenLine, strip_substitution(TokenChars)}}.
 \"[^"]*\"                : {token, {string, TokenLine, strip_string(TokenChars)}}. %"
 [0-9]+                   : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
 
@@ -30,4 +43,8 @@ strip_string(TokenChars) ->
 
 strip_identifier(TokenChars) ->
     [36|StrippedChars] = TokenChars,
+    list_to_binary(StrippedChars).
+
+strip_substitution(TokenChars) ->
+    [58|StrippedChars] = TokenChars,
     list_to_binary(StrippedChars).

--- a/src/leveled_evallexer.xrl
+++ b/src/leveled_evallexer.xrl
@@ -18,11 +18,14 @@ split        : {token, {split, TokenLine}}.
 slice        : {token, {slice, TokenLine}}.
 index        : {token, {index, TokenLine}}.
 kvsplit      : {token, {kvsplit, TokenLine}}.
+regex        : {token, {regex, TokenLine}}.
 to_integer   : {token, {to_integer, TokenLine}}.
 to_string    : {token, {to_string, TokenLine}}.
 add          : {token, {add, TokenLine}}.
 subtract     : {token, {subtract, TokenLine}}.
 map          : {token, {map, TokenLine}}.
+pcre         : {token, {pcre, TokenLine}}.
+re2          : {token, {re2, TokenLine}}.
 
 =       : {token, {comparator, '=', TokenLine}}.
 <       : {token, {comparator, '<', TokenLine}}.

--- a/src/leveled_evallexer.xrl
+++ b/src/leveled_evallexer.xrl
@@ -1,0 +1,33 @@
+%% Lexer for eval expressions
+
+Definitions.
+WhiteSpace  = ([\t\f\v\r\n\s]+)
+
+Rules.
+
+{WhiteSpace} : skip_token.
+
+\( : {token, {'(', TokenLine}}.
+\) : {token, {')', TokenLine}}.
+,  : {token, {',', TokenLine}}.
+\| : {token, {'PIPE', TokenLine}}.
+
+delim       : {token, {delim, TokenLine}}.
+join        : {token, {join, TokenLine}}.
+split       : {token, {split, TokenLine}}.
+slice       : {token, {slice, TokenLine}}.
+index       : {token, {index, TokenLine}}.
+to_integer  : {token, {to_integer, TokenLine}}.
+
+\$[a-zA-Z_][a-zA-Z_0-9]* : {token, {identifier, TokenLine, strip_identifier(TokenChars)}}.
+\"[^"]*\"                : {token, {string, TokenLine, strip_string(TokenChars)}}. %"
+[0-9]+                   : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
+
+Erlang code.
+
+strip_string(TokenChars) ->
+    list_to_binary(lists:sublist(TokenChars, 2, length(TokenChars) -2)).
+
+strip_identifier(TokenChars) ->
+    [36|StrippedChars] = TokenChars,
+    list_to_binary(StrippedChars).

--- a/src/leveled_evalparser.yrl
+++ b/src/leveled_evalparser.yrl
@@ -1,27 +1,50 @@
 %% Grammar for eval expressions
 
 Nonterminals
-top_level eval identifiers identifier_list.
+top_level eval
+operand math_operand
+mapping mappings mappings_list
+identifiers identifier_list.
 
 Terminals
 '(' ')' ','
-identifier string integer
+identifier string integer comparator
 'PIPE'
-delim join split slice index to_integer.
+delim join split slice index kvsplit map
+add subtract
+to_integer to_string.
 
 Rootsymbol top_level.
 
 top_level -> eval: {eval, '$1'}.
 
-eval -> eval 'PIPE' eval                                                     : {'PIPE', '$1', 'INTO', '$3'}.
-eval -> delim '(' identifier ',' string ',' identifier_list ')'              : {delim, '$3', '$5', '$7'}.
-eval -> join '(' identifier_list ',' string ',' identifier ')'               : {join, '$3', '$5', '$7'}.
-eval -> split '(' identifier ',' string ',' identifier ')'                   : {split, '$3', '$5', '$7'}.
-eval -> slice '(' identifier ',' integer ',' identifier ')'                  : {slice, '$3', '$5', '$7'}.
-eval -> index '(' identifier ',' integer ',' integer ',' 'identifier' ')'    : {index, '$3', '$5', '$7', '$9'}.
-eval -> to_integer '(' identifier ',' 'identifier' ')'                       : {to_integer, '$3', '$5'}.
+eval -> eval 'PIPE' eval                                                                           : {'PIPE', '$1', 'INTO', '$3'}.
+eval -> delim '(' identifier ',' string ',' identifier_list ')'                                    : {delim, '$3', '$5', '$7'}.
+eval -> join '(' identifier_list ',' string ',' identifier ')'                                     : {join, '$3', '$5', '$7'}.
+eval -> split '(' identifier ',' string ',' identifier ')'                                         : {split, '$3', '$5', '$7'}.
+eval -> slice '(' identifier ',' integer ',' identifier ')'                                        : {slice, '$3', '$5', '$7'}.
+eval -> index '(' identifier ',' integer ',' integer ',' 'identifier' ')'                          : {index, '$3', '$5', '$7', '$9'}.
+eval -> kvsplit '(' identifier ',' string ',' string ')'                                           : {kvsplit, '$3', '$5', '$7'}.
+eval -> map '(' identifier ',' comparator ',' mappings_list ',' operand ',' identifier ')'         : {map, '$3', '$5', '$7', '$9', '$11'}.
+eval -> to_integer '(' identifier ',' identifier ')'                                               : {to_integer, '$3', '$5'}.
+eval -> to_string '(' identifier ',' identifier ')'                                                : {to_string, '$3', '$5'}.
+eval -> subtract '(' math_operand ',' math_operand ',' identifier ')'                              : {subtract, '$3', '$5', '$7'}.
+eval -> add '(' math_operand ',' math_operand ',' identifier ')'                                   : {add, '$3', '$5', '$7'}.
 
-identifier_list -> '(' identifiers ')' : strip_ids('$2').
+mappings_list -> '(' mappings ')'         : '$2'.
+
+mappings -> mapping ',' mappings          : ['$1' | '$3'].
+mappings -> mapping                       : ['$1'].
+
+mapping -> '(' operand ',' operand ')' : {mapping, '$2', '$4'}.
+
+operand -> string          : '$1'.
+operand -> integer         : '$1'.
+
+math_operand -> integer    : '$1'.
+math_operand -> identifier : '$1'.
+
+identifier_list -> '(' identifiers ')'    : strip_ids('$2').
 
 identifiers -> identifier ',' identifiers : ['$1' | '$3'].
 identifiers -> identifier                 : ['$1'].

--- a/src/leveled_evalparser.yrl
+++ b/src/leveled_evalparser.yrl
@@ -1,0 +1,39 @@
+%% Grammar for eval expressions
+
+Nonterminals
+top_level eval identifiers identifier_list.
+
+Terminals
+'(' ')' ','
+identifier string integer
+'PIPE'
+delim join split slice index to_integer.
+
+Rootsymbol top_level.
+
+top_level -> eval: {eval, '$1'}.
+
+eval -> eval 'PIPE' eval                                                     : {'PIPE', '$1', 'INTO', '$3'}.
+eval -> delim '(' identifier ',' string ',' identifier_list ')'              : {delim, '$3', '$5', '$7'}.
+eval -> join '(' identifier_list ',' string ',' identifier ')'               : {join, '$3', '$5', '$7'}.
+eval -> split '(' identifier ',' string ',' identifier ')'                   : {split, '$3', '$5', '$7'}.
+eval -> slice '(' identifier ',' integer ',' identifier ')'                  : {slice, '$3', '$5', '$7'}.
+eval -> index '(' identifier ',' integer ',' integer ',' 'identifier' ')'    : {index, '$3', '$5', '$7', '$9'}.
+eval -> to_integer '(' identifier ',' 'identifier' ')'                       : {to_integer, '$3', '$5'}.
+
+identifier_list -> '(' identifiers ')' : strip_ids('$2').
+
+identifiers -> identifier ',' identifiers : ['$1' | '$3'].
+identifiers -> identifier                 : ['$1'].
+
+Endsymbol '$end'.
+
+Right 100 'PIPE'.
+
+Erlang code.
+
+strip_ids(IDL) ->
+    lists:map(
+        fun(ID) -> element(3, ID) end,
+        lists:flatten(IDL)
+    ). 

--- a/src/leveled_evalparser.yrl
+++ b/src/leveled_evalparser.yrl
@@ -2,7 +2,7 @@
 
 Nonterminals
 top_level eval
-operand math_operand
+operand math_operand regex_method
 mapping mappings mappings_list
 identifiers identifier_list.
 
@@ -10,26 +10,29 @@ Terminals
 '(' ')' ','
 identifier string integer comparator
 'PIPE'
-delim join split slice index kvsplit map
+delim join split slice index kvsplit regex map
 add subtract
-to_integer to_string.
+to_integer to_string
+pcre re2.
 
 Rootsymbol top_level.
 
 top_level -> eval: {eval, '$1'}.
 
-eval -> eval 'PIPE' eval                                                                           : {'PIPE', '$1', 'INTO', '$3'}.
-eval -> delim '(' identifier ',' string ',' identifier_list ')'                                    : {delim, '$3', '$5', '$7'}.
-eval -> join '(' identifier_list ',' string ',' identifier ')'                                     : {join, '$3', '$5', '$7'}.
-eval -> split '(' identifier ',' string ',' identifier ')'                                         : {split, '$3', '$5', '$7'}.
-eval -> slice '(' identifier ',' integer ',' identifier ')'                                        : {slice, '$3', '$5', '$7'}.
-eval -> index '(' identifier ',' integer ',' integer ',' 'identifier' ')'                          : {index, '$3', '$5', '$7', '$9'}.
-eval -> kvsplit '(' identifier ',' string ',' string ')'                                           : {kvsplit, '$3', '$5', '$7'}.
-eval -> map '(' identifier ',' comparator ',' mappings_list ',' operand ',' identifier ')'         : {map, '$3', '$5', '$7', '$9', '$11'}.
-eval -> to_integer '(' identifier ',' identifier ')'                                               : {to_integer, '$3', '$5'}.
-eval -> to_string '(' identifier ',' identifier ')'                                                : {to_string, '$3', '$5'}.
-eval -> subtract '(' math_operand ',' math_operand ',' identifier ')'                              : {subtract, '$3', '$5', '$7'}.
-eval -> add '(' math_operand ',' math_operand ',' identifier ')'                                   : {add, '$3', '$5', '$7'}.
+eval -> eval 'PIPE' eval                                                                     : {'PIPE', '$1', 'INTO', '$3'}.
+eval -> delim '(' identifier ',' string ',' identifier_list ')'                              : {delim, '$3', '$5', '$7'}.
+eval -> join '(' identifier_list ',' string ',' identifier ')'                               : {join, '$3', '$5', '$7'}.
+eval -> split '(' identifier ',' string ',' identifier ')'                                   : {split, '$3', '$5', '$7'}.
+eval -> slice '(' identifier ',' integer ',' identifier ')'                                  : {slice, '$3', '$5', '$7'}.
+eval -> index '(' identifier ',' integer ',' integer ',' 'identifier' ')'                    : {index, '$3', '$5', '$7', '$9'}.
+eval -> kvsplit '(' identifier ',' string ',' string ')'                                     : {kvsplit, '$3', '$5', '$7'}.
+eval -> regex '(' identifier ',' string ',' regex_method ',' identifier_list ')'             : {regex, '$3', re_compile('$5', '$7'), '$9'}.
+eval -> regex '(' identifier ',' string ',' identifier_list ')'                              : {regex, '$3', re_compile('$5'), '$7'}.
+eval -> map '(' identifier ',' comparator ',' mappings_list ',' operand ',' identifier ')'   : {map, '$3', '$5', '$7', '$9', '$11'}.
+eval -> to_integer '(' identifier ',' identifier ')'                                         : {to_integer, '$3', '$5'}.
+eval -> to_string '(' identifier ',' identifier ')'                                          : {to_string, '$3', '$5'}.
+eval -> subtract '(' math_operand ',' math_operand ',' identifier ')'                        : {subtract, '$3', '$5', '$7'}.
+eval -> add '(' math_operand ',' math_operand ',' identifier ')'                             : {add, '$3', '$5', '$7'}.
 
 mappings_list -> '(' mappings ')'         : '$2'.
 
@@ -43,6 +46,9 @@ operand -> integer         : '$1'.
 
 math_operand -> integer    : '$1'.
 math_operand -> identifier : '$1'.
+
+regex_method -> pcre       : '$1'.    
+regex_method -> re2        : '$1'.
 
 identifier_list -> '(' identifiers ')'    : strip_ids('$2').
 
@@ -59,4 +65,11 @@ strip_ids(IDL) ->
     lists:map(
         fun(ID) -> element(3, ID) end,
         lists:flatten(IDL)
-    ). 
+    ).
+
+re_compile(RegexStr) ->
+    re_compile(RegexStr, {re2, element(2, RegexStr)}).
+
+re_compile({string, _LN, Regex}, Method) ->
+    {ok, CRE} = leveled_util:regex_compile(Regex, element(1, Method)),
+    CRE.

--- a/src/leveled_filter.erl
+++ b/src/leveled_filter.erl
@@ -8,7 +8,8 @@
 -export(
     [
         generate_filter_expression/2,
-        apply_filter/2
+        apply_filter/2,
+        substitute_items/3
     ]).
 
 %%%============================================================================
@@ -110,17 +111,6 @@ generate_filter_expression(FilterString, Substitutions) ->
             leveled_filterparser:parse(UpdTokens)
     end.
 
-%%%============================================================================
-%%% Internal functions
-%%%============================================================================
-
-compare('>', V, CmpA) -> V > CmpA;
-compare('>=', V, CmpA) -> V >= CmpA;
-compare('<', V, CmpA) -> V < CmpA;
-compare('<=', V, CmpA) -> V =< CmpA;
-compare('=', V, CmpA) -> V == CmpA;
-compare('<>', V, CmpA) -> V =/= CmpA.
-
 substitute_items([], _Subs, UpdTokens) ->
     lists:reverse(UpdTokens);
 substitute_items([{substitution, LN, ID}|Rest], Subs, UpdTokens) ->
@@ -141,6 +131,17 @@ substitute_items([{substitution, LN, ID}|Rest], Subs, UpdTokens) ->
     end;
 substitute_items([Token|Rest], Subs, UpdTokens) ->
     substitute_items(Rest, Subs, [Token|UpdTokens]).
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+compare('>', V, CmpA) -> V > CmpA;
+compare('>=', V, CmpA) -> V >= CmpA;
+compare('<', V, CmpA) -> V < CmpA;
+compare('<=', V, CmpA) -> V =< CmpA;
+compare('=', V, CmpA) -> V == CmpA;
+compare('<>', V, CmpA) -> V =/= CmpA.
 
 
 %%%============================================================================

--- a/src/leveled_filter.erl
+++ b/src/leveled_filter.erl
@@ -121,7 +121,7 @@ substitute_items([{substitution, LN, ID}|Rest], Subs, UpdTokens) ->
                     io_lib:format("Substitution ~p not found", [ID]))};
         Value when is_binary(Value) ->
             substitute_items(
-                Rest, Subs, [{string, LN, binary_to_list(Value)}|UpdTokens]);
+                Rest, Subs, [{string, LN, Value}|UpdTokens]);
         Value when is_integer(Value) ->
             substitute_items(Rest, Subs, [{integer, LN, Value}|UpdTokens]);
         _UnexpectedValue ->

--- a/src/leveled_filter.erl
+++ b/src/leveled_filter.erl
@@ -1,0 +1,174 @@
+%% -------- Filter Functions ---------
+%%
+%% Support for different filter expressions within leveled 
+%%
+
+-module(leveled_filter).
+
+-export([validate_comparison_expression/2]).
+
+%%%============================================================================
+%%% External API
+%%%============================================================================
+
+%% @doc validate a comaprison expression
+%% A comparison expression allows for string comparisons to be made using
+%% >, <, >=, =< with andalso, or as well as () to group different expressions
+%% The output is a function which will be passed a Map where the Map may be the
+%% result of reading some projected attributes on an index string.
+%% To compare a string with a key in the map, the name of the key must begin
+%% with a "$".
+%% In creating the function, the potential keys must be known and passed as a
+%% string in the list (without the leading $). 
+-spec validate_comparison_expression(
+    string(), list(string())) ->
+        fun((map()) -> {value, boolean(), map()}) |
+        {error, string(), erl_anno:location()}.
+validate_comparison_expression(
+        Expression, AvailableArgs) when is_list(Expression) ->
+    case erl_scan:string(Expression) of
+        {ok, Tokens, _EndLoc} ->
+            case vert_compexpr_tokens(Tokens, AvailableArgs, []) of
+                {ok, UpdTokens} ->
+                    case erl_parse:parse_exprs(UpdTokens) of
+                        {ok, [Form]} ->
+                            io:format("Form ~p~n", [Form]),
+                            fun(LookupMap) ->
+                                erl_eval:expr(Form, LookupMap)
+                            end;
+                        {error, ErrorInfo} ->
+                            {error, ErrorInfo, undefined}
+                    end;
+                {error, Error, ErrorLocation} ->
+                    {error, lists:flatten(Error), ErrorLocation}
+            end;
+        {error, Error, ErrorLocation} ->
+            {error, Error, ErrorLocation}
+    end;
+validate_comparison_expression(_Expression, _AvailableArgs) ->
+    {error, "Expression not a valid string", undefined}.
+
+%%%============================================================================
+%%% Internal functions
+%%%============================================================================
+
+vert_compexpr_tokens([], _Args, ParsedTokens) ->
+    {ok, lists:reverse(ParsedTokens)};
+vert_compexpr_tokens([{dot, LN}], Args, ParsedTokens) ->
+    vert_compexpr_tokens([], Args, [{dot, LN}|ParsedTokens]);
+vert_compexpr_tokens(L, _Args, _ParsedTokens) when length(L) == 1 ->
+    {error, "Query does not end with `.`", undefined};
+vert_compexpr_tokens([{string, LN, String}|Rest], Args, ParsedTokens) ->
+    case hd(String) of
+        36 -> % 36 == $
+            Arg = tl(String),
+            case lists:member(Arg, Args) of
+                true ->
+                    VarToken = {var, LN, list_to_atom(Arg)},
+                    vert_compexpr_tokens(Rest, Args, [VarToken|ParsedTokens]);
+                false ->
+                    {error, io_lib:format("Unavailable Arg ~s", [Arg]), LN}
+            end;
+        _ -> % Not a key, treat as a string
+            vert_compexpr_tokens(
+                Rest, Args, [{string, LN, String}|ParsedTokens])
+    end;
+vert_compexpr_tokens([{'(',LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'(',LN}|ParsedTokens]);
+vert_compexpr_tokens([{')',LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{')',LN}|ParsedTokens]);
+vert_compexpr_tokens([{'andalso', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'andalso', LN}|ParsedTokens]);
+vert_compexpr_tokens([{'or', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'or', LN}|ParsedTokens]);
+vert_compexpr_tokens([{'>', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'>', LN}|ParsedTokens]);
+vert_compexpr_tokens([{'<', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'<', LN}|ParsedTokens]);
+vert_compexpr_tokens([{'>=', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'>=', LN}|ParsedTokens]);
+vert_compexpr_tokens([{'=<', LN}|Rest], Args, ParsedTokens) ->
+    vert_compexpr_tokens(Rest, Args, [{'=<', LN}|ParsedTokens]);
+vert_compexpr_tokens([InvalidToken|_Rest], _Args, _ParsedTokens) ->
+    {error, io_lib:format("Invalid token ~w", [InvalidToken]), undefined}.
+
+
+%%%============================================================================
+%%% Test
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+good_querystring_test() ->
+    QueryString =
+        "(\"$dob\" >= \"19740301\" andalso \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\" andalso \"$dod\" < \"20230101\").",
+    AvailableArgs = ["dob", "dod"],
+    F = validate_comparison_expression(QueryString, AvailableArgs),
+    M1 = maps:from_list([{dob, "19750202"}, {dod, "20221216"}]),
+    M2 = maps:from_list([{dob, "19750202"}, {dod, "20191216"}]),
+    M3 = maps:from_list([{dob, "19790202"}, {dod, "20221216"}]),
+    M4 = maps:from_list([{dob, "19790202"}, {dod, "20191216"}]),
+    M5 = maps:from_list([{dob, "19790202"}, {dod, "20241216"}]),
+    ?assertMatch(true, element(2, F(M1))),
+    ?assertMatch(true, element(2, F(M2))),
+    ?assertMatch(true, element(2, F(M3))),
+    ?assertMatch(false, element(2, F(M4))),
+    ?assertMatch(false, element(2, F(M5))).
+
+bad_querystring_test() ->
+    QueryString =
+        "(\"$dob\" >= \"19740301\" andalso \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\").",
+    BadString1 =
+        "(\"$dob\" >= \"19740301\" andalso \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\")",
+    BadString2 =
+        "(\"$dob\" >= \"19740301\" andalso \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\")).",
+    BadString3 =
+        "(\"$dob\" >= \"19740301\" and \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\").",
+    BadString4 = "os:cmd(foo)",
+    BadString5 =
+        [42,63,52,10,240,159,140,190] ++
+        "(\"$dob\" >= \"19740301\" andalso \"$dob\" =< \"19761030\")"
+        " or (\"$dod\" > \"20200101\").",
+    BadString6 = [(16#110000 + 1)|QueryString],
+    BadString7 = <<42:32/integer>>,
+    ?assertMatch(
+        {error, "Unavailable Arg dod", 1},
+        validate_comparison_expression(QueryString, ["dob", "pv"])
+    ),
+    ?assertMatch(
+        {error, "Query does not end with `.`", undefined},
+        validate_comparison_expression(BadString1, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, {1 ,erl_parse, ["syntax error before: ","')'"]}, undefined},
+        validate_comparison_expression(BadString2, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, "Invalid token {'and',1}", undefined},
+        validate_comparison_expression(BadString3, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, "Invalid token {atom,1,os}", undefined},
+        validate_comparison_expression(BadString4, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, "Invalid token {'*',1}", undefined},
+        validate_comparison_expression(BadString5, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, {1, erl_scan, {illegal,character}}, 1},
+        validate_comparison_expression(BadString6, ["dob", "dod"])
+    ),
+    ?assertMatch(
+        {error, "Expression not a valid string", undefined},
+        validate_comparison_expression(BadString7, ["dob", "dod"])
+    ).
+
+-endif.

--- a/src/leveled_filterlexer.xrl
+++ b/src/leveled_filterlexer.xrl
@@ -1,0 +1,49 @@
+%% Lexer for filter and conditional expressions
+%% Author: Thomas Arts
+
+Definitions.
+WhiteSpace  = ([\t\f\v\r\n\s]+)
+
+Rules.
+
+{WhiteSpace} : skip_token.
+
+\( : {token, {'(', TokenLine}}.
+\) : {token, {')', TokenLine}}.
+
+,       : {token, {',', TokenLine}}.
+NOT     : {token, {'NOT', TokenLine}}.
+AND     : {token, {'AND', TokenLine}}.
+OR      : {token, {'OR', TokenLine}}.
+BETWEEN : {token, {'BETWEEN', TokenLine}}.
+IN      : {token, {'IN', TokenLine}}.
+=       : {token, {comparator, '=', TokenLine}}.
+<       : {token, {comparator, '<', TokenLine}}.
+>       : {token, {comparator, '>', TokenLine}}.
+<>      : {token, {comparator, '<>', TokenLine}}.
+<=      : {token, {comparator, '<=', TokenLine}}.
+>=      : {token, {comparator, '>=', TokenLine}}.
+
+contains             : {token, {'contains', TokenLine}}.
+begins_with          : {token, {'begins_with', TokenLine}}.
+attribute_exists     : {token, {'attribute_exists', TokenLine}}.
+attribute_not_exists : {token, {'attribute_not_exists', TokenLine}}.
+attribute_empty      : {token, {'attribute_empty', TokenLine}}.
+
+\$[a-zA-Z_][a-zA-Z_0-9]* : {token, {identifier, TokenLine, strip_identifier(TokenChars)}}.
+\:[a-zA-Z_][a-zA-Z_0-9]* : {token, {substitution, TokenLine, strip_substitution(TokenChars)}}.
+[0-9]+                   : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
+\"[^"]*\"                : {token, {string, TokenLine, strip_string(TokenChars)}}. %"
+
+Erlang code.
+
+strip_string(TokenChars) ->
+    list_to_binary(lists:sublist(TokenChars, 2, length(TokenChars) -2)).
+
+strip_identifier(TokenChars) ->
+    [36|StrippedChars] = TokenChars,
+    list_to_binary(StrippedChars).
+
+strip_substitution(TokenChars) ->
+    [58|StrippedChars] = TokenChars,
+    list_to_binary(StrippedChars).

--- a/src/leveled_filterlexer.xrl
+++ b/src/leveled_filterlexer.xrl
@@ -24,11 +24,11 @@ IN      : {token, {'IN', TokenLine}}.
 <=      : {token, {comparator, '<=', TokenLine}}.
 >=      : {token, {comparator, '>=', TokenLine}}.
 
-contains             : {token, {'contains', TokenLine}}.
-begins_with          : {token, {'begins_with', TokenLine}}.
-attribute_exists     : {token, {'attribute_exists', TokenLine}}.
-attribute_not_exists : {token, {'attribute_not_exists', TokenLine}}.
-attribute_empty      : {token, {'attribute_empty', TokenLine}}.
+contains             : {token, {contains, TokenLine}}.
+begins_with          : {token, {begins_with, TokenLine}}.
+attribute_exists     : {token, {attribute_exists, TokenLine}}.
+attribute_not_exists : {token, {attribute_not_exists, TokenLine}}.
+attribute_empty      : {token, {attribute_empty, TokenLine}}.
 
 \$[a-zA-Z_][a-zA-Z_0-9]* : {token, {identifier, TokenLine, strip_identifier(TokenChars)}}.
 \:[a-zA-Z_][a-zA-Z_0-9]* : {token, {substitution, TokenLine, strip_substitution(TokenChars)}}.

--- a/src/leveled_filterparser.yrl
+++ b/src/leveled_filterparser.yrl
@@ -1,0 +1,50 @@
+%% Grammar for filter expressions
+%% Author: Thomas Arts
+
+Nonterminals
+top_level condition operand operand_list operands.
+
+
+Terminals
+'(' ')' comparator identifier string integer
+','
+'NOT' 'AND' 'OR' 'IN' 'BETWEEN'
+'contains' 'begins_with'
+'attribute_exists' 'attribute_not_exists' 'attribute_empty'.
+
+
+Rootsymbol top_level.
+
+top_level -> condition: {condition, '$1'}.
+
+condition -> operand comparator operand    : {'$2', '$1', '$3'}.
+condition -> operand 'BETWEEN' string 'AND' string   : {'BETWEEN', '$1', '$3', '$5'}.
+condition -> operand 'BETWEEN' integer 'AND' integer   : {'BETWEEN', '$1', '$3', '$5'}.
+condition -> operand 'IN' operand_list     : {'IN', '$1', '$3'}.
+condition -> condition 'AND' condition     : {'AND', '$1', '$3'}.
+condition -> condition 'OR' condition      : {'OR', '$1', '$3'}.
+condition -> 'NOT' condition               : {'NOT', '$2'}.
+condition -> 'contains' '(' identifier ',' string ')'       : {'contains', '$3', '$5'}.
+condition -> 'begins_with' '(' identifier ',' string ')'    : {'begins_with', '$3', '$5'}.
+condition -> 'attribute_exists' '(' identifier ')'          : {'attribute_exists', '$3'}.
+condition -> 'attribute_not_exists' '(' identifier ')'      : {'attribute_not_exists', '$3'}.
+condition -> 'attribute_empty' '(' identifier ')'           : {'attribute_empty', '$3'}.
+condition -> '(' condition ')'             : '$2'.
+
+operand -> identifier   : '$1'.
+operand -> string       : '$1'.
+operand -> integer      : '$1'.
+
+operand_list -> '(' operands ')' : '$2'.
+
+operands -> operand ',' operands : ['$1' | '$3'].
+operands -> operand              : ['$1'].
+
+Endsymbol '$end'.
+
+Right 200 'NOT'.
+Nonassoc 200 comparator.
+Left 150 'AND'.
+Left 100 'OR'.
+
+Erlang code.

--- a/src/leveled_filterparser.yrl
+++ b/src/leveled_filterparser.yrl
@@ -9,8 +9,8 @@ Terminals
 '(' ')' comparator identifier string integer
 ','
 'NOT' 'AND' 'OR' 'IN' 'BETWEEN'
-'contains' 'begins_with'
-'attribute_exists' 'attribute_not_exists' 'attribute_empty'.
+contains begins_with
+attribute_exists attribute_not_exists attribute_empty.
 
 
 Rootsymbol top_level.
@@ -18,17 +18,18 @@ Rootsymbol top_level.
 top_level -> condition: {condition, '$1'}.
 
 condition -> operand comparator operand    : {'$2', '$1', '$3'}.
-condition -> operand 'BETWEEN' string 'AND' string   : {'BETWEEN', '$1', '$3', '$5'}.
+condition -> operand 'BETWEEN' string 'AND' string     : {'BETWEEN', '$1', '$3', '$5'}.
 condition -> operand 'BETWEEN' integer 'AND' integer   : {'BETWEEN', '$1', '$3', '$5'}.
 condition -> operand 'IN' operand_list     : {'IN', '$1', '$3'}.
+condition -> operand 'IN' identifier       : {'IN', '$1', '$3'}.  
 condition -> condition 'AND' condition     : {'AND', '$1', '$3'}.
 condition -> condition 'OR' condition      : {'OR', '$1', '$3'}.
 condition -> 'NOT' condition               : {'NOT', '$2'}.
-condition -> 'contains' '(' identifier ',' string ')'       : {'contains', '$3', '$5'}.
-condition -> 'begins_with' '(' identifier ',' string ')'    : {'begins_with', '$3', '$5'}.
-condition -> 'attribute_exists' '(' identifier ')'          : {'attribute_exists', '$3'}.
-condition -> 'attribute_not_exists' '(' identifier ')'      : {'attribute_not_exists', '$3'}.
-condition -> 'attribute_empty' '(' identifier ')'           : {'attribute_empty', '$3'}.
+condition -> contains '(' identifier ',' string ')'       : {contains, '$3', '$5'}.
+condition -> begins_with '(' identifier ',' string ')'    : {begins_with, '$3', '$5'}.
+condition -> attribute_exists '(' identifier ')'          : {attribute_exists, '$3'}.
+condition -> attribute_not_exists '(' identifier ')'      : {attribute_not_exists, '$3'}.
+condition -> attribute_empty '(' identifier ')'           : {attribute_empty, '$3'}.
 condition -> '(' condition ')'             : '$2'.
 
 operand -> identifier   : '$1'.

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -130,12 +130,11 @@ bucket_list(SnapFun, Tag, FoldBucketsFun, InitAcc, MaxBuckets) ->
         end,
     {async, Runner}.
 
--spec index_query(snap_fun(), 
-                    {leveled_codec:ledger_key(), 
-                        leveled_codec:ledger_key(), 
-                        {boolean(), undefined|mp()|iodata()}}, 
-                    {fold_keys_fun(), foldacc()})
-                        -> {async, runner_fun()}.
+-spec index_query(
+    snap_fun(),
+    {leveled_codec:ledger_key(), leveled_codec:ledger_key(), 
+    {boolean()|binary(), leveled_codec:regular_expression()}}, 
+    {fold_keys_fun(), foldacc()}) -> {async, runner_fun()}.
 %% @doc
 %% Secondary index query
 %% This has the special capability that it will expect a message to be thrown
@@ -681,7 +680,7 @@ accumulate_keys(FoldKeysFun, undefined) ->
 accumulate_keys(FoldKeysFun, TermRegex) ->
     fun(Key, _Value, Acc) ->
         {B, K} = leveled_codec:from_ledgerkey(Key),
-        case leveled_util:regex_run(K, TermRegex) of
+        case leveled_util:regex_run(K, TermRegex, []) of
             nomatch ->
                 Acc;
             _ ->

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -12,7 +12,8 @@
             t2b/1,
             safe_rename/4,
             regex_run/3,
-            regex_compile/1
+            regex_compile/1,
+            regex_compile/2
         ]).
 
 -define(WRITE_OPS, [binary, raw, read, write]).
@@ -68,7 +69,12 @@ regex_run(Subject, CompiledPCRE, Opts) ->
 
 -spec regex_compile(iodata()) -> {ok, reference()}.
 regex_compile(PlainRegex) ->
-    re2:compile(PlainRegex).
+    regex_compile(PlainRegex, re2).
+
+regex_compile(PlainRegex, re2) ->
+    re2:compile(PlainRegex);
+regex_compile(PlainRegex, pcre) ->
+    re:compile(PlainRegex).
 
 -spec magic_hash(any()) -> 0..16#FFFFFFFF.
 %% @doc 

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -11,7 +11,7 @@
             magic_hash/1,
             t2b/1,
             safe_rename/4,
-            regex_run/2,
+            regex_run/3,
             regex_compile/1
         ]).
 
@@ -42,15 +42,31 @@ integer_time(TS) ->
     DT = calendar:now_to_universal_time(TS),
     calendar:datetime_to_gregorian_seconds(DT).
 
--spec regex_run(
-    iodata(), any()) ->
-        match | nomatch | {match, list()} | {error, atom()}.
-regex_run(Subject, CompiledRE2) when is_reference(CompiledRE2) ->
-    re2:run(Subject, CompiledRE2);
-regex_run(Subject, CompiledPCRE) ->
-    re:run(Subject, CompiledPCRE).
 
--spec regex_compile(iodata()) -> reference().
+-type match_option() ::
+    'caseless' |
+    {'offset', non_neg_integer()} |
+    {'capture', value_spec()} |
+    {'capture', value_spec(), value_spec_type()}.
+-type value_spec() ::
+    'all' | 'all_but_first' | 'first' | 'none' | [value_id()].
+-type value_spec_type() :: 'binary'.
+-type value_id() :: binary().
+-type match_index() :: {non_neg_integer(), non_neg_integer()}.
+
+-spec regex_run(
+    iodata(), leveled_codec:actual_regex(), list(match_option())) ->
+        match |
+        nomatch |
+        {match, list(match_index())} |
+        {match, list(binary())} |
+        {error, atom()}.
+regex_run(Subject, CompiledRE2, Opts) when is_reference(CompiledRE2) ->
+    re2:run(Subject, CompiledRE2, Opts);
+regex_run(Subject, CompiledPCRE, Opts) ->
+    re:run(Subject, CompiledPCRE, Opts).
+
+-spec regex_compile(iodata()) -> {ok, reference()}.
 regex_compile(PlainRegex) ->
     re2:compile(PlainRegex).
 

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -1100,6 +1100,18 @@ capture_and_filter_terms(_Config) ->
         "~nEval processed index with parsed filter expression took ~w ms~n",
         [timer:now_diff(SW11, SW10) div 1000]),
 
+    QueryRE2_3_WrongCapture =
+        {index_query,
+            {Bucket, null},
+            {fun testutil:foldkeysfun/3, []},
+            {IdxName, <<"M">>, <<"Z">>},
+            {<<"gns">>,
+                {capture, WillowLeedsExtractorRE2, [<<"dob">>], AllFun}}
+        },
+    {async, RunnerRE2_3_WC} =
+        leveled_bookie:book_returnfolder(Book1, QueryRE2_3_WrongCapture),
+    true = [] == RunnerRE2_3_WC(),
+
     ok = leveled_bookie:book_close(Book1),
     
     testutil:reset_filestructure().

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -582,6 +582,14 @@ random_people_queries(true, Bookie, Bucket, IndexesReturned) ->
             FilterExpression, maps:new()),
     FilterFun =
         fun(AttrMap) -> leveled_filter:apply_filter(ParsedFilter, AttrMap) end,
+    EvalExpression = "delim($term, \"|\", ($surname, $dob, $dod, $gns, $pcs))",
+    {ok, ParsedEval} =
+        leveled_eval:generate_eval_expression(EvalExpression, maps:new()),
+    EvalFun =
+        fun(Term, Key) ->
+            leveled_eval:apply_eval(ParsedEval, Term, Key, maps:new())
+        end,
+        
     QueryFun =
         fun() ->
             Surname = get_random_surname(),
@@ -597,12 +605,7 @@ random_people_queries(true, Bookie, Bucket, IndexesReturned) ->
                     {Bucket, <<>>}, 
                     {FoldKeysFun, 0},
                     Range,
-                    {true,
-                        {delimited,
-                            "|",
-                            [<<"surname">>, <<"dob">>, <<"dod">>, <<"gns">>, <<"pcs">>],
-                            FilterFun
-                        }
+                    {true, {eval, EvalFun, FilterFun}
                     }),
             R()
         end,

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -5,6 +5,7 @@
 -export([
     riak_ctperf/1, riak_fullperf/1, riak_profileperf/1, riak_miniperf/1
 ]).
+-export([random_people_index/0]).
 
 -define(PEOPLE_INDEX, <<"people_bin">>).
 -define(MINI_QUERY_DIVISOR, 8).


### PR DESCRIPTION
Allow for evaluation and filtering of 2i terms.

Eval: Have a language of functions whereby, a map of Key/Value pairs can be extracted by applying those functions in a pipeline.

Filter: Have a language of functions and operators to apply a logic expression to determine if a term matches a filter, based on the entries in the map output from the eval pipeline.

The aim is to have an alternative to regular expression filtering in Riak.  Sometimes the auto-generation of regular expressions become complex, and somethings (such as date ranges) and potentially impossible.  The aim of the filter expression is to do this in a more natural language.
