### PR TITLE
Mas i449 directpromptofdeletions

### DIFF
--- a/src/leveled_iclerk.erl
+++ b/src/leveled_iclerk.erl
@@ -85,7 +85,6 @@
         clerk_compact/6,
         clerk_hashtablecalc/3,
         clerk_trim/3,
-        clerk_promptdeletions/3,
         clerk_stop/1,
         clerk_loglevel/2,
         clerk_addlogs/2,
@@ -93,11 +92,8 @@
 
 -export([schedule_compaction/3]).
 
--define(JOURNAL_FILEX, "cdb").
--define(PENDING_FILEX, "pnd").
 -define(SAMPLE_SIZE, 192).
 -define(BATCH_SIZE, 32).
--define(BATCHES_TO_CHECK, 8).
 -define(CRC_SIZE, 4).
 -define(DEFAULT_RELOAD_STRATEGY, leveled_codec:inker_reload_strategy([])).
 -define(INTERVALS_PER_HOUR, 4).
@@ -187,12 +183,6 @@ clerk_compact(Pid, Checker, InitiateFun, CloseFun, FilterFun, Manifest) ->
 %% Trim the Inker back to the persisted SQN
 clerk_trim(Pid, PersistedSQN, ManifestAsList) ->
     gen_server:cast(Pid, {trim, PersistedSQN, ManifestAsList}).
-
--spec clerk_promptdeletions(pid(), pos_integer(), list()) -> ok. 
-%% @doc
-%%
-clerk_promptdeletions(Pid, ManifestSQN, DeletedFiles) ->
-    gen_server:cast(Pid, {prompt_deletions, ManifestSQN, DeletedFiles}).
 
 -spec clerk_hashtablecalc(ets:tid(), integer(), pid()) -> ok.
 %% @doc
@@ -418,14 +408,6 @@ handle_cast({trim, PersistedSQN, ManifestAsList}, State) ->
         leveled_imanifest:find_persistedentries(PersistedSQN, ManifestAsList),
     leveled_log:log(ic007, []),
     ok = leveled_inker:ink_clerkcomplete(State#state.inker, [], FilesToDelete),
-    {noreply, State};
-handle_cast({prompt_deletions, ManifestSQN, FilesToDelete}, State) ->
-    lists:foreach(fun({_SQN, _FN, J2D, _LK}) ->
-                        leveled_cdb:cdb_deletepending(J2D,
-                                                        ManifestSQN,
-                                                        State#state.inker)
-                        end,
-                    FilesToDelete),
     {noreply, State};
 handle_cast({hashtable_calc, HashTree, StartPos, CDBpid}, State) ->
     {IndexList, HashTreeBin} = leveled_cdb:hashtable_calc(HashTree, StartPos),

--- a/src/leveled_inker.erl
+++ b/src/leveled_inker.erl
@@ -736,9 +736,12 @@ handle_cast({clerk_complete, ManifestSnippet, FilesToDelete}, State) ->
     NewManifestSQN = State#state.manifest_sqn + 1,
     leveled_imanifest:printer(Man1),
     leveled_imanifest:writer(Man1, NewManifestSQN, State#state.root_path),
-    ok = leveled_iclerk:clerk_promptdeletions(State#state.clerk,
-                                                NewManifestSQN,
-                                                FilesToDelete),
+    lists:foreach(
+        fun({_SQN, _FN, J2D, _LK}) ->
+            leveled_cdb:cdb_deletepending(J2D, NewManifestSQN, self())
+        end,
+        FilesToDelete
+    ),
     {noreply, State#state{manifest=Man1,
                             manifest_sqn=NewManifestSQN,
                             pending_removals=FilesToDelete,

--- a/test/end_to_end/basic_SUITE.erl
+++ b/test/end_to_end/basic_SUITE.erl
@@ -388,6 +388,8 @@ fetchput_snapshot(_Config) ->
     RootPath = testutil:reset_filestructure(),
     StartOpts1 = [{root_path, RootPath},
                     {max_journalsize, 30000000},
+                    {cache_size, 2000},
+                    {max_pencillercachesize, 16000},
                     {sync_strategy, none}],
     {ok, Bookie1} = leveled_bookie:book_start(StartOpts1),
     {TestObject, TestSpec} = testutil:generate_testobject(),

--- a/test/property/leveled_statemeqc.erl
+++ b/test/property/leveled_statemeqc.erl
@@ -30,6 +30,7 @@
             [{gen_fsm, send_event, 2}]}]).
 
 -define(NUMTESTS, 1000).
+-define(TIMEOUT, 300).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
@@ -42,7 +43,7 @@
                        
 
 eqc_test_() ->
-    Timeout = 50,
+    Timeout = ?TIMEOUT,
     {timeout, max(2 * Timeout, Timeout + 10),
      ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(Timeout, ?QC_OUT(prop_db()))))}.
 

--- a/test/property/leveled_statemeqc.erl
+++ b/test/property/leveled_statemeqc.erl
@@ -30,7 +30,7 @@
             [{gen_fsm, send_event, 2}]}]).
 
 -define(NUMTESTS, 1000).
--define(TIMEOUT, 300).
+-define(TEST_TIMEOUT, 300).
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
@@ -43,7 +43,7 @@
                        
 
 eqc_test_() ->
-    Timeout = ?TIMEOUT,
+    Timeout = ?TEST_TIMEOUT,
     {timeout, max(2 * Timeout, Timeout + 10),
      ?_assertEqual(true, eqc:quickcheck(eqc:testing_time(Timeout, ?QC_OUT(prop_db()))))}.
 


### PR DESCRIPTION
Previously the inker casts to the clerk so that the clerk can cast about pending deletes to cdb files removed in compactions.  Now the inker casts directly, which addresses some potential race conditions when closes occur at the end of compaction jobs.