### PR TITLE
Mas d34 ms.i446 plusplus

### DIFF
--- a/src/leveled_cdb.erl
+++ b/src/leveled_cdb.erl
@@ -1722,11 +1722,11 @@ build_hashtree_binary(SlotMap, IndexLength) ->
 
 build_hashtree_binary([], IdxLen, SlotPos, Bin) ->
     case SlotPos of
-        IdxLen ->
-            lists:reverse(Bin);
+        N when N == IdxLen ->
+            Bin;
         N when N < IdxLen ->
             ZeroLen = (IdxLen - N) * 64,
-            lists:reverse([<<0:ZeroLen>>|Bin])
+            [<<0:ZeroLen>>|Bin]
     end;
 build_hashtree_binary([{TopSlot, TopBin}|SlotMapTail], IdxLen, SlotPos, Bin) ->
     case TopSlot of
@@ -1774,7 +1774,7 @@ write_hash_tables([], _HashTree, _CurrPos, _BasePos,
                                         IndexList, HT_BinList, {T1, T2, T3}) ->
     leveled_log:log(cdb14, [T1, T2, T3]),
     IL = lists:reverse(IndexList),
-    {IL, list_to_binary(HT_BinList)};
+    {IL, list_to_binary(lists:reverse(HT_BinList))};
 write_hash_tables([Index|Rest], HashTree, CurrPos, BasePos,
                                         IndexList, HT_BinList, Timers) ->
     SW1 = os:timestamp(),
@@ -1782,13 +1782,15 @@ write_hash_tables([Index|Rest], HashTree, CurrPos, BasePos,
     T1 = timer:now_diff(os:timestamp(), SW1) + element(1, Timers),
     case SlotMap of
         [] ->
-            write_hash_tables(Rest,
-                                HashTree,
-                                CurrPos,
-                                BasePos,
-                                [{Index, BasePos, 0}|IndexList],
-                                HT_BinList,
-                                Timers);
+            write_hash_tables(
+                Rest,
+                HashTree,
+                CurrPos,
+                BasePos,
+                [{Index, BasePos, 0}|IndexList],
+                HT_BinList,
+                Timers
+            );
         _ ->
             SW2 = os:timestamp(),
             IndexLength = length(SlotMap) * 2,
@@ -1797,13 +1799,15 @@ write_hash_tables([Index|Rest], HashTree, CurrPos, BasePos,
             SW3 = os:timestamp(),
             NewSlotBin = build_hashtree_binary(SortedMap, IndexLength),
             T3 = timer:now_diff(os:timestamp(), SW3) + element(3, Timers),
-            write_hash_tables(Rest,
-                                HashTree,
-                                CurrPos + IndexLength * ?DWORD_SIZE,
-                                BasePos,
-                                [{Index, CurrPos, IndexLength}|IndexList],
-                                HT_BinList ++ NewSlotBin,
-                                {T1, T2, T3})
+            write_hash_tables(
+                Rest,
+                HashTree,
+                CurrPos + IndexLength * ?DWORD_SIZE,
+                BasePos,
+                [{Index, CurrPos, IndexLength}|IndexList],
+                lists:append(NewSlotBin, HT_BinList),
+                {T1, T2, T3}
+            )
     end.
 
 
@@ -1949,7 +1953,12 @@ build_hashtree_bunchedatend_binary_test() ->
                 {14, <<15:32, 500:32>>},
                 {15, <<16:32, 600:32>>},
                 {15, <<17:32, 700:32>>}],
-    Bin = list_to_binary(build_hashtree_binary(SlotMap, 16)),
+    Bin =
+        list_to_binary(
+            lists:reverse(
+                build_hashtree_binary(SlotMap, 16)
+            )
+        ),
     ExpBinP1 = <<16:32, 600:32, 10:32, 0:32, 17:32, 700:32, 0:64>>,
     ExpBinP2 = <<11:32, 100:32, 0:192, 12:32, 200:32, 13:32, 300:32, 0:256>>,
     ExpBinP3 = <<14:32, 400:32, 15:32, 500:32>>,
@@ -1965,7 +1974,12 @@ build_hashtree_bunchedatstart_binary_test() ->
                 {6, <<15:32, 500:32>>},
                 {7, <<16:32, 600:32>>},
                 {8, <<17:32, 700:32>>}],
