### PR TITLE
Improve perf_SUITE test

### DIFF
--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -302,13 +302,7 @@ split_builder_speed_tester() ->
     Timings =
         lists:map(
             fun(HashList) ->
-                SlotCount =
-                    case length(HashList) of
-                        0 ->
-                            0;
-                        L ->
-                            min(128, max(2, (L - 1) div 512))
-                    end,
+                SlotCount = min(128, max(2, (length(HashList) - 1) div 512)),
                 InitTuple = list_to_tuple(lists:duplicate(SlotCount, [])),
                 {MTC, SlotHashes} =
                     timer:tc(

--- a/src/leveled_head.erl
+++ b/src/leveled_head.erl
@@ -32,8 +32,12 @@
             ]).
 
 %% Exported for testing purposes
--export([riak_metadata_to_binary/2,
-            riak_extract_metadata/2]).
+-export(
+    [
+        riak_metadata_to_binary/2,
+        riak_extract_metadata/2,
+        get_indexes_from_siblingmetabin/2
+    ]).
 
 
 -define(MAGIC, 53). % riak_kv -> riak_object

--- a/src/leveled_pmanifest.erl
+++ b/src/leveled_pmanifest.erl
@@ -74,7 +74,7 @@
             % At o(10) trillion keys behaviour may become increasingly 
             % difficult to predict.
 
--if(OTP_RELEASE >= 25).
+-if(?OTP_RELEASE >= 25).
 -if(length(?LEVEL_SCALEFACTOR) /= ?MAX_LEVELS).
 -error("length ?LEVEL_SCALEFACTOR differs from ?MAX_LEVELS").
 -endif.

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -93,13 +93,13 @@ riak_load_tester(Bucket, KeyCount, ObjSize, ProfileList, PM, LC) ->
         fun(ListID) ->
             fun() ->
                 RandInt = leveled_rand:uniform(IndexCount - 1),
-                IntIndex = "integer" ++ integer_to_list(ListID) ++ "_int",
-                BinIndex = "binary" ++ integer_to_list(ListID) ++ "_bin",
-                [{add, list_to_binary(IntIndex), RandInt},
+                IntIndex = ["integer", integer_to_list(ListID), "_int"],
+                BinIndex = ["binary", integer_to_list(ListID), "_bin"],
+                [{add, iolist_to_binary(IntIndex), RandInt},
                 {add, ?PEOPLE_INDEX, list_to_binary(random_people_index())},
-                {add, list_to_binary(IntIndex), RandInt + 1},
-                {add, list_to_binary(BinIndex), <<RandInt:32/integer>>},
-                {add, list_to_binary(BinIndex), <<(RandInt + 1):32/integer>>}]
+                {add, iolist_to_binary(IntIndex), RandInt + 1},
+                {add, iolist_to_binary(BinIndex), <<RandInt:32/integer>>},
+                {add, iolist_to_binary(BinIndex), <<(RandInt + 1):32/integer>>}]
             end
         end,
 
@@ -361,7 +361,7 @@ profile_app(Pids, ProfiledFun, P) ->
 
     eprof:stop_profiling(),
     eprof:log(atom_to_list(P) ++ ".log"),
-    eprof:analyze(total, [{filter, [{time, 150000}]}]),
+    eprof:analyze(total, [{filter, [{time, 100000}]}]),
     eprof:stop(),
     {ok, Analysis} = file:read_file(atom_to_list(P) ++ ".log"),
     io:format(user, "~n~s~n", [Analysis])
@@ -609,7 +609,7 @@ random_queries(Bookie, Bucket, IDs, IdxCnt, MaxRange, IndexesReturned) ->
         fun() ->
             ID = leveled_rand:uniform(IDs), 
             BinIndex =
