### PR TITLE
Fix tuple mistake

### DIFF
--- a/src/leveled_pclerk.erl
+++ b/src/leveled_pclerk.erl
@@ -389,7 +389,7 @@ do_merge(
 
 add_entry(empty, FileName, _TS1, Additions) ->
     leveled_log:log(pc013, [FileName]),
-    {[], [], Additions};
+    {Additions, [], []};
 add_entry({ok, Pid, Reply, Bloom}, FileName, TS1, Additions) ->
     {{KL1Rem, KL2Rem}, SmallestKey, HighestKey} = Reply,
     Entry =


### PR DESCRIPTION
Otherwise leveled_pclerk will crash if there is a partial merge that results in an an empty addition