-    Bin = list_to_binary(build_hashtree_binary(SlotMap, 16)),
+    Bin =
+        list_to_binary(
+            lists:reverse(
+                build_hashtree_binary(SlotMap, 16)
+            )
+        ),
     ExpBinP1 = <<0:64, 10:32, 0:32, 11:32, 100:32, 12:32, 200:32>>,
     ExpBinP2 = <<13:32, 300:32, 14:32, 400:32, 15:32, 500:32, 16:32, 600:32>>,
     ExpBinP3 = <<17:32, 700:32, 0:448>>,
@@ -1988,7 +2002,7 @@ build_hashtree_test() ->
                 [<<2424915712:32, 300:32>>, <<0:64>>] ++
                 [<<2424903936:32, 400:32>>, <<2424907008:32, 500:32>>] ++
                 [<<2424913408:32, 600:32>>],
-    ?assertMatch(ExpOut, BinList).
+    ?assertMatch(ExpOut, lists:reverse(BinList)).
 
 
 find_firstzero_test() ->

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -96,7 +96,7 @@ map_hashes([Hash|Rest], HashListTuple, SlotCount) ->
     SlotHL = element(Slot + 1, HashListTuple),
     map_hashes(
         Rest,
-        setelement(Slot + 1, HashListTuple, [H0|[H1|SlotHL]]),
+        setelement(Slot + 1, HashListTuple, [H0, H1 | SlotHL]),
         SlotCount).
 
 -spec split_hash(external_hash(), slot_count())

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -92,11 +92,11 @@ check_hash({_SegHash, Hash}, BloomBin) when is_binary(BloomBin)->
 map_hashes([], HashListTuple,  _SlotCount) ->
     HashListTuple;
 map_hashes([Hash|Rest], HashListTuple, SlotCount) ->
-    {Slot, Hashes} = split_hash(element(2, Hash), SlotCount),
+    {Slot, [H0, H1]} = split_hash(element(2, Hash), SlotCount),
     SlotHL = element(Slot + 1, HashListTuple),
     map_hashes(
         Rest,
-        setelement(Slot + 1, HashListTuple, Hashes ++ SlotHL),
+        setelement(Slot + 1, HashListTuple, [H0|[H1|SlotHL]]),
         SlotCount).
 
 -spec split_hash(external_hash(), slot_count())

