### PR TITLE
Support sub-key queries

### DIFF
--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -2438,13 +2438,13 @@ recalcfor_ledgercache(
                 not_present;
             {LK, LV} ->
                 case leveled_codec:get_metadata(LV) of
-                    MDO when MDO =/= null ->
+                    MDO when is_tuple(MDO) ->
                         MDO
                 end
         end,
     UpdMetadata =
         case leveled_codec:get_metadata(MetaValue) of
-            MDU when MDU =/= null ->
+            MDU when is_tuple(MDU) ->
                 MDU
         end,
     IdxSpecs =

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -73,8 +73,9 @@
 -type segment_hash() :: 
         % hash of the key to an aae segment - to be used in ledger filters
         {integer(), integer()}|no_lookup.
+-type head_value() :: any().
 -type metadata() ::
-        tuple()|null. % null for empty metadata
+        tuple()|null|head_value(). % null for empty metadata
 -type last_moddate() ::
         % modified date as determined by the object (not this store)
         % if the object has siblings in the store will be the maximum of those
@@ -177,7 +178,8 @@
             regular_expression/0,
             value_fetcher/0,
             proxy_object/0,
-            slimmed_key/0
+            slimmed_key/0,
+            head_value/0
         ]).
 
 
@@ -428,6 +430,8 @@ to_querykey(Bucket, Key, Tag, Field, Value) when Tag == ?IDX_TAG ->
 -spec to_querykey(key()|null, key()|null, tag()) -> query_key().
 %% @doc
 %% Convert something into a ledger query key
+to_querykey(Bucket, {Key, SubKey}, Tag) ->
+    {Tag, Bucket, Key, SubKey};
 to_querykey(Bucket, Key, Tag) ->
     {Tag, Bucket, Key, null}.
 
@@ -781,7 +785,7 @@ gen_headspec(
 
 -spec return_proxy
     (leveled_head:headonly_tag(), leveled_head:object_metadata(), null, journal_ref())
-        -> leveled_head:object_metadata();
+        -> head_value();
     (leveled_head:object_tag(), leveled_head:object_metadata(), pid(), journal_ref())
         -> proxy_objectbin().
 %% @doc
@@ -872,7 +876,7 @@ get_size(PK, Value) ->
 
 -spec get_keyandobjhash(tuple(), tuple()) -> tuple().
 %% @doc
-%% Return a tucple of {Bucket, Key, Hash} where hash is a hash of the object
+%% Return a tuple of {Bucket, Key, Hash} where hash is a hash of the object
 %% not the key (for example with Riak tagged objects this will be a hash of
 %% the sorted vclock)
 get_keyandobjhash(LK, Value) ->

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -783,19 +783,16 @@ gen_headspec(
     gen_headspec({IdxOp, v1, Bucket, Key, SubKey, undefined, Value}, SQN, TTL).
 
 
--spec return_proxy
-    (leveled_head:headonly_tag(), leveled_head:object_metadata(), null, journal_ref())
-        -> head_value();
-    (leveled_head:object_tag(), leveled_head:object_metadata(), pid(), journal_ref())
-        -> proxy_objectbin().
+-spec return_proxy(
+    leveled_head:object_tag(),
+    leveled_head:object_metadata(),
+    pid(),
+    journal_ref()) -> proxy_objectbin().
 %% @doc
 %% If the object has a value, return the metadata and a proxy through which
-%% the applictaion or runner can access the value.  If it is a ?HEAD_TAG
-%% then it has no value, so just return the metadata
-return_proxy(?HEAD_TAG, ObjectMetadata, _InkerClone, _JR) ->
-    % Object has no value - so proxy object makese no sense, just return the
-    % metadata as is
-    ObjectMetadata;
+%% the application or runner can access the value.
+%% This is only called if there is an object tag - i.e. ?RIAK_TAG//STD_TAG or
+%% a user-defined tag that uses ObjMetadata in the ?STD_TAG format
 return_proxy(Tag, ObjMetadata, InkerClone, JournalRef) ->
     Size = leveled_head:get_size(Tag, ObjMetadata),
     HeadBin = leveled_head:build_head(Tag, ObjMetadata),

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -527,13 +527,19 @@ log_wrongkey_test() ->
         error,
         {badkey, wrong0001},
         log(wrong0001, [],[warning, error], ?LOGBASE, backend)
-    ),
+    ).
+
+logtimer_wrongkey_test() ->
+    ST = os:timestamp(),
+    % Note - 
+    % An issue with cover means issues with ?assertException, where the
+    % function being tested is split across lines, the closing bracket on the
+    % next line is not recognised as being covered. We want 100% coverage, so
+    % need to write this on one line.
     ?assertException(
         error,
         {badkey, wrong0001},
-        log_timer(
-            wrong0001, [], os:timestamp(), [warning, error], ?LOGBASE, backend
-        )
+        log_timer(wrong0001, [], ST, [warning, error], ?LOGBASE, backend)
     ).
 
 shouldilog_test() ->

--- a/src/leveled_runner.erl
+++ b/src/leveled_runner.erl
@@ -636,7 +636,9 @@ accumulate_objects(FoldObjectsFun, InkerClone, Tag, DeferredFetch) ->
                 end,
             JK = {leveled_codec:to_objectkey(B, K, Tag), SQN},
             case DeferredFetch of
-                {true, JournalCheck} when MD =/= null ->
+                {true, false} when Tag == ?HEAD_TAG ->
+                    FoldObjectsFun(B, K, MD, Acc);
+                {true, JournalCheck} when is_tuple(MD) ->
                     ProxyObj = 
                         leveled_codec:return_proxy(Tag, MD, InkerClone, JK),
                     case {JournalCheck, InkerClone} of

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -3377,7 +3377,7 @@ generate_randomkeys(Seqn, Count, Acc, BucketLow, BRange) ->
     Chunk = crypto:strong_rand_bytes(64),
     MV = leveled_codec:convert_to_ledgerv(LK, Seqn, Chunk, 64, infinity),
     MD = element(4, MV),
-    MD =/= null orelse error(bad_type),
+    is_tuple(MD) orelse error(bad_type),
     ?assertMatch(undefined, element(3, MD)),
     MD0 = [{magic_md, [<<0:32/integer>>, base64:encode(Chunk)]}],
     MV0 = setelement(4, MV, setelement(3, MD, MD0)),


### PR DESCRIPTION
Also requires a refactoring of types.

In head-only mode - the metadata in the ledger is just the value, and the value can be anything.  So metadata() definition needs to reflect that.

There are then issues with appdefined functions for extracting metadata.  In theory an appdefined function could extract some unsopprted type.  So made explicit that the appdefined function must extract std_metadata() as metadata - otherwise functionality will not work.

This means that if it is an object key, that is not a ?HEAD key, then the Metadata must be a tuple (of either Riak or Standard type).