-                list_to_binary("binary" ++ integer_to_list(ID) ++ "_bin"),
+                iolist_to_binary(["binary", integer_to_list(ID), "_bin"]),
             Twenty = IdxCnt div 5,
             RI = leveled_rand:uniform(MaxRange),
             [Start, End] =

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -562,25 +562,23 @@ counter(Bookie, estimate) ->
     
 
 random_fetches(FetchType, Bookie, Bucket, ObjCount, Fetches) ->
-    KeysToFetch =
-        lists:map(
-            fun(I) ->
-                Twenty = ObjCount div 5,
-                case I rem 5 of
-                    1 ->
-                        testutil:fixed_bin_key(
-                            Twenty + leveled_rand:uniform(ObjCount - Twenty));
-                    _ ->
-                        testutil:fixed_bin_key(leveled_rand:uniform(Twenty))
-                end
-            end,
-            lists:seq(1, Fetches)
-        ),
+    Twenty = ObjCount div 5,
+    KeyFun = 
+        fun(I) ->        
+            case I rem 5 of
+                1 ->
+                    testutil:fixed_bin_key(
+                        Twenty + leveled_rand:uniform(ObjCount - Twenty));
+                _ ->
+                    testutil:fixed_bin_key(leveled_rand:uniform(Twenty))
+            end
+        end,
     {TC, ok} =
         timer:tc(
             fun() ->
                 lists:foreach(
-                    fun(K) ->
+                    fun(I) ->
+                        K = KeyFun(I),
                         {ok, _} =
                             case FetchType of
                                 riakget ->
@@ -595,7 +593,7 @@ random_fetches(FetchType, Bookie, Bucket, ObjCount, Fetches) ->
                                     testutil:book_riakhead(Bookie, Bucket, K)
                             end
                     end,
-                    KeysToFetch
+                    lists:seq(1, Fetches)
                 )
             end
         ),

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -83,7 +83,6 @@ riak_load_tester(Bucket, KeyCount, ObjSize, ProfileList, PM, LC) ->
             {log_level, warn},
             {compression_method, PM},
             {ledger_compression, LC},
