### PR TITLE
Make tree compatible with binary L1

### DIFF
--- a/test/end_to_end/tictac_SUITE.erl
+++ b/test/end_to_end/tictac_SUITE.erl
@@ -164,21 +164,44 @@ many_put_compare(_Config) ->
                 [timer:now_diff(os:timestamp(), SWB0Obj)]),
     true = length(leveled_tictac:find_dirtyleaves(TreeA, TreeAObj0)) == 0,
 
-    InitAccTree = leveled_tictac:new_tree(0, TreeSize),
+    InitAccTree = leveled_tictac:new_tree(0, TreeSize, true),
     
     {async, TreeAObjFolder1} =
-        leveled_bookie:book_headfold(Bookie2, 
-                                        ?RIAK_TAG,
-                                        {range, "Bucket", all},
-                                        {FoldObjectsFun, 
-                                            InitAccTree},
-                                        true, true, false),
+        leveled_bookie:book_headfold(
+            Bookie2, 
+            ?RIAK_TAG,
+            {range, "Bucket", all},
+            {FoldObjectsFun, InitAccTree},
+            true,
+            true,
+            false
+        ),
     SWB1Obj = os:timestamp(),
     TreeAObj1 = TreeAObjFolder1(),
-    io:format("Build tictac tree via object fold with "++
-                    "presence check and 200K objects in ~w~n",
-                [timer:now_diff(os:timestamp(), SWB1Obj)]),
+    io:format(
+        "Build tictac tree via object fold with map level 1 "
+        "presence check and 200K objects in ~w~n",
+        [timer:now_diff(os:timestamp(), SWB1Obj)]
+    ),
     true = length(leveled_tictac:find_dirtyleaves(TreeA, TreeAObj1)) == 0,
+    {async, TreeAObjFolder1Alt} =
+        leveled_bookie:book_headfold(
+            Bookie2, 
+            ?RIAK_TAG,
+            {range, "Bucket", all},
+            {FoldObjectsFun, leveled_tictac:new_tree(0, TreeSize, false)},
+            true,
+            true,
+            false
+        ),
+    SWB1ObjAlt = os:timestamp(),
+    TreeAObj1Alt = TreeAObjFolder1Alt(),
+    io:format(
+        "Build tictac tree via object fold with binary level 1 "
+        "presence check and 200K objects in ~w~n",
+        [timer:now_diff(os:timestamp(), SWB1ObjAlt)]
+    ),
+    true = length(leveled_tictac:find_dirtyleaves(TreeA, TreeAObj1Alt)) == 0,
 
     % For an exportable comparison, want hash to be based on something not 
     % coupled to erlang language - so use exportable query


### PR DESCRIPTION
The old leveled_tictac had a pure binary L1.  this was slower than the new map version.

However, in a Riak cluster, when running a merge_tree_range during a rolling update, the fold the query coordinator will initiate a tree.  If this tree is not a map-based tree (as that node has not yet been upgraded), then a node that has been upgraded would previously fail the query as it cannot handle a level 1 in a binary form.  This now enables updated nodes to handle both forms of trees.

Obviously, if the coordinating node has been updated non-updated nodes will crash queries as they cannot handle the tree with the map at Level 1.  The aim is to make it configurable to force non-map trees in a cluster, until all nodes have been upgraded.  So as long as each node understands how to update both non-map trees and map-based trees - evrything should be OK.