--- a/src/leveled_ebloom.erl
+++ b/src/leveled_ebloom.erl
@@ -302,13 +302,7 @@ split_builder_speed_tester() ->
     Timings =
         lists:map(
             fun(HashList) ->
-                SlotCount =
-                    case length(HashList) of
-                        0 ->
-                            0;
-                        L ->
-                            min(128, max(2, (L - 1) div 512))
-                    end,
+                SlotCount = min(128, max(2, (length(HashList) - 1) div 512)),
                 InitTuple = list_to_tuple(lists:duplicate(SlotCount, [])),
                 {MTC, SlotHashes} =
                     timer:tc(

--- a/src/leveled_head.erl
+++ b/src/leveled_head.erl
@@ -417,9 +417,9 @@ decode_maybe_binary(<<0, Bin/binary>>) ->
 decode_maybe_binary(<<_Other:8, Bin/binary>>) ->
     Bin.
 
--spec diff_index_data([{binary(), index_value()}],
-                      [{binary(), index_value()}]) ->
-    [{index_op(), binary(), index_value()}].
+-spec diff_index_data(
+    [{binary(), index_value()}], [{binary(), index_value()}]) ->
+        [{index_op(), binary(), index_value()}].
 diff_index_data(OldIndexes, AllIndexes) ->
     OldIndexSet = ordsets:from_list(OldIndexes),
     AllIndexSet = ordsets:from_list(AllIndexes),
@@ -431,18 +431,20 @@ diff_specs_core(AllIndexSet, OldIndexSet) ->
     RemoveIndexSet =
         ordsets:subtract(OldIndexSet, AllIndexSet),
     NewIndexSpecs =
-        assemble_index_specs(ordsets:subtract(NewIndexSet, OldIndexSet),
-                             add),
+        assemble_index_specs(
+            ordsets:subtract(NewIndexSet, OldIndexSet),
+            add
+        ),
     RemoveIndexSpecs =
-        assemble_index_specs(RemoveIndexSet,
-                             remove),
+        assemble_index_specs(RemoveIndexSet, remove),
     NewIndexSpecs ++ RemoveIndexSpecs.
 
 %% @doc Assemble a list of index specs in the
 %% form of triplets of the form
 %% {IndexOperation, IndexField, IndexValue}.
--spec assemble_index_specs([{binary(), binary()}], index_op()) ->
-                                  [{index_op(), binary(), binary()}].
+-spec assemble_index_specs(
+    [{binary(), binary()}], index_op()) ->
+        [{index_op(), binary(), binary()}].
 assemble_index_specs(Indexes, IndexOp) ->
     [{IndexOp, Index, Value} || {Index, Value} <- Indexes].
 

--- a/src/leveled_penciller.erl
+++ b/src/leveled_penciller.erl
@@ -2008,6 +2008,9 @@ format_status_test() ->
     ?assertMatch(redacted, ST#state.levelzero_cache),
     ?assertMatch(redacted, ST#state.levelzero_index),
     ?assertMatch(redacted, ST#state.levelzero_astree),
+    NormStatus = format_status(#{reason => normal, state => S}),
+    NST = maps:get(state, NormStatus),
+    ?assert(is_integer(array:size(element(2, NST#state.manifest)))),
     clean_testdir(RootPath).
 
 close_no_crash_test_() ->

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2705,7 +2705,7 @@ revert_position(Pos) ->
 %%%============================================================================
 
 
-%% @doc See usnit test append_performance_test_/0 and also
+%% @doc See eunit test append_performance_test_/0 and also
 %% https://github.com/erlang/otp/pull/8743
 %% On OTP 26.2.1 -
 %% Time for plus plus 16565

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2713,7 +2713,7 @@ revert_position(Pos) ->
 %% Time for plus plus 16565
 %% Time for append 7453
 %% Time for lists:append 16428
-%% Time for bidmas plus plus 15928
+%% Time for right associative plus plus 15928
 %% ... this is all about optimising the case where there is an empty list
 %% on the RHS ... and the absolute benefit is marginal
 -spec append(list(), list()) -> list().

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2711,7 +2711,7 @@ revert_position(Pos) ->
 %% https://github.com/erlang/otp/pull/8743
 %% On OTP 26.2.1 -
 %% Time for plus plus 16565
-%% Time for inline append 7453
+%% Time for append 7453
 %% Time for lists:append 16428
 %% Time for bidmas plus plus 15928
 %% ... this is all about optimising the case where there is an empty list

--- a/src/leveled_tictac.erl
+++ b/src/leveled_tictac.erl
@@ -253,9 +253,12 @@ find_dirtyleaves(SrcTree, SnkTree) ->
             {Idx, SrcLeaf} = lists:keyfind(Idx, 1, SrcLeaves),
             {Idx, SnkLeaf} = lists:keyfind(Idx, 1, SnkLeaves),
             L2IdxList = segmentcompare(SrcLeaf, SnkLeaf),
-            Acc ++ lists:map(fun(X) -> X + Idx * ?L2_CHUNKSIZE end, L2IdxList)
+            lists:append(
+                lists:map(fun(X) -> X + Idx * ?L2_CHUNKSIZE end, L2IdxList),
+                Acc
+            )
         end,
-    lists:sort(lists:foldl(FoldFun, [], IdxList)).
+    lists:sort(lists:foldr(FoldFun, [], IdxList)).
 
 -spec find_dirtysegments(binary(), binary()) -> list(integer()).
 %% @doc
@@ -386,9 +389,9 @@ generate_segmentfilter_list(SegmentList, xsmall) ->
             A1 = 1 bsl 14,
             ExpandSegFun = 
                 fun(X, Acc) -> 
-                    Acc ++ [X, X + A0, X + A1, X + A0 + A1]
+                    [X, X + A0, X + A1, X + A0 + A1] ++ Acc
                 end,
-            lists:foldl(ExpandSegFun, [], SegmentList);
+            lists:foldr(ExpandSegFun, [], SegmentList);
         false ->
             false
     end;

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -5,12 +5,15 @@
 
 -module(leveled_util).
 
--export([generate_uuid/0,
+-export([
+            generate_uuid/0,
             integer_now/0,
             integer_time/1,
             magic_hash/1,
             t2b/1,
-            safe_rename/4]).
+            safe_rename/4
+        ]
+    ).
 
 -define(WRITE_OPS, [binary, raw, read, write]).
 


### PR DESCRIPTION
Within the `leveled_sst`, a previous attempt to avoid the inefficiency of using  `[relatively large list] ++ [relatively small list]` led to lost of reversing an re-reversing of lists.

This refactoring does a better job of enforcing the efficient appending of lists (as measured by perf_SUITE), and is potentially simpler to follow.