-            {max_pencillercachesize, 16000},
             {forced_logs,
                 [b0015, b0016, b0017, b0018, p0032, sst12]}
         ],

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -459,12 +459,37 @@ rotation_withnocheck(Book, B, NumberOfObjects, ObjSize, IdxCnt) ->
     ok.
 
 generate_chunk(CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
-    testutil:generate_objects(
-        CountPerList, 
-        {fixed_binary, (Chunk - 1) * CountPerList + 1}, [],
-        base64:encode(leveled_rand:rand_bytes(ObjSize)),
-        IndexGenFun(Chunk),
-        Bucket
+    IndexGen = IndexGenFun(Chunk),
+    Value = base64:encode(leveled_rand:rand_bytes(ObjSize)),
+    lists:map(
+        fun(KeyNumber) ->
+            {Obj, IdxSpecs} =
+                testutil:set_object(
+                    Bucket, testutil:fixed_bin_key(KeyNumber), Value, IndexGen, []
+                ),
+            {
+                Bucket,
+                testutil:fixed_bin_key(KeyNumber),
+                testutil:to_binary(v1, Obj),
+                IdxSpecs
+            }
+        end,
+        lists:seq((Chunk - 1) * CountPerList + 1, Chunk * CountPerList)
+    ).
+
+load_chunk(Bookie, ObjList) ->
+    lists:foreach(
+        fun({Bucket, Key, BinObject, IndexSpecs}) ->
+            leveled_bookie:book_put(
+                Bookie,
+                Bucket,
+                binary:copy(Key),
+                binary:copy(BinObject),
+                IndexSpecs,
+                ?RIAK_TAG
+            )
+        end,
+        ObjList
     ).
 
 load_chunk(Bookie, CountPerList, ObjSize, IndexGenFun, Bucket, Chunk) ->
@@ -725,10 +750,21 @@ profile_fun(
 profile_fun(
         {load, IndexGenFun},
         {Bookie, Bucket, KeyCount, ObjSize, _IndexCount, _IndexesReturned}) ->
-    ObjList11 =
-        generate_chunk(KeyCount div 10, ObjSize, IndexGenFun, Bucket, 11),
+    Chunk11 = generate_chunk(KeyCount div 50, ObjSize, IndexGenFun, Bucket, 11),
+    Chunk12 = generate_chunk(KeyCount div 50, ObjSize, IndexGenFun, Bucket, 12),
+    Chunk13 = generate_chunk(KeyCount div 50, ObjSize, IndexGenFun, Bucket, 13),
+    Chunk14 = generate_chunk(KeyCount div 50, ObjSize, IndexGenFun, Bucket, 14),
+    Chunk15 = generate_chunk(KeyCount div 50, ObjSize, IndexGenFun, Bucket, 15),
     fun() ->
-        testutil:riakload(Bookie, ObjList11)
+        load_chunk(Bookie, Chunk11),
+        garbage_collect(),
+        load_chunk(Bookie, Chunk12),
+        garbage_collect(),
+        load_chunk(Bookie, Chunk13),
+        garbage_collect(),
+        load_chunk(Bookie, Chunk14),
+        garbage_collect(),
+        load_chunk(Bookie, Chunk15)
     end;
 profile_fun(
         update,

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -361,7 +361,7 @@ profile_app(Pids, ProfiledFun, P) ->
 
     eprof:stop_profiling(),
     eprof:log(atom_to_list(P) ++ ".log"),
-    eprof:analyze(total, [{filter, [{time, 100000}]}]),
+    eprof:analyze(total, [{filter, [{time, 160000}]}]),
     eprof:stop(),
     {ok, Analysis} = file:read_file(atom_to_list(P) ++ ".log"),
     io:format(user, "~n~s~n", [Analysis])
@@ -694,21 +694,21 @@ profile_fun(
     fun() ->
         random_queries(
             Bookie, Bucket, 10, IndexCount, QuerySize,
-            IndexesReturned div ?MINI_QUERY_DIVISOR)
+            (IndexesReturned * 2) div ?MINI_QUERY_DIVISOR)
     end;
 profile_fun(
         {query, QuerySize},
         {Bookie, Bucket, _KeyCount, _ObjSize, IndexCount, IndexesReturned}) ->
     fun() ->
         random_queries(
-            Bookie, Bucket, 10, IndexCount, QuerySize, IndexesReturned)
+            Bookie, Bucket, 10, IndexCount, QuerySize, IndexesReturned * 2)
     end;
 profile_fun(
         regex_query,
         {Bookie, Bucket, _KeyCount, _ObjSize, _IndexCount, IndexesReturned}) ->
     fun() ->
         random_people_queries(
-            Bookie, Bucket, IndexesReturned div ?RGEX_QUERY_DIVISOR)
+            Bookie, Bucket, (IndexesReturned * 2) div ?RGEX_QUERY_DIVISOR)
     end;
 profile_fun(
         {head, HeadFetches},
@@ -734,7 +734,7 @@ profile_fun(
         update,
         {Bookie, _Bucket, KeyCount, ObjSize, _IndexCount, _IndexesReturned}) ->
     fun() ->
-        rotate_chunk(Bookie, <<"ProfileB">>, KeyCount div 200, ObjSize, 2)
+        rotate_chunk(Bookie, <<"ProfileB">>, KeyCount div 100, ObjSize, 2)
     end;
 profile_fun(
         CounterFold,
@@ -744,7 +744,7 @@ profile_fun(
             full ->
                 20;
             estimate ->
-                40;
+                50;
             guess ->
                 100
         end,

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -653,8 +653,10 @@ get_value(ObjectBin) ->
             <<SibLength:32/integer, Rest2/binary>> = SibsBin,
             <<ContentBin:SibLength/binary, _MetaBin/binary>> = Rest2,
             case ContentBin of
-                <<0, ContentBin0/binary>> ->
-                    binary_to_term(ContentBin0)
+                <<0:8/integer, ContentBin0/binary>> ->
+                    binary_to_term(ContentBin0);
+                <<1:8/integer, ContentAsIs/binary>> ->
+                    ContentAsIs
             end;
         N ->
             io:format("SibCount of ~w with ObjectBin ~w~n", [N, ObjectBin]),

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -65,9 +65,7 @@
             numbered_key/1,
             fixed_bin_key/1,
             convert_to_seconds/1,
-            compact_and_wait/1,
-            to_binary/2
-        ]).
+            compact_and_wait/1]).
 
 -define(RETURN_TERMS, {true, undefined}).
 -define(SLOWOFFER_DELAY, 40).

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -65,7 +65,9 @@
             numbered_key/1,
             fixed_bin_key/1,
             convert_to_seconds/1,
-            compact_and_wait/1]).
+            compact_and_wait/1,
+            to_binary/2
+        ]).
 
 -define(RETURN_TERMS, {true, undefined}).
 -define(SLOWOFFER_DELAY, 40).

--- a/test/end_to_end/testutil.erl
+++ b/test/end_to_end/testutil.erl
@@ -295,8 +295,11 @@ reset_filestructure(RootPath) when is_list(RootPath) ->
     reset_filestructure(0, RootPath).
 
 reset_filestructure(Wait, RootPath) ->
-    io:format("Waiting ~w ms to give a chance for all file closes " ++
-                 "to complete~n", [Wait]),
+    io:format(
+        "Waiting ~w ms to give a chance for all file closes "
+        "to complete~n",
+        [Wait]
+    ),
     timer:sleep(Wait),
     filelib:ensure_dir(RootPath ++ "/journal/"),
     filelib:ensure_dir(RootPath ++ "/ledger/"),
@@ -311,8 +314,11 @@ wait_for_compaction(Bookie) ->
                             false ->
                                 false;
                             true ->
-                                io:format("Loop ~w waiting for journal "
-                                    ++ "compaction to complete~n", [X]),
+                                io:format(
+                                    "Loop ~w waiting for journal "
+                                    "compaction to complete~n",
+                                    [X]
+                                ),
                                 timer:sleep(5000),
                                 F(Bookie)
                         end end,
@@ -855,7 +861,7 @@ put_altered_indexed_objects(Book, Bucket, KSpecL, RemoveOld2i, V) ->
                 end,
             % Note that order in the SpecL is important, as
             % check_indexed_objects, needs to find the latest item added
-            {{K, NewSpecs ++ AddSpc}, AccOut}
+            {{K, lists:append(NewSpecs, AddSpc)}, AccOut}
         end,
     {RplKSpecL, Pauses} = lists:mapfoldl(MapFun, 0, KSpecL),
     io:format(
@@ -949,17 +955,22 @@ compact_and_wait(Book) ->
 compact_and_wait(Book, WaitForDelete) ->
     ok = leveled_bookie:book_compactjournal(Book, 30000),
     F = fun leveled_bookie:book_islastcompactionpending/1,
-    lists:foldl(fun(X, Pending) ->
-                        case Pending of
-                            false ->
-                                false;
-                            true ->
-                                io:format("Loop ~w waiting for journal "
-                                    ++ "compaction to complete~n", [X]),
-                                timer:sleep(20000),
-                                F(Book)
-                        end end,
-                    true,
-                    lists:seq(1, 15)),
+    lists:foldl(
+        fun(X, Pending) ->
+            case Pending of
+                false ->
+                    false;
+                true ->
+                    io:format(
+                        "Loop ~w waiting for journal "
+                        "compaction to complete~n",
+                        [X]
+                    ),
+                    timer:sleep(20000),
+                    F(Book)
+            end
+        end,
+        true,
+        lists:seq(1, 15)),
     io:format("Waiting for journal deletes~n"),
     timer:sleep(WaitForDelete).


### PR DESCRIPTION
The update teat is refactored so as not to generate a large KV list which dominates the memory utilisation.

The update and the get tests changes to do a head before each operation - which emulates how this will work in RIAK.