### PR TITLE
SST sub-blocks and block types

### DIFF
--- a/include/leveled.hrl
+++ b/include/leveled.hrl
@@ -27,6 +27,7 @@
 -define(SST_PAGECACHELEVEL_LOOKUP, 4).
 -define(DEFAULT_STATS_PERC, 10).
 -define(DEFAULT_SYNC_STRATEGY, none).
+-define(DEFAULT_BLOCK_VERSION, 1).
 %%%============================================================================
 
 %%%============================================================================
@@ -105,17 +106,22 @@
                             :: leveled_monitor:monitor()}).
 
 -record(sst_options,
-                        {press_method = ?COMPRESSION_METHOD
-                            :: leveled_sst:press_method(),
-                        press_level = ?COMPRESSION_LEVEL :: non_neg_integer(),
-                        log_options = leveled_log:get_opts() 
-                            :: leveled_log:log_options(),
-                        max_sstslots = ?MAX_SSTSLOTS :: pos_integer()|infinity,
-                        max_mergebelow = ?MAX_MERGEBELOW :: pos_integer()|infinity,
-                        pagecache_level = ?SST_PAGECACHELEVEL_NOLOOKUP
-                            :: pos_integer(),
-                        monitor = {no_monitor, 0}
-                            :: leveled_monitor:monitor()}).
+    {
+        press_method = ?COMPRESSION_METHOD
+            :: leveled_sst:press_method(),
+        block_version = ?DEFAULT_BLOCK_VERSION
+            :: leveled_sst:block_version(),
+        press_level = ?COMPRESSION_LEVEL :: non_neg_integer(),
+        log_options = leveled_log:get_opts() 
+            :: leveled_log:log_options(),
+        max_sstslots = ?MAX_SSTSLOTS :: pos_integer()|infinity,
+        max_mergebelow = ?MAX_MERGEBELOW :: pos_integer()|infinity,
+        pagecache_level = ?SST_PAGECACHELEVEL_NOLOOKUP
+            :: pos_integer(),
+        monitor = {no_monitor, 0}
+            :: leveled_monitor:monitor()
+        }
+    ).
 
 -record(inker_options,
                         {cdb_max_size :: integer() | undefined,

--- a/src/leveled_bookie.erl
+++ b/src/leveled_bookie.erl
@@ -127,6 +127,7 @@
                 {ledger_preloadpagecache_level, ?SST_PAGECACHELEVEL_LOOKUP},
                 {compression_method, ?COMPRESSION_METHOD},
                 {ledger_compression, as_store},
+                {block_version, 1},
                 {compression_point, ?COMPRESSION_POINT},
                 {compression_level, ?COMPRESSION_LEVEL},
                 {log_level, ?LOG_LEVEL},
@@ -309,6 +310,10 @@
             % Define an alternative to the compression method to be used by the
             % ledger only.  Default is as_store - use the method defined as
             % compression_method for the whole store
+        {block_version, 0|1} |
+            % Version of the leveled_sst blocks.  Block version 0 does not use
+            % sub-blocks, whereas block version 1 has multiple types of blocks
+            % which can be split into sub-blocks
         {compression_point, on_compact|on_receipt} |
             % The =compression point can be changed between on_receipt (all
             % values are compressed as they are received), to on_compact where
@@ -1884,45 +1889,54 @@ set_options(Opts, Monitor) ->
         end,
     CompressionLevel = proplists:get_value(compression_level, Opts),
     
+    BlockVersion = proplists:get_value(block_version, Opts),
     MaxSSTSlots = proplists:get_value(max_sstslots, Opts),
     MaxMergeBelow = proplists:get_value(max_mergebelow, Opts),
 
     ScoreOneIn = proplists:get_value(journalcompaction_scoreonein, Opts),
 
-    {#inker_options{root_path = JournalFP,
-                    reload_strategy = ReloadStrategy,
-                    max_run_length = proplists:get_value(max_run_length, Opts),
-                    singlefile_compactionperc = SFL_CompPerc,
-                    maxrunlength_compactionperc = MRL_CompPerc,
-                    waste_retention_period = WRP,
-                    snaptimeout_long = SnapTimeoutLong,
-                    compression_method = JournalCompression,
-                    compress_on_receipt = CompressOnReceipt,
-                    score_onein = ScoreOneIn,
-                    cdb_options = 
-                        #cdb_options{
-                            max_size = MaxJournalSize,
-                            max_count = MaxJournalCount,
-                            binary_mode = true,
-                            sync_strategy = SyncStrat,
-                            log_options = leveled_log:get_opts(),
-                            monitor = Monitor},
-                    monitor = Monitor},
-        #penciller_options{root_path = LedgerFP,
-                            max_inmemory_tablesize = PCLL0CacheSize,
-                            levelzero_cointoss = true,
-                            snaptimeout_short = SnapTimeoutShort,
-                            snaptimeout_long = SnapTimeoutLong,
-                            sst_options =
-                                #sst_options{
-                                    press_method = LedgerCompression,
-                                    press_level = CompressionLevel,
-                                    log_options = leveled_log:get_opts(),
-                                    max_sstslots = MaxSSTSlots,
-                                    max_mergebelow = MaxMergeBelow,
-                                    monitor = Monitor},
-                            monitor = Monitor}
-        }.
+    {
+        #inker_options{
+            root_path = JournalFP,
+            reload_strategy = ReloadStrategy,
+            max_run_length = proplists:get_value(max_run_length, Opts),
+            singlefile_compactionperc = SFL_CompPerc,
+            maxrunlength_compactionperc = MRL_CompPerc,
+            waste_retention_period = WRP,
+            snaptimeout_long = SnapTimeoutLong,
+            compression_method = JournalCompression,
+            compress_on_receipt = CompressOnReceipt,
+            score_onein = ScoreOneIn,
+            cdb_options = 
+                #cdb_options{
+                    max_size = MaxJournalSize,
+                    max_count = MaxJournalCount,
+                    binary_mode = true,
+                    sync_strategy = SyncStrat,
+                    log_options = leveled_log:get_opts(),
+                    monitor = Monitor
+                },
+            monitor = Monitor
+        },
+        #penciller_options{
+            root_path = LedgerFP,
+            max_inmemory_tablesize = PCLL0CacheSize,
+            levelzero_cointoss = true,
+            snaptimeout_short = SnapTimeoutShort,
+            snaptimeout_long = SnapTimeoutLong,
+            sst_options =
+                #sst_options{
+                    press_method = LedgerCompression,
+                    press_level = CompressionLevel,
+                    block_version = BlockVersion,
+                    log_options = leveled_log:get_opts(),
+                    max_sstslots = MaxSSTSlots,
+                    max_mergebelow = MaxMergeBelow,
+                    monitor = Monitor
+                },
+            monitor = Monitor
+        }
+    }.
 
 
 -spec return_snapfun(

--- a/src/leveled_codec.erl
+++ b/src/leveled_codec.erl
@@ -468,16 +468,16 @@ isvalid_ledgerkey(_LK) ->
 %% false and further results may be required from further ranges.
 endkey_passed(all, _) ->
     false;
-endkey_passed({K1, null, null, null}, {K1, _, _, _}) ->
-    false;
-endkey_passed({K1, K2, null, null}, {K1, K2, _, _}) ->
-    false;
-endkey_passed({K1, K2, K3, null}, {K1, K2, K3, _}) ->
-    false;
-endkey_passed({K1, null}, {K1, _}) ->
+endkey_passed({KQ1, null, null, null}, {KR1, _, _, _}) when KQ1 =/= null ->
+    KQ1 < KR1;
+endkey_passed({K1, KQ2, null, null}, {K1, KR2, _, _}) when KQ2 =/= null ->
+    KQ2 < KR2;
+endkey_passed({K1, K2, KQ3, null}, {K1, K2, KR3, _}) when KQ3 =/= null ->
+    KQ3 < KR3;
+endkey_passed({KQ1, null}, {KR1, _}) when KQ1 =/= null ->
     % See leveled_sst SlotIndex implementation.  Here keys may be slimmed to
     % single binaries or two element tuples before forming the index.
-    false;
+    KQ1 < KR1;
 endkey_passed(null, _) ->
     false;
 endkey_passed(QueryEndKey, RangeEndKey) ->

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -218,6 +218,8 @@
             {info, <<"SST merge list build timings of fold_toslot=~w slot_hashlist=~w slot_serialise=~w slot_finish=~w is_basement=~w level=~w">>},
         sst14 =>
             {debug, <<"File ~s has completed BIC">>},
+        sst15 =>
+            {warning, <<"Default returned from block due to handling error ~0p ~0p">>},
         i0001 =>
             {info, <<"Unexpected failure to fetch value for Key=~w SQN=~w with reason ~w">>},
         i0002 =>

--- a/src/leveled_log.erl
+++ b/src/leveled_log.erl
@@ -219,7 +219,7 @@
         sst14 =>
             {debug, <<"File ~s has completed BIC">>},
         sst15 =>
-            {warning, <<"Default returned from block due to handling error ~0p ~0p">>},
+            {warning, <<"Default returned from block due to handling error ~0p">>},
         i0001 =>
             {info, <<"Unexpected failure to fetch value for Key=~w SQN=~w with reason ~w">>},
         i0002 =>

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2821,12 +2821,46 @@ next_block_required({_FK, LK}, EndKey) ->
 in_range(KVL, all, all) ->
     KVL;
 in_range(KVL, all, EK) ->
-    lists:takewhile(
-        fun({K, _V}) -> not leveled_codec:endkey_passed(EK, K) end, KVL);
+    before_end(KVL, EK, []);
 in_range(KVL, SK, all) ->
-    lists:dropwhile(fun({K, _V}) -> K < SK end, KVL);
+    after_start(KVL, SK);
 in_range(KVL, SK, EK) ->
-    in_range(in_range(KVL, SK, all), all, EK).
+    before_end(after_start(KVL, SK), EK, []).
+
+before_end(KVL, EK, Acc) when length(KVL) > 12 ->
+    case leveled_codec:endkey_passed(EK, element(1, lists:nth(6, KVL))) of
+        true ->
+            append(
+                Acc,
+                lists:takewhile(
+                    fun({K, _V}) -> not leveled_codec:endkey_passed(EK, K) end,
+                    KVL
+                )
+            );
+        false ->
+            {B, MB} = lists:split(6, KVL),
+            before_end(MB, EK, append(Acc, B))
+    end;
+before_end(KVL, EK, Acc) ->
+    append(
+        Acc,
+        lists:takewhile(
+            fun({K, _V}) -> not leveled_codec:endkey_passed(EK, K) end,
+            KVL
+        )
+    ).
+
+after_start(KVL, SK) when length(KVL) > 24 ->
+    case element(1, lists:nth(12, KVL)) < SK of
+        true ->
+            {_B, MB} = lists:split(12, KVL),
+            after_start(MB, SK);
+        false ->
+            lists:dropwhile(fun({K, _V}) -> K < SK end, KVL)
+    end;
+after_start(KVL, SK) ->
+    lists:dropwhile(fun({K, _V}) -> K < SK end, KVL).
+
 
 crc_check_slot(FullBin) ->
     <<CRC32PBL:32/integer,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -4637,7 +4637,7 @@ corrupted_block_rangetester(BlockMethod, TestCount) ->
             no_lookup, BlockMethod, lists:sublist(KVL1, 41, 20)),
     B4 =
         leveled_sstblock:serialise_block(
-            np_lookup, BlockMethod, lists:sublist(KVL1, 61, 20)),
+            no_lookup, BlockMethod, lists:sublist(KVL1, 61, 20)),
     B5 =
         leveled_sstblock:serialise_block(
             no_lookup, BlockMethod, lists:sublist(KVL1, 81, 20)),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -134,7 +134,7 @@
 
 -export([in_range/3]).
 
--export([hmac/1, append/2, append/3, append/4, filterby_midblock/2]).
+-export([hmac/1, filterby_midblock/2]).
 
 -record(slot_index_value,
         {slot_id :: integer(),

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2689,90 +2689,103 @@ blocks_required(
         leveled_sstblock:get_topandtail(MidBlock, BlockMethod),
     case filterby_midblock({Top, Tail}, {StartKey, EndKey}) of
         empty ->
-            append(
-                in_range(
+            in_range(
+                append(
                     leveled_sstblock:get_all(B1, BlockMethod),
-                    StartKey,
-                    EndKey
-                ),
-                in_range(
                     leveled_sstblock:get_all(B2, BlockMethod),
-                    StartKey,
-                    EndKey
-                ),
-                in_range(
                     leveled_sstblock:get_all(B4, BlockMethod),
-                    StartKey,
-                    EndKey
+                    leveled_sstblock:get_all(B5, BlockMethod)
                 ),
-                in_range(
-                    leveled_sstblock:get_all(B5, BlockMethod),
-                    StartKey,
-                    EndKey
-                )
+                StartKey,
+                EndKey
             );
         all_blocks ->
             append(
-                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
+                in_range(
+                    get_lefthand_blocks(
+                        B1, B2, BlockMethod, StartKey, EndKey),
+                    StartKey,
+                    all
+                ),
                 MidBlockFetchFun(),
-                get_righthand_blocks(B4, B5, BlockMethod, EndKey)
+                in_range(
+                    get_righthand_blocks(
+                        B4, B5, BlockMethod, StartKey, EndKey),
+                    all,
+                    EndKey
+                )
             );
         lt_mid ->
             in_range(
-                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
-                all,
+                get_lefthand_blocks(
+                    B1, B2, BlockMethod, StartKey, EndKey),
+                StartKey,
                 EndKey);
         le_mid ->
-            append(
-                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
-                in_range(MidBlockFetchFun(), all, EndKey)
+            in_range(
+                append(
+                    get_lefthand_blocks(
+                        B1, B2, BlockMethod, StartKey, EndKey),
+                    MidBlockFetchFun()
+                ),
+                StartKey,
+                EndKey
             );
         mid_only ->
             in_range(MidBlockFetchFun(), StartKey, EndKey);
         ge_mid ->
-            append(
-                in_range(MidBlockFetchFun(), StartKey, all),
-                get_righthand_blocks(B4, B5, BlockMethod, EndKey)
+            in_range(
+                append(
+                    MidBlockFetchFun(),
+                    get_righthand_blocks(
+                        B4, B5, BlockMethod, all, EndKey)
+                ),
+                StartKey,
+                EndKey
             );
         gt_mid ->
             in_range(
-                get_righthand_blocks(B4, B5, BlockMethod, EndKey),
+                get_righthand_blocks(
+                    B4, B5, BlockMethod, StartKey, EndKey),
                 StartKey,
-                all)
+                EndKey
+            )
     end.
 
-get_lefthand_blocks(B1, B2, BlockMethod, StartKey) ->
+get_lefthand_blocks(B1, B2, BlockMethod, StartKey, EndKey) ->
     {Top, Tail, InnerLeftBlockFetchFun} =
         leveled_sstblock:get_topandtail(B2, BlockMethod),
     case previous_block_required({Top, Tail}, StartKey) of
         true ->
             append(
-                in_range(
-                    leveled_sstblock:get_all(B1, BlockMethod),
-                    StartKey,
-                    all
-                ),
-                InnerLeftBlockFetchFun()
+                leveled_sstblock:get_all(B1, BlockMethod),
+                case this_leftblock_required({Top, Tail}, EndKey) of
+                    true ->
+                        InnerLeftBlockFetchFun();
+                    _ ->
+                        []
+                end
             );
         false ->
-            in_range(InnerLeftBlockFetchFun(), StartKey, all)
+            InnerLeftBlockFetchFun()
     end.
 
-get_righthand_blocks(B4, B5, BlockMethod, EndKey) ->
+get_righthand_blocks(B4, B5, BlockMethod, StartKey, EndKey) ->
     {Top, Tail, InnerRightBlockFetchFun} =
         leveled_sstblock:get_topandtail(B4, BlockMethod),
     case next_block_required({Top, Tail}, EndKey) of
         true ->
             append(
-                InnerRightBlockFetchFun(),
-                in_range(
-                    leveled_sstblock:get_all(B5, BlockMethod),
-                    all,
-                    EndKey
-                )
+                case this_rightblock_required({Top, Tail}, StartKey) of
+                    true ->
+                        InnerRightBlockFetchFun();
+                    _ ->
+                        []
+                end,
+                leveled_sstblock:get_all(B5, BlockMethod)
             );
         false ->
-            in_range(InnerRightBlockFetchFun(), all, EndKey)
+            InnerRightBlockFetchFun()
     end.
 
 filterby_midblock({not_present, not_present}, _RangeKeys) ->
@@ -2799,6 +2812,20 @@ filterby_midblock({MidFirst, MidLast}, {_StartKey, EndKey}) ->
         {false, false} ->
             all_blocks
     end.
+
+this_leftblock_required({not_present, not_present}, _EndKey) ->
+    true;
+this_leftblock_required(_, all) ->
+    true;
+this_leftblock_required({Top, _Tail}, EndKey) ->
+    not leveled_codec:endkey_passed(EndKey, Top).
+        
+this_rightblock_required({not_present, not_present}, _StartKey) ->
+    true;
+this_rightblock_required(_, all) ->
+    true;
+this_rightblock_required({_Top, Tail}, StartKey) ->
+    Tail >= StartKey.
 
 previous_block_required({not_present, not_present}, _SK) ->
     true;
@@ -2827,8 +2854,14 @@ in_range(KVL, SK, all) ->
 in_range(KVL, SK, EK) ->
     before_end(after_start(KVL, SK), EK, []).
 
-before_end(KVL, EK, Acc) when length(KVL) > 12 ->
-    case leveled_codec:endkey_passed(EK, element(1, lists:nth(6, KVL))) of
+-define(MAX_AHEAD, 12).
+-define(CHECK_AHEAD, 8).
+
+before_end(KVL, EK, Acc) when length(KVL) > ?MAX_AHEAD ->
+    SkipCheck =
+    leveled_codec:endkey_passed(
+        EK, element(1, lists:nth(?CHECK_AHEAD, KVL))),
+    case SkipCheck of
         true ->
             append(
                 Acc,
@@ -2838,7 +2871,7 @@ before_end(KVL, EK, Acc) when length(KVL) > 12 ->
                 )
             );
         false ->
-            {B, MB} = lists:split(6, KVL),
+            {B, MB} = lists:split(?CHECK_AHEAD, KVL),
             before_end(MB, EK, append(Acc, B))
     end;
 before_end(KVL, EK, Acc) ->
@@ -2850,10 +2883,11 @@ before_end(KVL, EK, Acc) ->
         )
     ).
 
-after_start(KVL, SK) when length(KVL) > 24 ->
-    case element(1, lists:nth(12, KVL)) < SK of
+after_start(KVL, SK) when length(KVL) > ?MAX_AHEAD ->
+    SkipCheck = element(1, lists:nth(?CHECK_AHEAD, KVL)) < SK,
+    case SkipCheck of
         true ->
-            {_B, MB} = lists:split(12, KVL),
+            {_B, MB} = lists:split(?CHECK_AHEAD, KVL),
             after_start(MB, SK);
         false ->
             lists:dropwhile(fun({K, _V}) -> K < SK end, KVL)

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -4681,11 +4681,17 @@ stop_whenstarter_stopped_testto() ->
         end,
     ?assertMatch(false, lists:foldl(TestFun, true, [10000, 2000, 2000, 2000])).
 
-corrupted_block_range_test() ->
+corrupted_block_range_v0_test() ->
     corrupted_block_rangetester({0, native}, 100),
     corrupted_block_rangetester({0, lz4}, 100),
     corrupted_block_rangetester({0, zstd}, 100),
     corrupted_block_rangetester({0, none}, 100).
+
+corrupted_block_range_v1_test() ->
+    corrupted_block_rangetester({1, native}, 100),
+    corrupted_block_rangetester({1, lz4}, 100),
+    corrupted_block_rangetester({1, zstd}, 100),
+    corrupted_block_rangetester({1, none}, 100).
 
 corrupted_block_rangetester(BlockMethod, TestCount) ->
     N = 100,
@@ -4736,11 +4742,17 @@ corrupted_block_rangetester(BlockMethod, TestCount) ->
     end,
     lists:foreach(CheckFun, RandomRanges).
 
-corrupted_block_fetch_test() ->
+corrupted_block_fetch_v0_test() ->
     corrupted_block_fetch_tester({0, native}),
     corrupted_block_fetch_tester({0, lz4}),
     corrupted_block_fetch_tester({0, zstd}),
     corrupted_block_fetch_tester({0, none}).
+
+corrupted_block_fetch_v1_test() ->
+    corrupted_block_fetch_tester({1, native}),
+    corrupted_block_fetch_tester({1, lz4}),
+    corrupted_block_fetch_tester({1, zstd}),
+    corrupted_block_fetch_tester({1, none}).
 
 corrupted_block_fetch_tester(BlockMethod) ->
     KC = 120,

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -134,6 +134,8 @@
 
 -export([in_range/3]).
 
+-export([hmac/1, append/4]).
+
 -record(slot_index_value,
         {slot_id :: integer(),
         start_position :: integer(),
@@ -153,6 +155,10 @@
     :: #slot_index_value{}.
 -type press_method()
     :: lz4|native|zstd|none.
+-type block_version()
+    :: 0|1.
+-type block_method()
+    :: {block_version(), press_method()}.
 -type range_endpoint()
     :: all|leveled_codec:ledger_key().
 -type slot_pointer()
@@ -227,7 +233,7 @@
         root_path,
         filename,
         read_state :: read_state() | undefined,
-        compression_method = native :: press_method(),
+        block_method = {0, native} :: block_method(),
         index_moddate = ?INDEX_MODDATE :: boolean(),
         starting_pid :: pid()|undefined,
         new_slots :: list()|undefined,
@@ -256,6 +262,8 @@
         sst_pointer/0,
         slot_pointer/0,
         press_method/0,
+        block_version/0,
+        block_method/0,
         segment_check_fun/0,
         sst_options/0
     ]
@@ -568,6 +576,7 @@ starting({call, From},
     leveled_log:save(OptsSST#sst_options.log_options),
     Monitor = OptsSST#sst_options.monitor,
     PressMethod = OptsSST#sst_options.press_method,
+    BlockVersion = OptsSST#sst_options.block_version,
     {Length, SlotIndex, BlockEntries, SlotsBin, Bloom} =
         build_all_slots(SlotList),
     {_, BlockIndexCache, HighModDate} =
@@ -581,8 +590,14 @@ starting({call, From},
             SlotIndex, Level, FirstKey, Length, MaxSQN, Bloom, CountOfTombs),
     ActualFilename =
         write_file(
-            RootPath, Filename, SummaryBin, SlotsBin,
-            PressMethod, IdxModDate, CountOfTombs),
+            RootPath,
+            Filename,
+            SummaryBin,
+            SlotsBin,
+            {BlockVersion, PressMethod},
+            IdxModDate,
+            CountOfTombs
+        ),
     {UpdState, Bloom} =
         read_file(
             ActualFilename,
@@ -632,6 +647,7 @@ starting(cast, complete_l0startup, State) ->
     leveled_log:save(OptsSST#sst_options.log_options),
     Monitor = OptsSST#sst_options.monitor,
     PressMethod = OptsSST#sst_options.press_method,
+    BlockVersion= OptsSST#sst_options.block_version,
     FetchFun = fun(Slot) -> lists:nth(Slot, FetchedSlots) end,
     KVList = leveled_pmem:to_list(length(FetchedSlots), FetchFun),
     Time0 = timer:now_diff(os:timestamp(), SW0),
@@ -660,8 +676,15 @@ starting(cast, complete_l0startup, State) ->
 
     SW4 = os:timestamp(),
     ActualFilename =
-        write_file(RootPath, Filename, SummaryBin, SlotsBin,
-                    PressMethod, IdxModDate, not_counted),
+        write_file(
+            RootPath,
+            Filename,
+            SummaryBin,
+            SlotsBin,
+            {BlockVersion, PressMethod},
+            IdxModDate,
+            not_counted
+        ),
     {UpdState, Bloom} =
         read_file(
             ActualFilename,
@@ -740,7 +763,7 @@ reader({call, From},
             LedgerKey,
             Hash,
             State#state.summary,
-            State#state.compression_method,
+            State#state.block_method,
             State#state.high_modified_date,
             State#state.index_moddate,
             RS#read_state.filter_fun,
@@ -791,17 +814,17 @@ reader({call, From},
 reader({call, From},
         {get_slots, SlotList, SegChecker, LowLastMod},
         State = #state{read_state = RS}) when ?IS_DEF(RS) ->
-    PressMethod = State#state.compression_method,
+    BlockMethod = State#state.block_method,
     IdxModDate = State#state.index_moddate,
     {NeedBlockIdx, SlotBins} =
         read_slots(
             RS#read_state.handle,
             SlotList,
             {SegChecker, LowLastMod, RS#read_state.blockindex_cache},
-            State#state.compression_method,
+            State#state.block_method,
             State#state.index_moddate),
     {keep_state_and_data,
-        [{reply, From, {NeedBlockIdx, SlotBins, PressMethod, IdxModDate}}]};
+        [{reply, From, {NeedBlockIdx, SlotBins, BlockMethod, IdxModDate}}]};
 reader({call, From}, get_maxsequencenumber, State) ->
     Summary = State#state.summary,
     {keep_state_and_data,
@@ -877,7 +900,7 @@ delete_pending({call, From},
         fetch(
             LedgerKey, Hash,
             State#state.summary,
-            State#state.compression_method,
+            State#state.block_method,
             State#state.high_modified_date,
             State#state.index_moddate,
             RS#read_state.filter_fun,
@@ -914,17 +937,17 @@ delete_pending(
         {call, From},
         {get_slots, SlotList, SegChecker, LowLastMod},
         State = #state{read_state = RS}) when ?IS_DEF(RS) ->
-    PressMethod = State#state.compression_method,
+    BlockMethod = State#state.block_method,
     IdxModDate = State#state.index_moddate,
     {_NeedBlockIdx, SlotBins} =
         read_slots(
             RS#read_state.handle,
             SlotList,
             {SegChecker, LowLastMod, RS#read_state.blockindex_cache},
-            PressMethod,
+            BlockMethod,
             IdxModDate),
     {keep_state_and_data,
-        [{reply, From, {false, SlotBins, PressMethod, IdxModDate}},
+        [{reply, From, {false, SlotBins, BlockMethod, IdxModDate}},
             ?DELETE_TIMEOUT]};
 delete_pending(
         {call, From},
@@ -1398,7 +1421,7 @@ check_modified(_, _, _) ->
     leveled_codec:ledger_key(),
     leveled_codec:segment_hash(),
     sst_summary(),
-    press_method(),
+    block_method(),
     non_neg_integer()|undefined,
     boolean(),
     summary_filter(),
@@ -1417,7 +1440,7 @@ check_modified(_, _, _) ->
 %% not_present if the key is not in the store.
 fetch(LedgerKey, Hash,
         Summary,
-        PressMethod, HighModDate, IndexModDate, FilterFun, BIC, FetchCache,
+        BlockMethod, HighModDate, IndexModDate, FilterFun, BIC, FetchCache,
         Handle, Level, Monitor) ->
     SW0 = leveled_monitor:maybe_time(Monitor),
     Slot =
@@ -1430,7 +1453,7 @@ fetch(LedgerKey, Hash,
             SlotBin = read_slot(Handle, Slot),
             {Result, Header} =
                 binaryslot_get(
-                    SlotBin, LedgerKey, Hash, PressMethod, IndexModDate),
+                    SlotBin, LedgerKey, Hash, BlockMethod, IndexModDate),
             {_UpdateState, BIC0, HMD0} =
                 update_blockindex_cache(
                     [{SlotID, Header}], BIC, HighModDate, IndexModDate),
@@ -1469,7 +1492,7 @@ fetch(LedgerKey, Hash,
                                     BlockLengths,
                                     byte_size(PosBin),
                                     LedgerKey,
-                                    PressMethod,
+                                    BlockMethod,
                                     IndexModDate
                                 ),
                             case Result of
@@ -1549,11 +1572,11 @@ maxslots_level(_Level, MaxSlotCount) ->
     2 * MaxSlotCount.
 
 write_file(RootPath, Filename, SummaryBin, SlotsBin,
-            PressMethod, IdxModDate, CountOfTombs) ->
+            BlockMethod, IdxModDate, CountOfTombs) ->
     SummaryLength = byte_size(SummaryBin),
     SlotsLength = byte_size(SlotsBin),
     {PendingName, FinalName} = generate_filenames(Filename),
-    FileVersion = gen_fileversion(PressMethod, IdxModDate, CountOfTombs),
+    FileVersion = gen_fileversion(BlockMethod, IdxModDate, CountOfTombs),
     case filelib:is_file(filename:join(RootPath, FinalName)) of
         true ->
             AltName = filename:join(RootPath, filename:basename(FinalName))
@@ -1564,14 +1587,19 @@ write_file(RootPath, Filename, SummaryBin, SlotsBin,
             ok
     end,
 
-    ok = leveled_util:safe_rename(filename:join(RootPath, PendingName),
-                                    filename:join(RootPath, FinalName),
-                                    <<FileVersion:8/integer,
-                                        SlotsLength:32/integer,
-                                        SummaryLength:32/integer,
-                                        SlotsBin/binary,
-                                        SummaryBin/binary>>,
-                                        false),
+    ok = 
+        leveled_util:safe_rename(
+            filename:join(RootPath, PendingName),
+            filename:join(RootPath, FinalName),
+            <<
+                FileVersion:8/integer,
+                SlotsLength:32/integer,
+                SummaryLength:32/integer,
+                SlotsBin/binary,
+                SummaryBin/binary
+            >>,
+            false
+        ),
     FinalName.
 
 read_file(Filename, State, LoadPageCache, BIC, Level) ->
@@ -1611,7 +1639,7 @@ read_file(Filename, State, LoadPageCache, BIC, Level) ->
         },
         Bloom}.
 
-gen_fileversion(PressMethod, IdxModDate, CountOfTombs) ->
+gen_fileversion({BlockVersion, PressMethod}, IdxModDate, CountOfTombs) ->
     % Native or none can be treated the same once written, as reader 
     % does not need to know as compression info will be in header of the 
     % block
@@ -1643,16 +1671,38 @@ gen_fileversion(PressMethod, IdxModDate, CountOfTombs) ->
             _ ->
                 0
             end,
-    Bit1 + Bit2 + Bit3 + Bit4.
+    Bit5 =
+        case BlockVersion of
+            0 ->
+                0;
+            1 ->
+                16
+        end,
+    Bit1 + Bit2 + Bit3 + Bit4 + Bit5.
 
 imp_fileversion(VersionInt, State) ->
-    UpdState0 = 
+    CompressionMethod0 = 
         case VersionInt band 1 of 
             0 ->
-                State#state{compression_method = native};
+                native;
             1 ->
-                State#state{compression_method = lz4}
+                lz4
         end,
+    CompressionMethod =
+        case VersionInt band 8 of
+            0 ->
+                CompressionMethod0;
+            8 ->
+                zstd
+        end,
+    BlockVersion =
+        case VersionInt band 16 of
+            0 ->
+                0;
+            16 ->
+                1
+        end,
+    UpdState0 = State#state{block_method = {BlockVersion, CompressionMethod}},
     UpdState1 =
         case VersionInt band 2 of
             0 ->
@@ -1667,12 +1717,7 @@ imp_fileversion(VersionInt, State) ->
             4 ->
                 UpdState1#state{tomb_count = 0}
         end,
-    case VersionInt band 8 of
-            0 ->
-                UpdState2;
-            8 ->
-                UpdState2#state{compression_method = zstd}
-    end.
+    UpdState2.
 
 open_reader(Filename, LoadPageCache) ->
     {ok, Handle} = file:open(Filename, [binary, raw, read]),
@@ -1766,7 +1811,6 @@ build_all_slots(
         lists:append(HashList, HashLists)
     ).
 
-
 generate_filenames(RootFilename) ->
     Ext = filename:extension(RootFilename),
     Components = filename:split(RootFilename),
@@ -1780,64 +1824,6 @@ generate_filenames(RootFilename) ->
             {filename:join(DN, FP_NOEXT) ++ ".pnd",
                 filename:join(DN, FP_NOEXT) ++ ".sst"}
     end.
-
-
--spec serialise_block(any(), press_method()) -> binary().
-%% @doc
-%% Convert term to binary
-%% Function split out to make it easier to experiment with different
-%% compression methods.  Also, perhaps standardise applictaion of CRC
-%% checks
-serialise_block(Term, lz4) ->
-    {ok, Bin} = lz4:pack(term_to_binary(Term)),
-    CRC32 = hmac(Bin),
-    <<Bin/binary, CRC32:32/integer>>;
-serialise_block(Term, native) ->
-    Bin = term_to_binary(Term, ?BINARY_SETTINGS),
-    CRC32 = hmac(Bin),
-    <<Bin/binary, CRC32:32/integer>>;
-serialise_block(Term, zstd) ->
-    Bin = zstd:compress(term_to_binary(Term)),
-    CRC32 = hmac(Bin),
-    <<Bin/binary, CRC32:32/integer>>;
-serialise_block(Term, none) ->
-    Bin = term_to_binary(Term),
-    CRC32 = hmac(Bin),
-    <<Bin/binary, CRC32:32/integer>>.
-
--spec deserialise_block(binary(), press_method()) -> list(leveled_codec:ledger_kv()).
-%% @doc
-%% Convert binary to term
-%% Function split out to make it easier to experiment with different
-%% compression methods.
-%%
-%% If CRC check fails we treat all the data as missing
-deserialise_block(Bin, PressMethod) when byte_size(Bin) > 4 ->
-    BinS = byte_size(Bin) - 4,
-    <<TermBin:BinS/binary, CRC32:32/integer>> = Bin,
-    try
-        CRC32 = hmac(TermBin),
-        deserialise_checkedblock(TermBin, PressMethod)
-    catch
-        _Exception:_Reason ->
-            []
-    end;
-deserialise_block(_Bin, _PM) ->
-    [].
-
-deserialise_checkedblock(Bin, lz4) when is_binary(Bin) ->
-    case lz4:unpack(Bin) of
-        {ok, Bin0} when is_binary(Bin0) ->
-            binary_to_term(Bin0)
-    end;
-deserialise_checkedblock(Bin, zstd) when is_binary(Bin) ->
-    case zstd:decompress(Bin) of
-        Bin0 when is_binary(Bin0) ->
-            binary_to_term(Bin0)
-    end;
-deserialise_checkedblock(Bin, _Other) when is_binary(Bin) ->
-    % native or none can be treated the same
-    binary_to_term(Bin).
 
 -spec hmac(binary()|integer()) -> integer().
 %% @doc
@@ -2054,14 +2040,14 @@ take_max_lastmoddate(LMD, LMDAcc) ->
 -spec generate_binary_slot(
     leveled_codec:maybe_lookup(),
     {forward|reverse, list(leveled_codec:ledger_kv())},
-    press_method(),
+    block_method(),
     boolean(),
     build_timings()) -> {binary_slot(), build_timings()}.
 %% @doc
 %% Generate the serialised slot to be used when storing this sublist of keys
 %% and values
 generate_binary_slot(
-        Lookup, {DR, KVL0}, PressMethod, IndexModDate, BuildTimings0) ->
+        Lookup, {DR, KVL0}, BlockMethod, IndexModDate, BuildTimings0) ->
     % The slot should be received reversed - get last key before flipping
     % accumulate_positions/2 should use the reversed KVL for efficiency
     {KVL, KVLr} =
@@ -2104,45 +2090,55 @@ generate_binary_slot(
     {B1, B2, B3, B4, B5} =
         case length(KVL) of
             L when L =< SideBlockSize ->
-                {serialise_block(KVL, PressMethod),
+                {
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVL),
                     <<0:0>>,
                     <<0:0>>,
                     <<0:0>>,
-                    <<0:0>>};
+                    <<0:0>>
+                };
             L when L =< 2 * SideBlockSize ->
                 {KVLA, KVLB} = lists:split(SideBlockSize, KVL),
-                {serialise_block(KVLA, PressMethod),
-                    serialise_block(KVLB, PressMethod),
+                {
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLA),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLB),
                     <<0:0>>,
                     <<0:0>>,
-                    <<0:0>>};
+                    <<0:0>>
+                };
             L when L =< (2 * SideBlockSize + MidBlockSize) ->
                 {KVLA, KVLB_Rest} = lists:split(SideBlockSize, KVL),
                 {KVLB, KVLC} = lists:split(SideBlockSize, KVLB_Rest),
-                {serialise_block(KVLA, PressMethod),
-                    serialise_block(KVLB, PressMethod),
-                    serialise_block(KVLC, PressMethod),
+                {
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLA),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLB),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLC),
                     <<0:0>>,
-                    <<0:0>>};
+                    <<0:0>>
+                };
             L when L =< (3 * SideBlockSize + MidBlockSize) ->
                 {KVLA, KVLB_Rest} = lists:split(SideBlockSize, KVL),
                 {KVLB, KVLC_Rest} = lists:split(SideBlockSize, KVLB_Rest),
                 {KVLC, KVLD} = lists:split(MidBlockSize, KVLC_Rest),
-                {serialise_block(KVLA, PressMethod),
-                    serialise_block(KVLB, PressMethod),
-                    serialise_block(KVLC, PressMethod),
-                    serialise_block(KVLD, PressMethod),
-                    <<0:0>>};
+                {
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLA),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLB),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLC),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLD),
+                    <<0:0>>
+                };
             L when L =< (4 * SideBlockSize + MidBlockSize) ->
                 {KVLA, KVLB_Rest} = lists:split(SideBlockSize, KVL),
                 {KVLB, KVLC_Rest} = lists:split(SideBlockSize, KVLB_Rest),
                 {KVLC, KVLD_Rest} = lists:split(MidBlockSize, KVLC_Rest),
                 {KVLD, KVLE} = lists:split(SideBlockSize, KVLD_Rest),
-                {serialise_block(KVLA, PressMethod),
-                    serialise_block(KVLB, PressMethod),
-                    serialise_block(KVLC, PressMethod),
-                    serialise_block(KVLD, PressMethod),
-                    serialise_block(KVLE, PressMethod)}
+                {
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLA),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLB),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLC),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLD),
+                    leveled_sstblock:serialise_block(Lookup, BlockMethod, KVLE)
+                }
         end,
 
     BuildTimings2 = update_buildtimings(BuildTimings1, slot_serialise),
@@ -2163,25 +2159,38 @@ generate_binary_slot(
     Header =
         case IndexModDate of
             true ->
-                <<B1L:32/integer,
+                <<
+                    B1L:32/integer,
                     B2L:32/integer,
                     B3L:32/integer,
                     B4L:32/integer,
                     B5L:32/integer,
                     LMD:32/integer,
-                    PosBinIndex/binary>>;
+                    PosBinIndex/binary
+                >>;
             false ->
-                <<B1L:32/integer,
+                <<
+                    B1L:32/integer,
                     B2L:32/integer,
                     B3L:32/integer,
                     B4L:32/integer,
                     B5L:32/integer,
-                    PosBinIndex/binary>>
+                    PosBinIndex/binary
+                >>
         end,
     CheckH = hmac(Header),
-    SlotBin = <<CheckB1P:32/integer, B1P:32/integer,
-                    CheckH:32/integer, Header/binary,
-                    B1/binary, B2/binary, B3/binary, B4/binary, B5/binary>>,
+    SlotBin =
+        <<
+            CheckB1P:32/integer,
+            B1P:32/integer,
+            CheckH:32/integer,
+            Header/binary,
+            B1/binary,
+            B2/binary,
+            B3/binary,
+            B4/binary,
+            B5/binary
+        >>,
 
     BuildTimings3 = update_buildtimings(BuildTimings2, slot_finish),
 
@@ -2193,21 +2202,21 @@ generate_binary_slot(
     binary()|{file:io_device(), integer()},
     binary(),
     integer(),
-    press_method(),
+    block_method(),
     boolean(),
     list()) ->
         list(leveled_codec:ledger_kv()).
 %% @doc
 %% Acc should start as not_present if LedgerKey is a key, and a list if
 %% LedgerKey is false
-check_blocks_allkeys([], _BP, _BLs, _PBL, _PM, _IMD, Acc) ->
+check_blocks_allkeys([], _BP, _BLs, _PBL, _BM, _IMD, Acc) ->
     lists:reverse(Acc);
 check_blocks_allkeys(
         [Pos|Rest],
         BlockPointer,
         BlockLengths,
         PosBinLength,
-        PressMethod,
+        BlockMethod,
         IdxModDate,
         Acc) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
@@ -2219,14 +2228,14 @@ check_blocks_allkeys(
             BlockNumber,
             additional_offset(IdxModDate)
         ),
-    case spawn_check_block(BlockPos, BlockBin, PressMethod) of
+    case spawn_check_block(BlockPos, BlockBin, BlockMethod) of
         {K, V} ->
             check_blocks_allkeys(
                 Rest,
                 BlockPointer,
                 BlockLengths,
                 PosBinLength,
-                PressMethod,
+                BlockMethod,
                 IdxModDate,
                 [{K, V}|Acc]
             )
@@ -2238,7 +2247,7 @@ check_blocks_allkeys(
     binary(),
     integer(),
     leveled_codec:ledger_key(),
-    press_method(),
+    block_method(),
     boolean()) ->
         not_present|leveled_codec:ledger_kv().
 %% @doc
@@ -2252,7 +2261,7 @@ check_blocks_matchkey(
         BlockLengths,
         PosBinLength,
         LedgerKeyToCheck,
-        PressMethod,
+        BlockMethod,
         IdxModDate) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
     BlockBin =
@@ -2262,7 +2271,7 @@ check_blocks_matchkey(
         BlockNumber,
         additional_offset(IdxModDate)
     ),
-    CheckResult = spawn_check_block(BlockPos, BlockBin, PressMethod),
+    CheckResult = spawn_check_block(BlockPos, BlockBin, BlockMethod),
     case {CheckResult, LedgerKeyToCheck} of
         {{K, V}, K} ->
             {K, V};
@@ -2273,23 +2282,25 @@ check_blocks_matchkey(
                 BlockLengths,
                 PosBinLength,
                 LedgerKeyToCheck,
-                PressMethod,
+                BlockMethod,
                 IdxModDate
             )
 end.
 
--spec spawn_check_block(non_neg_integer(), binary(), press_method())
+-spec spawn_check_block(non_neg_integer(), binary(), block_method())
         -> not_present|leveled_codec:ledger_kv().
-spawn_check_block(BlockPos, BlockBin, PressMethod) ->
+spawn_check_block(BlockPos, BlockBin, BlockMethod) ->
     Parent = self(),
     Pid =
         spawn_link(
-            fun() -> check_block(Parent, BlockPos, BlockBin, PressMethod) end
+            fun() ->
+                check_block(Parent, BlockPos, BlockBin, BlockMethod)
+            end
         ),
     receive {checked_block, Pid, R} -> R end.
 
-check_block(From, BlockPos, BlockBin, PressMethod) ->
-    R = fetchfrom_rawblock(BlockPos, deserialise_block(BlockBin, PressMethod)),
+check_block(From, BlockPos, BlockBin, BlockMethod) ->
+    R = leveled_sstblock:get_nth(BlockPos, BlockBin, BlockMethod),
     From ! {checked_block, self(), R}.
 
 -spec additional_offset(boolean()) -> pos_integer().
@@ -2304,12 +2315,11 @@ additional_offset(false) ->
 
 read_block({Handle, StartPos}, BlockLengths, PosBinLength, BlockID, AO) ->
     {Offset, Length} = block_offsetandlength(BlockLengths, BlockID),
-    {ok, BlockBin} = file:pread(Handle,
-                                StartPos
-                                    + Offset
-                                    + PosBinLength
-                                    + AO,
-                                Length),
+    {ok, BlockBin} =
+        file:pread(
+            Handle,
+            StartPos + Offset + PosBinLength + AO,  Length
+        ),
     BlockBin;
 read_block(SlotBin, BlockLengths, PosBinLength, BlockID, AO) ->
     {Offset, Length} = block_offsetandlength(BlockLengths, BlockID),
@@ -2318,9 +2328,12 @@ read_block(SlotBin, BlockLengths, PosBinLength, BlockID, AO) ->
     BlockBin.
 
 read_slot(Handle, Slot) ->
-    {ok, SlotBin} = file:pread(Handle,
-                                Slot#slot_index_value.start_position,
-                                Slot#slot_index_value.length),
+    {ok, SlotBin} =
+        file:pread(
+            Handle,
+            Slot#slot_index_value.start_position,
+            Slot#slot_index_value.length
+        ),
     SlotBin.
 
 -spec pointer_mapfun(
@@ -2355,7 +2368,7 @@ binarysplit_mapfun(MultiSlotBin, StartPos) ->
         file:io_device(),
         list(),
         {segment_check_fun(), non_neg_integer(), blockindex_cache()},
-        press_method(),
+        block_method(),
         boolean())
             -> {boolean(), list(expanded_slot()|leveled_codec:ledger_kv())}.
 %% @doc
@@ -2368,12 +2381,12 @@ binarysplit_mapfun(MultiSlotBin, StartPos) ->
 %% be considered as superior to a matching key - as otherwise a matching key
 %% may be intermittently removed from the result set
 read_slots(Handle, SlotList, {false, 0, _BlockIndexCache},
-                _PressMethod, _IdxModDate) ->
+                _BlockMethod, _IdxModDate) ->
     % No list of segments passed or useful Low LastModified Date
     % Just read slots in SlotList
     {false, read_slotlist(SlotList, Handle)};
 read_slots(Handle, SlotList, {SegChecker, LowLastMod, BlockIndexCache},
-                PressMethod, IdxModDate) ->
+                BlockMethod, IdxModDate) ->
     % Potentially need to check the low last modified date, and also the
     % segment_check_fun against the index.  If the index is cached, return the
     % KV pairs at this point, otherwise return the slot pointer so that the
@@ -2423,7 +2436,7 @@ read_slots(Handle, SlotList, {SegChecker, LowLastMod, BlockIndexCache},
                                             BlockIdx,
                                             {Handle, SP},
                                             BlockLengths,
-                                            PressMethod,
+                                            BlockMethod,
                                             IdxModDate,
                                             SegChecker,
                                             {SK, EK}),
@@ -2439,14 +2452,14 @@ read_slots(Handle, SlotList, {SegChecker, LowLastMod, BlockIndexCache},
         binary(),
         binary()|{file:io_device(), integer()},
         binary(),
-        press_method(),
+        block_method(),
         boolean(),
         segment_check_fun(),
         {range_endpoint(), range_endpoint()})
             -> list(leveled_codec:ledger_kv()).
 checkblocks_segandrange(
         BlockIdx, SlotOrHandle, BlockLengths,
-        PressMethod, IdxModDate, SegChecker, {StartKey, EndKey}) ->
+        BlockMethod, IdxModDate, SegChecker, {StartKey, EndKey}) ->
     PositionList = find_pos(BlockIdx, SegChecker),
     KVL =
         check_blocks_allkeys(
@@ -2454,7 +2467,7 @@ checkblocks_segandrange(
             SlotOrHandle,
             BlockLengths,
             byte_size(BlockIdx),
-            PressMethod,
+            BlockMethod,
             IdxModDate,
             []
         ),
@@ -2469,7 +2482,7 @@ read_slotlist(SlotList, Handle) ->
 
 -spec binaryslot_reader(
     list(expanded_slot()),
-    press_method(),
+    block_method(),
     boolean(),
     segment_check_fun(),
     list(expandable_pointer()))
@@ -2486,7 +2499,7 @@ read_slotlist(SlotList, Handle) ->
 %% endpoints of the block are outside of the range, and leaving blocks already
 %% proven to be outside of the range unopened.
 binaryslot_reader(
-        SlotBinsToFetch, PressMethod, IdxModDate, SegChecker, SlotsToPoint) ->
+        SlotBinsToFetch, BlockMethod, IdxModDate, SegChecker, SlotsToPoint) ->
     % Two accumulators are added.
     % One to collect the list of keys and values found in the binary slots
     % (subject to range filtering if the slot is still deserialised at this
@@ -2498,18 +2511,18 @@ binaryslot_reader(
     % loop state), and those caches can be used for future queries.
     binaryslot_reader(
         lists:reverse(SlotBinsToFetch),
-        PressMethod,
+        BlockMethod,
         IdxModDate,
         SegChecker,
         SlotsToPoint,
         []
     ).
 
-binaryslot_reader([], _PressMethod, _IdxModDate, _SegChecker, Acc, BIAcc) ->
+binaryslot_reader([], _BlockMethod, _IdxModDate, _SegChecker, Acc, BIAcc) ->
     {Acc, BIAcc};
 binaryslot_reader(
         [{SlotBin, ID, SK, EK}|Tail],
-        PressMethod, IdxModDate, SegChecker, Acc, BIAcc) ->
+        BlockMethod, IdxModDate, SegChecker, Acc, BIAcc) ->
     % The start key and end key here, may not the start key and end key the
     % application passed into the query.  If the slot is known to lie entirely
     % inside the range, on either of both sides, the SK and EK may be
@@ -2517,18 +2530,18 @@ binaryslot_reader(
     % entries in this slot to be trimmed from either or both sides.
     {TrimmedL, BICache} =
         binaryslot_trimmed(
-            SlotBin, SK, EK, PressMethod, IdxModDate, SegChecker, Acc
+            SlotBin, SK, EK, BlockMethod, IdxModDate, SegChecker, Acc
         ),
     binaryslot_reader(
         Tail,
-        PressMethod,
+        BlockMethod,
         IdxModDate,
         SegChecker,
         TrimmedL,
         [{ID, BICache}|BIAcc]
     );
-binaryslot_reader([{K, V}|Tail], PM, IMD, SC, Acc, BIAcc) ->
-    binaryslot_reader(Tail, PM, IMD, SC, [{K, V}|Acc], BIAcc).
+binaryslot_reader([{K, V}|Tail], BM, IMD, SC, Acc, BIAcc) ->
+    binaryslot_reader(Tail, BM, IMD, SC, [{K, V}|Acc], BIAcc).
 
 
 read_length_list(Handle, LengthList) ->
@@ -2559,9 +2572,9 @@ extract_header(Header, false) ->
     binary(),
     leveled_codec:ledger_key(),
     leveled_codec:segment_hash(),
-    press_method(),
+    block_method(),
     boolean()) -> {not_present|leveled_codec:ledger_kv(), binary()|none}.
-binaryslot_get(FullBin, Key, Hash, PressMethod, IdxModDate) ->
+binaryslot_get(FullBin, Key, Hash, BlockMethod, IdxModDate) ->
     case crc_check_slot(FullBin) of
         {Header, Blocks} ->
             {BlockLengths, _LMD, PosBinIndex} =
@@ -2571,7 +2584,7 @@ binaryslot_get(FullBin, Key, Hash, PressMethod, IdxModDate) ->
                     HashExtract when is_integer(HashExtract) ->
                         find_pos(PosBinIndex, segment_checker(HashExtract))
                 end,
-            {fetch_value(PosList, BlockLengths, Blocks, Key, PressMethod),
+            {fetch_value(PosList, BlockLengths, Blocks, Key, BlockMethod),
                 Header};
         crc_wonky ->
             {not_present, none}
@@ -2579,11 +2592,11 @@ binaryslot_get(FullBin, Key, Hash, PressMethod, IdxModDate) ->
 
 -spec binaryslot_tolist(
         binary(),
-        press_method(),
+        block_method(),
         boolean(),
         list(leveled_codec:ledger_kv()|expandable_pointer()))
             -> list(leveled_codec:ledger_kv()|expandable_pointer()).
-binaryslot_tolist(FullBin, PressMethod, IdxModDate, InitAcc) ->
+binaryslot_tolist(FullBin, BlockMethod, IdxModDate, InitAcc) ->
     case crc_check_slot(FullBin) of
         {Header, Blocks} ->
             {BlockLengths, _LMD, _PosBinIndex} =
@@ -2600,7 +2613,7 @@ binaryslot_tolist(FullBin, PressMethod, IdxModDate, InitAcc) ->
                 B5:B5L/binary>> = Blocks,
             lists:foldl(
                 fun(B, Acc) ->
-                    append(deserialise_block(B, PressMethod), Acc)
+                    append(leveled_sstblock:get_all(B, BlockMethod), Acc)
                 end,
                 InitAcc,
                 [B5, B4, B3, B2, B1]
@@ -2613,7 +2626,7 @@ binaryslot_tolist(FullBin, PressMethod, IdxModDate, InitAcc) ->
         binary(),
         range_endpoint(),
         range_endpoint(),
-        press_method(),
+        block_method(),
         boolean(),
         segment_check_fun(),
         list(leveled_codec:ledger_kv()|expandable_pointer())
@@ -2623,10 +2636,10 @@ binaryslot_tolist(FullBin, PressMethod, IdxModDate, InitAcc) ->
 %% @doc
 %% Must return a trimmed and reversed list of results in the range
 binaryslot_trimmed(
-        FullBin, all, all, PressMethod, IdxModDate, false, Acc) ->
-    {binaryslot_tolist(FullBin, PressMethod, IdxModDate, Acc), none};
+        FullBin, all, all, BlockMethod, IdxModDate, false, Acc) ->
+    {binaryslot_tolist(FullBin, BlockMethod, IdxModDate, Acc), none};
 binaryslot_trimmed(
-        FullBin, StartKey, EndKey, PressMethod, IdxModDate, SegmentChecker, Acc
+        FullBin, StartKey, EndKey, BlockMethod, IdxModDate, SegmentChecker, Acc
     ) ->
     case {crc_check_slot(FullBin), SegmentChecker} of
         % Get a trimmed list of keys in the slot based on the range, trying
@@ -2647,7 +2660,7 @@ binaryslot_trimmed(
                 blocks_required(
                     {StartKey, EndKey},
                     Block1, Block2, MidBlock, Block4, Block5,
-                    PressMethod),
+                    BlockMethod),
             {append(TrimmedKVL, Acc), none};
         {{Header, _Blocks}, SegmentChecker} ->
             {BlockLengths, _LMD, BlockIdx} =
@@ -2657,7 +2670,7 @@ binaryslot_trimmed(
                     BlockIdx,
                     FullBin,
                     BlockLengths,
-                    PressMethod,
+                    BlockMethod,
                     IdxModDate,
                     SegmentChecker,
                     {StartKey, EndKey}),
@@ -2669,69 +2682,97 @@ binaryslot_trimmed(
 -spec blocks_required(
         {range_endpoint(), range_endpoint()},
         binary(), binary(), binary(), binary(), binary(),
-        press_method()) -> list(leveled_codec:ledger_kv()).
+        block_method()) -> list(leveled_codec:ledger_kv()).
 blocks_required(
-        {StartKey, EndKey}, B1, B2, MidBlock, B4, B5, PressMethod) ->
-    MidBlockList = deserialise_block(MidBlock, PressMethod),
-    case filterby_midblock(
-            fetchends_rawblock(MidBlockList), {StartKey, EndKey}) of
+        {StartKey, EndKey}, B1, B2, MidBlock, B4, B5, BlockMethod) ->
+    {Top, Tail, MidBlockFetchFun} =
+        leveled_sstblock:get_topandtail(MidBlock, BlockMethod),
+    case filterby_midblock({Top, Tail}, {StartKey, EndKey}) of
         empty ->
             append(
-                in_range(deserialise_block(B1, PressMethod), StartKey, EndKey),
-                in_range(deserialise_block(B2, PressMethod), StartKey, EndKey),
-                in_range(deserialise_block(B4, PressMethod), StartKey, EndKey),
-                in_range(deserialise_block(B5, PressMethod), StartKey, EndKey)
+                in_range(
+                    leveled_sstblock:get_all(B1, BlockMethod),
+                    StartKey,
+                    EndKey
+                ),
+                in_range(
+                    leveled_sstblock:get_all(B2, BlockMethod),
+                    StartKey,
+                    EndKey
+                ),
+                in_range(
+                    leveled_sstblock:get_all(B4, BlockMethod),
+                    StartKey,
+                    EndKey
+                ),
+                in_range(
+                    leveled_sstblock:get_all(B5, BlockMethod),
+                    StartKey,
+                    EndKey
+                )
             );
         all_blocks ->
             append(
-                get_lefthand_blocks(B1, B2, PressMethod, StartKey),
-                MidBlockList,
-                get_righthand_blocks(B4, B5, PressMethod, EndKey)
+                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
+                MidBlockFetchFun(),
+                get_righthand_blocks(B4, B5, BlockMethod, EndKey)
             );
         lt_mid ->
             in_range(
-                get_lefthand_blocks(B1, B2, PressMethod, StartKey),
+                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
                 all,
                 EndKey);
         le_mid ->
             append(
-                get_lefthand_blocks(B1, B2, PressMethod, StartKey),
-                in_range(MidBlockList, all, EndKey)
+                get_lefthand_blocks(B1, B2, BlockMethod, StartKey),
+                in_range(MidBlockFetchFun(), all, EndKey)
             );
         mid_only ->
-            in_range(MidBlockList, StartKey, EndKey);
+            in_range(MidBlockFetchFun(), StartKey, EndKey);
         ge_mid ->
             append(
-                in_range(MidBlockList, StartKey, all),
-                get_righthand_blocks(B4, B5, PressMethod, EndKey)
+                in_range(MidBlockFetchFun(), StartKey, all),
+                get_righthand_blocks(B4, B5, BlockMethod, EndKey)
             );
         gt_mid ->
             in_range(
-                get_righthand_blocks(B4, B5, PressMethod, EndKey),
+                get_righthand_blocks(B4, B5, BlockMethod, EndKey),
                 StartKey,
                 all)
     end.
 
-get_lefthand_blocks(B1, B2, PressMethod, StartKey) ->
-    BlockList2 = deserialise_block(B2, PressMethod),
-    case previous_block_required(
-            fetchends_rawblock(BlockList2), StartKey) of
+get_lefthand_blocks(B1, B2, BlockMethod, StartKey) ->
+    {Top, Tail, InnerLeftBlockFetchFun} =
+        leveled_sstblock:get_topandtail(B2, BlockMethod),
+    case previous_block_required({Top, Tail}, StartKey) of
         true ->
-            in_range(deserialise_block(B1, PressMethod), StartKey, all)
-            ++ BlockList2;
+            append(
+                in_range(
+                    leveled_sstblock:get_all(B1, BlockMethod),
+                    StartKey,
+                    all
+                ),
+                InnerLeftBlockFetchFun()
+            );
         false ->
-            in_range(BlockList2, StartKey, all)
+            in_range(InnerLeftBlockFetchFun(), StartKey, all)
     end.
 
-get_righthand_blocks(B4, B5, PressMethod, EndKey) ->
-    BlockList4 = deserialise_block(B4, PressMethod),
-    case next_block_required(
-            fetchends_rawblock(BlockList4), EndKey) of
+get_righthand_blocks(B4, B5, BlockMethod, EndKey) ->
+    {Top, Tail, InnerRightBlockFetchFun} =
+        leveled_sstblock:get_topandtail(B4, BlockMethod),
+    case next_block_required({Top, Tail}, EndKey) of
         true ->
-            BlockList4
-            ++ in_range(deserialise_block(B5, PressMethod), all, EndKey);
+            append(
+                InnerRightBlockFetchFun(),
+                in_range(
+                    leveled_sstblock:get_all(B5, BlockMethod),
+                    all,
+                    EndKey
+                )
+            );
         false ->
-            in_range(BlockList4, all, EndKey)
+            in_range(InnerRightBlockFetchFun(), all, EndKey)
     end.
 
 filterby_midblock({not_present, not_present}, _RangeKeys) ->
@@ -2839,48 +2880,20 @@ block_offsetandlength(BlockLengths, BlockID) ->
     binary(),
     binary(),
     leveled_codec:ledger_key(),
-    press_method()) -> not_present|leveled_codec:ledger_kv().
-fetch_value([], _BlockLengths, _Blocks, _Key, _PressMethod) ->
+    block_method()) -> not_present|leveled_codec:ledger_kv().
+fetch_value([], _BlockLengths, _Blocks, _Key, _BlockMethod) ->
     not_present;
-fetch_value([Pos|Rest], BlockLengths, Blocks, Key, PressMethod) ->
+fetch_value([Pos|Rest], BlockLengths, Blocks, Key, BlockMethod) ->
     {BlockNumber, BlockPos} = revert_position(Pos),
     {Offset, Length} = block_offsetandlength(BlockLengths, BlockNumber),
     <<_Pre:Offset/binary, Block:Length/binary, _Rest/binary>> = Blocks,
-    R = fetchfrom_rawblock(BlockPos, deserialise_block(Block, PressMethod)),
+    R = leveled_sstblock:get_nth(BlockPos, Block, BlockMethod),
     case R of 
         {K, V} when K == Key ->
             {K, V};
         _ ->
-            fetch_value(Rest, BlockLengths, Blocks, Key, PressMethod)
+            fetch_value(Rest, BlockLengths, Blocks, Key, BlockMethod)
     end.
-
--spec fetchfrom_rawblock(
-        pos_integer(), list(leveled_codec:ledger_kv()))
-            -> not_present|leveled_codec:ledger_kv().
-%% @doc
-%% Fetch from a deserialised block, but accounting for potential corruption
-%% in that block which may lead to it returning as an empty list if that
-%% corruption is detected by the deserialising function
-fetchfrom_rawblock(BlockPos, RawBlock) when BlockPos > length(RawBlock) ->
-    %% Capture the slightly more general case than this being an empty list
-    %% in case of some other unexpected misalignement that would otherwise
-    %% crash the leveled_sst file process
-    not_present;
-fetchfrom_rawblock(BlockPos, RawBlock) ->
-    lists:nth(BlockPos, RawBlock).
-
--spec fetchends_rawblock(
-    list(leveled_codec:ledger_kv()))
-        -> {not_present, not_present}|
-            {leveled_codec:ledger_key(), leveled_codec:ledger_key()}.
-%% @doc
-%% Fetch the first and last key from a block, and not_present if the block
-%% is empty (rather than crashing)
-fetchends_rawblock([]) ->
-    {not_present, not_present};
-fetchends_rawblock(RawBlock) ->
-    {element(1, hd(RawBlock)),
-        element(1, lists:last(RawBlock))}.
 
 revert_position(Pos) ->
     {SideBlockSize, MidBlockSize} = ?LOOK_BLOCKSIZE,
@@ -2967,26 +2980,35 @@ append(L1, L2, L3, L4) ->
 %% Merge from a single list (i.e. at Level 0)
 merge_lists(KVList1, SSTOpts, IdxModDate) ->
     SlotCount = length(KVList1) div ?LOOK_SLOTSIZE,
-    {[],
+    {
         [],
-        split_lists(KVList1, [],
-                    SlotCount, SSTOpts#sst_options.press_method, IdxModDate),
+        [],
+        split_lists(
+            KVList1,[],
+            SlotCount,
+            {
+                SSTOpts#sst_options.block_version,
+                SSTOpts#sst_options.press_method
+            },
+            IdxModDate
+        ),
         element(1, lists:nth(1, KVList1)),
-        not_counted}.
+        not_counted
+    }.
 
-split_lists([], SlotLists, 0, _PressMethod, _IdxModDate) ->
+split_lists([], SlotLists, 0, _BlockMethod, _IdxModDate) ->
     lists:reverse(SlotLists);
-split_lists(LastPuff, SlotLists, 0, PressMethod, IdxModDate) ->
+split_lists(LastPuff, SlotLists, 0, BlockMethod, IdxModDate) ->
     {SlotD, _} =
         generate_binary_slot(
-            lookup, {forward, LastPuff}, PressMethod, IdxModDate, no_timing),
+            lookup, {forward, LastPuff}, BlockMethod, IdxModDate, no_timing),
     lists:reverse([SlotD|SlotLists]);
-split_lists(KVList1, SlotLists, N, PressMethod, IdxModDate) ->
+split_lists(KVList1, SlotLists, N, BlockMethod, IdxModDate) ->
     {Slot, KVListRem} = lists:split(?LOOK_SLOTSIZE, KVList1),
     {SlotD, _} =
         generate_binary_slot(
-            lookup, {forward, Slot}, PressMethod, IdxModDate, no_timing),
-    split_lists(KVListRem, [SlotD|SlotLists], N - 1, PressMethod, IdxModDate).
+            lookup, {forward, Slot}, BlockMethod, IdxModDate, no_timing),
+    split_lists(KVListRem, [SlotD|SlotLists], N - 1, BlockMethod, IdxModDate).
 
 -spec merge_lists(
     list(maybe_expanded_pointer()),
@@ -3019,7 +3041,7 @@ merge_lists(
         null,
         0,
         SSTOpts#sst_options.max_sstslots,
-    SSTOpts#sst_options.press_method,
+        {SSTOpts#sst_options.block_version, SSTOpts#sst_options.press_method},
         IndexModDate,
         0,
         BuildTimings
@@ -3034,7 +3056,7 @@ merge_lists(
     leveled_codec:ledger_key()|null,
     non_neg_integer(),
     pos_integer()|infinity,
-    press_method(),
+    block_method(),
     boolean(),
     non_neg_integer(),
     build_timings()) ->
@@ -3043,18 +3065,18 @@ merge_lists(
             non_neg_integer()}.
 
 merge_lists(KVL1, KVL2, LI, SlotList, FirstKey, MaxSlots, MaxSlots,
-                                _PressMethod, _IdxModDate, CountOfTombs, T0) ->
+                                _BlockMethod, _IdxModDate, CountOfTombs, T0) ->
     % This SST file is full, move to complete file, and return the
     % remainder
     log_buildtimings(T0, LI),
     {KVL1, KVL2, lists:reverse(SlotList), FirstKey, CountOfTombs};
 merge_lists([], [], LI, SlotList, FirstKey, _SlotCount, _MaxSlots,
-                                _PressMethod, _IdxModDate, CountOfTombs, T0) ->
+                                _BlockMethod, _IdxModDate, CountOfTombs, T0) ->
     % the source files are empty, complete the file
     log_buildtimings(T0, LI),
     {[], [], lists:reverse(SlotList), FirstKey, CountOfTombs};
 merge_lists(KVL1, KVL2, LI, SlotList, FirstKey, SlotCount, MaxSlots,
-                                PressMethod, IdxModDate, CountOfTombs, T0) ->
+                                BlockMethod, IdxModDate, CountOfTombs, T0) ->
     % Form a slot by merging the two lists until the next 128 K/V pairs have
     % been determined
     {KVRem1, KVRem2, Slot, FK0} =
@@ -3063,34 +3085,38 @@ merge_lists(KVL1, KVL2, LI, SlotList, FirstKey, SlotCount, MaxSlots,
     case Slot of
         {_, []} ->
             % There were no actual keys in the slot (maybe some expired)
-            merge_lists(KVRem1,
-                        KVRem2,
-                        LI,
-                        SlotList,
-                        FK0,
-                        SlotCount,
-                        MaxSlots,
-                        PressMethod,
-                        IdxModDate,
-                        CountOfTombs,
-                        T1);
+            merge_lists(
+                KVRem1,
+                KVRem2,
+                LI,
+                SlotList,
+                FK0,
+                SlotCount,
+                MaxSlots,
+                BlockMethod,
+                IdxModDate,
+                CountOfTombs,
+                T1
+            );
         {Lookup, KVL} ->
             % Convert the list of KVs for the slot into a binary, and related
             % metadata
             {SlotD, T2} =
                 generate_binary_slot(
-                    Lookup, {reverse, KVL}, PressMethod, IdxModDate, T1),
-            merge_lists(KVRem1,
-                        KVRem2,
-                        LI,
-                        [SlotD|SlotList],
-                        FK0,
-                        SlotCount + 1,
-                        MaxSlots,
-                        PressMethod,
-                        IdxModDate,
-                        leveled_codec:count_tombs(KVL, CountOfTombs),
-                        T2)
+                    Lookup, {reverse, KVL}, BlockMethod, IdxModDate, T1),
+            merge_lists(
+                KVRem1,
+                    KVRem2,
+                    LI,
+                    [SlotD|SlotList],
+                    FK0,
+                    SlotCount + 1,
+                    MaxSlots,
+                    BlockMethod,
+                    IdxModDate,
+                    leveled_codec:count_tombs(KVL, CountOfTombs),
+                    T2
+                )
     end.
 
 -spec form_slot(
@@ -3313,13 +3339,13 @@ maybelog_fetch_timing({Pid, _SlotFreq}, Level, Type, SW) when is_pid(Pid), SW =/
 -define(TEST_AREA, "test/test_area/").
 
 binaryslot_trimmed(
-    FullBin, StartKey, EndKey, PressMethod, IdxModDate, SegmentChecker) ->
+    FullBin, StartKey, EndKey, BlockMethod, IdxModDate, SegmentChecker) ->
     binaryslot_trimmed(
-        FullBin, StartKey, EndKey, PressMethod, IdxModDate, SegmentChecker, []
+        FullBin, StartKey, EndKey, BlockMethod, IdxModDate, SegmentChecker, []
     ).
 
-binaryslot_tolist(FullBin, PressMethod, IdxModDate) ->
-    binaryslot_tolist(FullBin, PressMethod, IdxModDate, []).
+binaryslot_tolist(FullBin, BlockMethod, IdxModDate) ->
+    binaryslot_tolist(FullBin, BlockMethod, IdxModDate, []).
 
 
 sst_getkvrange(Pid, StartKey, EndKey, ScanWidth) ->
@@ -3352,26 +3378,30 @@ sst_getkvrange(Pid, StartKey, EndKey, ScanWidth, SegChecker, LowLastMod) ->
 sst_getslots(Pid, SlotList) ->
     sst_getfilteredslots(Pid, SlotList, false, 0, []).
 
-testsst_new(RootPath, Filename, Level, KVList, MaxSQN, PressMethod) ->
+testsst_new(
+    RootPath, Filename, Level, KVList, MaxSQN, {BV, PM}) ->
     OptsSST =
-        #sst_options{press_method=PressMethod,
-                        log_options=leveled_log:get_opts()},
+        #sst_options{
+            press_method=PM,
+            block_version=BV,
+            log_options=leveled_log:get_opts()
+        },
     sst_new(RootPath, Filename, Level, KVList, MaxSQN, OptsSST, false).
 
 testsst_new(RootPath, Filename,
-            KVL1, KVL2, IsBasement, Level, MaxSQN, PressMethod) ->
+            KVL1, KVL2, IsBasement, Level, MaxSQN, {BV, PM}) ->
     OptsSST =
-        #sst_options{press_method=PressMethod,
-                        log_options=leveled_log:get_opts()},
+        #sst_options{
+            press_method=PM,
+            block_version=BV,
+            log_options=leveled_log:get_opts()
+        },
     sst_newmerge(RootPath, Filename, KVL1, KVL2, IsBasement, Level, MaxSQN,
                     OptsSST, false).
 
 generate_randomkeys(Seqn, Count, BucketRangeLow, BucketRangeHigh) ->
-    generate_randomkeys(Seqn,
-                        Count,
-                        [],
-                        BucketRangeLow,
-                        BucketRangeHigh).
+    generate_randomkeys(
+        Seqn, Count, [], BucketRangeLow, BucketRangeHigh).
 
 generate_randomkeys(_Seqn, 0, Acc, _BucketLow, _BucketHigh) ->
     Acc;
@@ -3564,7 +3594,7 @@ indexed_list_test() ->
 
     {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, KVL1}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, KVL1}, {0, native}, ?INDEX_MODDATE, no_timing),
     io:format(user,
                 "Indexed list created slot in ~w microseconds of size ~w~n",
                 [timer:now_diff(os:timestamp(), SW0), byte_size(FullBin)]),
@@ -3594,7 +3624,7 @@ indexed_list_mixedkeys_test() ->
 
     {{_PosBinIndex1, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, Keys}, {0, native}, ?INDEX_MODDATE, no_timing),
 
     {TestK1, TestV1} = lists:nth(4, KVL1),
     MH1 = leveled_codec:segment_hash(TestK1),
@@ -3622,7 +3652,7 @@ indexed_list_mixedkeys2_test() ->
     Keys = IdxKeys1 ++ KVL1 ++ IdxKeys2,
     {{_Header, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, Keys}, {0, native}, ?INDEX_MODDATE, no_timing),
     lists:foreach(fun({K, V}) ->
                         MH = leveled_codec:segment_hash(K),
                         test_binary_slot(FullBin, K, MH, {K, V})
@@ -3634,10 +3664,10 @@ indexed_list_allindexkeys_test() ->
                             ?LOOK_SLOTSIZE),
     {{HeaderT, FullBinT, HL, LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, true, no_timing),
+            lookup, {forward, Keys}, {0, native}, true, no_timing),
     {{HeaderF, FullBinF, HL, LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, false, no_timing),
+            lookup, {forward, Keys}, {0, native}, false, no_timing),
     EmptySlotSize = ?LOOK_SLOTSIZE - 1,
     LMD = ?FLIPPER32,
     ?assertMatch(<<_BL:20/binary, LMD:32/integer, EmptySlotSize:8/integer>>,
@@ -3645,8 +3675,8 @@ indexed_list_allindexkeys_test() ->
     ?assertMatch(<<_BL:20/binary, EmptySlotSize:8/integer>>,
                     HeaderF),
     % SW = os:timestamp(),
-    BinToListT = binaryslot_tolist(FullBinT, native, true),
-    BinToListF = binaryslot_tolist(FullBinF, native, false),
+    BinToListT = binaryslot_tolist(FullBinT, {0, native}, true),
+    BinToListF = binaryslot_tolist(FullBinF, {0, native}, false),
     % io:format(user,
     %             "Indexed list flattened in ~w microseconds ~n",
     %             [timer:now_diff(os:timestamp(), SW)]),
@@ -3655,37 +3685,37 @@ indexed_list_allindexkeys_test() ->
     ?assertMatch(
         {Keys, none},
         binaryslot_trimmed(
-            FullBinT, all, all, native, true, false)),
+            FullBinT, all, all, {0, native}, true, false)),
     ?assertMatch(Keys, BinToListF),
     ?assertMatch(
         {Keys, none},
         binaryslot_trimmed(
-            FullBinF, all, all, native, false, false)).
+            FullBinF, all, all, {0, native}, false, false)).
 
 indexed_list_allindexkeys_nolookup_test() ->
     Keys = lists:sublist(lists:ukeysort(1, generate_indexkeys(1000)),
                             ?NOLOOK_SLOTSIZE),
     {{Header, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            no_lookup, {forward, Keys}, native, ?INDEX_MODDATE,no_timing),
+            no_lookup, {forward, Keys}, {0, native}, ?INDEX_MODDATE,no_timing),
     ?assertMatch(<<_BL:20/binary, _LMD:32/integer, 127:8/integer>>, Header),
     % SW = os:timestamp(),
     BinToList =
-        binaryslot_tolist(FullBin, native, ?INDEX_MODDATE),
+        binaryslot_tolist(FullBin, {0, native}, ?INDEX_MODDATE),
     % io:format(user,
     %             "Indexed list flattened in ~w microseconds ~n",
     %             [timer:now_diff(os:timestamp(), SW)]),
     ?assertMatch(Keys, BinToList),
     ?assertMatch(
         {Keys, none},
-        binaryslot_trimmed(FullBin, all, all, native, ?INDEX_MODDATE, false)).
+        binaryslot_trimmed(FullBin, all, all, {0, native}, ?INDEX_MODDATE, false)).
 
 indexed_list_allindexkeys_trimmed_test() ->
     Keys = lists:sublist(lists:ukeysort(1, generate_indexkeys(150)),
                             ?LOOK_SLOTSIZE),
     {{Header, FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, Keys}, {0, native}, ?INDEX_MODDATE, no_timing),
     EmptySlotSize = ?LOOK_SLOTSIZE - 1,
     ?assertMatch(
         <<_BL:20/binary, _LMD:32/integer, EmptySlotSize:8/integer>>,
@@ -3696,7 +3726,7 @@ indexed_list_allindexkeys_trimmed_test() ->
             FullBin,
             {i, "Bucket", {"t1_int", 0}, null},
             {i, "Bucket", {"t1_int", 99999}, null},
-            native,
+            {0, native},
             ?INDEX_MODDATE,
             false)),
 
@@ -3705,7 +3735,7 @@ indexed_list_allindexkeys_trimmed_test() ->
     R1 = lists:sublist(Keys, 10, 91),
     {O1, none} =
         binaryslot_trimmed(
-            FullBin, SK1, EK1, native, ?INDEX_MODDATE, false),
+            FullBin, SK1, EK1, {0, native}, ?INDEX_MODDATE, false),
     ?assertMatch(91, length(O1)),
     ?assertMatch(R1, O1),
 
@@ -3713,7 +3743,7 @@ indexed_list_allindexkeys_trimmed_test() ->
     {EK2, _} = lists:nth(20, Keys),
     R2 = lists:sublist(Keys, 10, 11),
     {O2, none} =
-        binaryslot_trimmed(FullBin, SK2, EK2, native, ?INDEX_MODDATE, false),
+        binaryslot_trimmed(FullBin, SK2, EK2, {0, native}, ?INDEX_MODDATE, false),
     ?assertMatch(11, length(O2)),
     ?assertMatch(R2, O2),
 
@@ -3721,7 +3751,7 @@ indexed_list_allindexkeys_trimmed_test() ->
     {EK3, _} = lists:nth(?LOOK_SLOTSIZE, Keys),
     R3 = lists:sublist(Keys, ?LOOK_SLOTSIZE - 1, 2),
     {O3, none} =
-        binaryslot_trimmed(FullBin, SK3, EK3, native, ?INDEX_MODDATE, false),
+        binaryslot_trimmed(FullBin, SK3, EK3, {0, native}, ?INDEX_MODDATE, false),
     ?assertMatch(2, length(O3)),
     ?assertMatch(R3, O3).
 
@@ -3735,7 +3765,7 @@ indexed_list_mixedkeys_bitflip_test() ->
     Keys = lists:ukeysort(1, generate_indexkeys(60) ++ KVL1),
     {{Header, SlotBin, _HL, LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, Keys}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, Keys}, {0, native}, ?INDEX_MODDATE, no_timing),
 
     ?assertMatch(LK, element(1, lists:last(Keys))),
 
@@ -3755,7 +3785,7 @@ indexed_list_mixedkeys_bitflip_test() ->
     test_binary_slot(SlotBin, TestKey1, MH1, lists:nth(1, KVL1)),
     test_binary_slot(SlotBin, TestKey2, MH2, lists:nth(33, KVL1)),
     ToList =
-        binaryslot_tolist(SlotBin, native, ?INDEX_MODDATE),
+        binaryslot_tolist(SlotBin, {0, native}, ?INDEX_MODDATE),
     ?assertMatch(Keys, ToList),
 
     EH1 = case extract_hash(MH1) of Int1 when is_integer(Int1) -> Int1 end,
@@ -3777,9 +3807,9 @@ indexed_list_mixedkeys_bitflip_test() ->
     test_binary_slot(SlotBin2, TestKey2, MH2, not_present),
 
     ToList1 =
-        binaryslot_tolist(SlotBin1, native, ?INDEX_MODDATE),
+        binaryslot_tolist(SlotBin1, {0, native}, ?INDEX_MODDATE),
     ToList2 =
-        binaryslot_tolist(SlotBin2, native, ?INDEX_MODDATE),
+        binaryslot_tolist(SlotBin2, {0, native}, ?INDEX_MODDATE),
 
     ?assertMatch(true, is_list(ToList1)),
     ?assertMatch(true, is_list(ToList2)),
@@ -3793,7 +3823,7 @@ indexed_list_mixedkeys_bitflip_test() ->
     {SK1, _} = lists:nth(10, Keys),
     {EK1, _} = lists:nth(20, Keys),
     {O1, none} =
-        binaryslot_trimmed(SlotBin3, SK1, EK1, native, ?INDEX_MODDATE, false),
+        binaryslot_trimmed(SlotBin3, SK1, EK1, {0, native}, ?INDEX_MODDATE, false),
     ?assertMatch([], O1),
 
     SlotBin4 = flip_byte(SlotBin, 0, 20),
@@ -3802,15 +3832,15 @@ indexed_list_mixedkeys_bitflip_test() ->
     test_binary_slot(SlotBin4, TestKey1, MH1, not_present),
     test_binary_slot(SlotBin5, TestKey1, MH1, not_present),
     ToList4 =
-        binaryslot_tolist(SlotBin4, native, ?INDEX_MODDATE),
+        binaryslot_tolist(SlotBin4, {0, native}, ?INDEX_MODDATE),
     ToList5 =
-        binaryslot_tolist(SlotBin5, native, ?INDEX_MODDATE),
+        binaryslot_tolist(SlotBin5, {0, native}, ?INDEX_MODDATE),
     ?assertMatch([], ToList4),
     ?assertMatch([], ToList5),
     {O4, none} =
-        binaryslot_trimmed(SlotBin4, SK1, EK1, native, ?INDEX_MODDATE, false),
+        binaryslot_trimmed(SlotBin4, SK1, EK1, {0, native}, ?INDEX_MODDATE, false),
     {O5, none} =
-        binaryslot_trimmed(SlotBin4, SK1, EK1, native, ?INDEX_MODDATE, false),
+        binaryslot_trimmed(SlotBin4, SK1, EK1, {0, native}, ?INDEX_MODDATE, false),
     ?assertMatch([], O4),
     ?assertMatch([], O5).
 
@@ -3829,7 +3859,7 @@ flip_byte(Binary, Offset, Length) ->
 test_binary_slot(FullBin, Key, Hash, ExpectedValue) ->
     % SW = os:timestamp(),
     {ReturnedValue, _Header} =
-        binaryslot_get(FullBin, Key, Hash, native, ?INDEX_MODDATE),
+        binaryslot_get(FullBin, Key, Hash, {0, native}, ?INDEX_MODDATE),
     ?assertMatch(ExpectedValue, ReturnedValue).
     % io:format(user, "Fetch success in ~w microseconds ~n",
     %             [timer:now_diff(os:timestamp(), SW)]).
@@ -3863,8 +3893,7 @@ size_tester(KVL1, KVL2, N) ->
 
     {RP, Filename} = {?TEST_AREA, "doublesize_test"},
     Opts =
-        #sst_options{press_method=native,
-                        log_options=leveled_log:get_opts()},
+        #sst_options{press_method=native, log_options=leveled_log:get_opts()},
     {ok, SST1, _KD, _BB} =
         sst_newmerge(
             RP, Filename, KVL1, KVL2, false, ?DOUBLESIZE_LEVEL, N, Opts, false
@@ -3909,9 +3938,9 @@ merge_tester(NewFunS, NewFunM) ->
     KVL3 = lists:ukeymerge(1, KVL1, KVL2),
     SW0 = os:timestamp(),
     {ok, P1, {FK1, LK1}, _Bloom1} =
-        NewFunS(?TEST_AREA, "level1_src", 1, KVL1, 6000, native),
+        NewFunS(?TEST_AREA, "level1_src", 1, KVL1, 6000, {0, native}),
     {ok, P2, {FK2, LK2}, _Bloom2} =
-        NewFunS(?TEST_AREA, "level2_src", 2, KVL2, 3000, native),
+        NewFunS(?TEST_AREA, "level2_src", 2, KVL2, 3000, {0, native}),
     ExpFK1 = element(1, lists:nth(1, KVL1)),
     ExpLK1 = element(1, lists:last(KVL1)),
     ExpFK2 = element(1, lists:nth(1, KVL2)),
@@ -3935,7 +3964,7 @@ merge_tester(NewFunS, NewFunM) ->
             FK2
         }],
     NewR =
-        NewFunM(?TEST_AREA, "level2_merge", ML1, ML2, false, 2, N * 2, native),
+        NewFunM(?TEST_AREA, "level2_merge", ML1, ML2, false, 2, N * 2, {0, native}),
     {ok, P3, {{Rem1, Rem2}, FK3, LK3}, _Bloom3} = NewR,
     ?assertMatch([], Rem1),
     ?assertMatch([], Rem2),
@@ -3973,7 +4002,7 @@ simple_persisted_range_tester(SSTNewFun) ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
+        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
 
     {o, B, K, null} = LastKey,
     SK1 = {o, B, K, 0},
@@ -4015,7 +4044,7 @@ simple_persisted_rangesegfilter_tester(SSTNewFun) ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
+        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
 
     SK1 = element(1, lists:nth(124, KVList1)),
     SK2 = element(1, lists:nth(126, KVList1)),
@@ -4107,7 +4136,8 @@ additional_range_test() ->
                         lists:seq(?NOLOOK_SLOTSIZE + Gap + 1,
                                     2 * ?NOLOOK_SLOTSIZE + Gap)),
     {ok, P1, {{Rem1, Rem2}, SK, EK}, _Bloom1} =
-        testsst_new(?TEST_AREA, "range1_src", IK1, IK2, false, 1, 9999, native),
+        testsst_new(
+            ?TEST_AREA, "range1_src", IK1, IK2, false, 1, 9999, {0, native}),
     ?assertMatch([], Rem1),
     ?assertMatch([], Rem2),
     ?assertMatch(SK, element(1, lists:nth(1, IK1))),
@@ -4167,7 +4197,7 @@ simple_switchcache_tester() ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, OpenP4, {FirstKey, LastKey}, _Bloom1} =
-        testsst_new(RP, Filename, 4, KVList1, length(KVList1), native),
+        testsst_new(RP, Filename, 4, KVList1, length(KVList1), {0, native}),
     lists:foreach(fun({K, V}) ->
                         ?assertMatch({K, V}, sst_get(OpenP4, K))
                         end,
@@ -4187,8 +4217,8 @@ simple_switchcache_tester() ->
                         end,
                     KVList1),
     ok = sst_close(OpenP4),
-    OptsSST = #sst_options{press_method=native,
-                            log_options=leveled_log:get_opts()},
+    OptsSST =
+        #sst_options{press_method=native, log_options=leveled_log:get_opts()},
     {ok, OpenP5, {FirstKey, LastKey}, _Bloom2} =
         sst_open(RP, Filename ++ ".sst", OptsSST, 5),
     lists:foreach(fun({K, V}) ->
@@ -4229,7 +4259,7 @@ simple_persisted_slotsize_tester(SSTNewFun) ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), native),
+        SSTNewFun(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
     lists:foreach(fun({K, V}) ->
                         ?assertMatch({K, V}, sst_get(Pid, K))
                         end,
@@ -4247,7 +4277,7 @@ reader_hibernate_tester() ->
     [{FirstKey, FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        testsst_new(RP, Filename, 1, KVList1, length(KVList1), native),
+        testsst_new(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
     ?assertMatch({FirstKey, FV}, sst_get(Pid, FirstKey)),
     SQN = leveled_codec:strip_to_seqonly({FirstKey, FV}),
     ?assertMatch(
@@ -4267,7 +4297,7 @@ delete_pending_tester() ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        testsst_new(RP, Filename, 1, KVList1, length(KVList1), native),
+        testsst_new(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
     timer:sleep(2000),
     leveled_sst:sst_setfordelete(Pid, false),
     timer:sleep(?DELETE_TIMEOUT + 1000),
@@ -4280,7 +4310,7 @@ fetch_status_test() ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, _Bloom} =
-        testsst_new(RP, Filename, 1, KVList1, length(KVList1), native),
+        testsst_new(RP, Filename, 1, KVList1, length(KVList1), {0, native}),
     {status, Pid, {module, gen_statem}, SItemL} = sys:get_status(Pid),
     {data,[{"State", {reader, S}}]} = lists:nth(3, lists:nth(5, SItemL)),
     RS = S#state.read_state,
@@ -4312,7 +4342,7 @@ simple_persisted_tester(SSTNewFun) ->
     [{FirstKey, _FV}|_Rest] = KVList1,
     {LastKey, _LV} = lists:last(KVList1),
     {ok, Pid, {FirstKey, LastKey}, Bloom} =
-        SSTNewFun(RP, Filename, Level, KVList1, length(KVList1), native),
+        SSTNewFun(RP, Filename, Level, KVList1, length(KVList1), {0, native}),
 
     B0 = check_binary_references(Pid),
 
@@ -4416,8 +4446,8 @@ simple_persisted_tester(SSTNewFun) ->
     ok = sst_close(Pid),
 
     io:format(user, "Reopen SST file~n", []),
-    OptsSST = #sst_options{press_method=native,
-                            log_options=leveled_log:get_opts()},
+    OptsSST = 
+        #sst_options{press_method=native, log_options=leveled_log:get_opts()},
     {ok, OpenP, {FirstKey, LastKey}, Bloom} =
         sst_open(RP, Filename ++ ".sst", OptsSST, Level),
 
@@ -4514,10 +4544,13 @@ nonsense_coverage_test() ->
 
 hashmatching_bytreesize_test() ->
     B = <<"Bucket">>,
-    V = leveled_head:riak_metadata_to_binary(term_to_binary([{"actor1", 1}]),
-                                                <<1:32/integer,
-                                                    0:32/integer,
-                                                    0:32/integer>>),
+    V =
+        leveled_head:riak_metadata_to_binary(
+            term_to_binary([{"actor1", 1}]),
+            <<1:32/integer,
+            0:32/integer,
+            0:32/integer>>
+        ),
     GenKeyFun =
         fun(X) ->
             LK =
@@ -4534,7 +4567,7 @@ hashmatching_bytreesize_test() ->
     KVL = lists:map(GenKeyFun, lists:seq(1, 128)),
     {{PosBinIndex1, _FullBin, _HL, _LK}, no_timing} =
         generate_binary_slot(
-            lookup, {forward, KVL}, native, ?INDEX_MODDATE, no_timing),
+            lookup, {forward, KVL}, {0, native}, ?INDEX_MODDATE, no_timing),
     check_segment_match(PosBinIndex1, KVL, small),
     check_segment_match(PosBinIndex1, KVL, medium).
 
@@ -4576,12 +4609,12 @@ stop_whenstarter_stopped_testto() ->
     ?assertMatch(false, lists:foldl(TestFun, true, [10000, 2000, 2000, 2000])).
 
 corrupted_block_range_test() ->
-    corrupted_block_rangetester(native, 100),
-    corrupted_block_rangetester(lz4, 100),
-    corrupted_block_rangetester(zstd, 100),
-    corrupted_block_rangetester(none, 100).
+    corrupted_block_rangetester({0, native}, 100),
+    corrupted_block_rangetester({0, lz4}, 100),
+    corrupted_block_rangetester({0, zstd}, 100),
+    corrupted_block_rangetester({0, none}, 100).
 
-corrupted_block_rangetester(PressMethod, TestCount) ->
+corrupted_block_rangetester(BlockMethod, TestCount) ->
     N = 100,
     KVL1 = lists:ukeysort(1, generate_randomkeys(1, N, 1, 2)),
     RandomRangesFun =
@@ -4593,11 +4626,21 @@ corrupted_block_rangetester(PressMethod, TestCount) ->
             {SK, EK}
         end,
     RandomRanges = lists:map(RandomRangesFun, lists:seq(1, TestCount)),
-    B1 = serialise_block(lists:sublist(KVL1, 1, 20), PressMethod),
-    B2 = serialise_block(lists:sublist(KVL1, 21, 20), PressMethod),
-    MidBlock = serialise_block(lists:sublist(KVL1, 41, 20), PressMethod),
-    B4 = serialise_block(lists:sublist(KVL1, 61, 20), PressMethod),
-    B5 = serialise_block(lists:sublist(KVL1, 81, 20), PressMethod),
+    B1 =
+        leveled_sstblock:serialise_block(
+            no_lookup, BlockMethod, lists:sublist(KVL1, 1, 20)),
+    B2 =
+        leveled_sstblock:serialise_block(
+            no_lookup, BlockMethod, lists:sublist(KVL1, 21, 20)),
+    MidBlock =
+        leveled_sstblock:serialise_block(
+            no_lookup, BlockMethod, lists:sublist(KVL1, 41, 20)),
+    B4 =
+        leveled_sstblock:serialise_block(
+            np_lookup, BlockMethod, lists:sublist(KVL1, 61, 20)),
+    B5 =
+        leveled_sstblock:serialise_block(
+            no_lookup, BlockMethod, lists:sublist(KVL1, 81, 20)),
     CorruptBlockFun =
         fun(Block) ->
             case rand:uniform(10) < 2 of
@@ -4614,25 +4657,25 @@ corrupted_block_rangetester(PressMethod, TestCount) ->
                 lists:map(CorruptBlockFun, [B1, B2, MidBlock, B4, B5]),
             BR =
                 blocks_required(
-                    {SK, EK}, CB1, CB2, CBMid, CB4, CB5, PressMethod),
+                    {SK, EK}, CB1, CB2, CBMid, CB4, CB5, BlockMethod),
             ?assertMatch(true, length(BR) =< 100),
             lists:foreach(fun({_K, _V}) -> ok end, BR)
     end,
     lists:foreach(CheckFun, RandomRanges).
 
 corrupted_block_fetch_test() ->
-    corrupted_block_fetch_tester(native),
-    corrupted_block_fetch_tester(lz4),
-    corrupted_block_fetch_tester(zstd),
-    corrupted_block_fetch_tester(none).
+    corrupted_block_fetch_tester({0, native}),
+    corrupted_block_fetch_tester({0, lz4}),
+    corrupted_block_fetch_tester({0, zstd}),
+    corrupted_block_fetch_tester({0, none}).
 
-corrupted_block_fetch_tester(PressMethod) ->
+corrupted_block_fetch_tester(BlockMethod) ->
     KC = 120,
     KVL1 = lists:ukeysort(1, generate_randomkeys(1, KC, 1, 2)),
 
     {{Header, SlotBin, _HashL, _LastKey}, _BT} =
         generate_binary_slot(
-            lookup, {forward, KVL1}, PressMethod, false, no_timing),
+            lookup, {forward, KVL1}, BlockMethod, false, no_timing),
     <<B1L:32/integer,
         B2L:32/integer,
         B3L:32/integer,
@@ -4665,7 +4708,7 @@ corrupted_block_fetch_tester(PressMethod) ->
                     BlockLengths,
                     byte_size(PosBinIndex),
                     LK,
-                    PressMethod,
+                    BlockMethod,
                     false
                 ),
             case R of
@@ -5458,16 +5501,16 @@ blocks_required_test() ->
         lists:map(fun(I) -> {IdxKey(I), IdxValue(I)} end, lists:seq(65, 70))
         ++
         lists:map(fun(I) -> {StdKey(I), MetaValue(I)} end, lists:seq(1, 8)),
-    B1 = serialise_block(Block1L, native),
-    B2 = serialise_block(Block2L, native),
-    B3 = serialise_block(MidBlockL, native),
-    B4 = serialise_block(Block4L, native),
-    B5 = serialise_block(Block5L, native),
-    Empty = serialise_block([], native),
+    B1 = leveled_sstblock:serialise_block(no_lookup, {0, native}, Block1L),
+    B2 = leveled_sstblock:serialise_block(no_lookup, {0, native}, Block2L),
+    B3 = leveled_sstblock:serialise_block(no_lookup, {0, native}, MidBlockL),
+    B4 = leveled_sstblock:serialise_block(no_lookup, {0, native}, Block4L),
+    B5 = leveled_sstblock:serialise_block(no_lookup, {0, native}, Block5L),
+    Empty = leveled_sstblock:serialise_block(no_lookup, {0, native}, []),
 
     TestFun =
         fun(SK, EK, Exp) ->
-            KVL = blocks_required({SK, EK}, B1, B2, B3, B4, B5, native),
+            KVL = blocks_required({SK, EK}, B1, B2, B3, B4, B5, {0, native}),
             io:format(
                 "Length KVL ~w First ~p Last ~p~n",
                 [length(KVL), hd(KVL), lists:last(KVL)]),
@@ -5493,31 +5536,31 @@ blocks_required_test() ->
         blocks_required(
             {{?IDX_TAG, B, {Idx, KeyFun(3)}, null},
                 {?IDX_TAG, B, {Idx, KeyFun(99)}, null}},
-            B1, B2, Empty, B4, B5, native),
+            B1, B2, Empty, B4, B5, {0, native}),
     ?assertMatch(52, length(KVL1)),
     KVL2 =
         blocks_required(
             {{?IDX_TAG, B, {Idx, KeyFun(3)}, null},
                 {?IDX_TAG, B, {Idx, KeyFun(99)}, null}},
-            B1, B2, Empty, Empty, Empty, native),
+            B1, B2, Empty, Empty, Empty, {0, native}),
     ?assertMatch(30, length(KVL2)),
     KVL3 =
         blocks_required(
             {{?IDX_TAG, B, {Idx, KeyFun(3)}, null},
                 {?IDX_TAG, B, {Idx, KeyFun(99)}, null}},
-            B1, Empty, Empty, Empty, Empty, native),
+            B1, Empty, Empty, Empty, Empty, {0, native}),
     ?assertMatch(14, length(KVL3)),
     KVL4 =
         blocks_required(
             {{?IDX_TAG, B, {Idx, KeyFun(3)}, null},
                 {?IDX_TAG, B, {Idx, KeyFun(99)}, null}},
-            B1, Empty, B3, B4, B5, native),
+            B1, Empty, B3, B4, B5, {0, native}),
     ?assertMatch(52, length(KVL4)),
     KVL5 =
         blocks_required(
             {{?IDX_TAG, B, {Idx, KeyFun(3)}, null},
                 {?IDX_TAG, B, {Idx, KeyFun(99)}, null}},
-            B1, B2, B3, Empty, B5, native),
+            B1, B2, B3, Empty, B5, {0, native}),
     ?assertMatch(52, length(KVL5))
     .
     

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -134,7 +134,7 @@
 
 -export([in_range/3]).
 
--export([hmac/1, append/4]).
+-export([hmac/1, append/2, append/3, append/4, filterby_midblock/2]).
 
 -record(slot_index_value,
         {slot_id :: integer(),
@@ -2707,7 +2707,7 @@ blocks_required(
                     StartKey,
                     all
                 ),
-                MidBlockFetchFun(),
+                MidBlockFetchFun(all),
                 in_range(
                     get_righthand_blocks(
                         B4, B5, BlockMethod, StartKey, EndKey),
@@ -2720,23 +2720,24 @@ blocks_required(
                 get_lefthand_blocks(
                     B1, B2, BlockMethod, StartKey, EndKey),
                 StartKey,
-                EndKey);
+                EndKey
+            );
         le_mid ->
             in_range(
                 append(
                     get_lefthand_blocks(
                         B1, B2, BlockMethod, StartKey, EndKey),
-                    MidBlockFetchFun()
+                    MidBlockFetchFun(all)
                 ),
                 StartKey,
                 EndKey
             );
         mid_only ->
-            in_range(MidBlockFetchFun(), StartKey, EndKey);
+            in_range(MidBlockFetchFun(all), StartKey, EndKey);
         ge_mid ->
             in_range(
                 append(
-                    MidBlockFetchFun(),
+                    MidBlockFetchFun(all),
                     get_righthand_blocks(
                         B4, B5, BlockMethod, all, EndKey)
                 ),
@@ -2757,17 +2758,19 @@ get_lefthand_blocks(B1, B2, BlockMethod, StartKey, EndKey) ->
         leveled_sstblock:get_topandtail(B2, BlockMethod),
     case previous_block_required({Top, Tail}, StartKey) of
         true ->
-            append(
-                leveled_sstblock:get_all(B1, BlockMethod),
-                case this_leftblock_required({Top, Tail}, EndKey) of
-                    true ->
-                        InnerLeftBlockFetchFun();
-                    _ ->
-                        []
-                end
-            );
+            case this_leftblock_required({Top, Tail}, EndKey) of
+                true ->
+                    append(
+                        leveled_sstblock:get_all(B1, BlockMethod),
+                        InnerLeftBlockFetchFun(all)
+                    );
+                _ ->
+                    {_, _, OuterLeftBlockFetchFun} =
+                        leveled_sstblock:get_topandtail(B1, BlockMethod),
+                    OuterLeftBlockFetchFun({StartKey, EndKey})
+            end;
         false ->
-            InnerLeftBlockFetchFun()
+            InnerLeftBlockFetchFun({StartKey, EndKey})
     end.
 
 get_righthand_blocks(B4, B5, BlockMethod, StartKey, EndKey) ->
@@ -2775,17 +2778,19 @@ get_righthand_blocks(B4, B5, BlockMethod, StartKey, EndKey) ->
         leveled_sstblock:get_topandtail(B4, BlockMethod),
     case next_block_required({Top, Tail}, EndKey) of
         true ->
-            append(
-                case this_rightblock_required({Top, Tail}, StartKey) of
-                    true ->
-                        InnerRightBlockFetchFun();
-                    _ ->
-                        []
-                end,
-                leveled_sstblock:get_all(B5, BlockMethod)
-            );
+            case this_rightblock_required({Top, Tail}, StartKey) of
+                true ->
+                    append(
+                        InnerRightBlockFetchFun(all),
+                        leveled_sstblock:get_all(B5, BlockMethod)
+                    );
+                _ ->
+                    {_, _, OuterRightBlockFetchFun} =
+                        leveled_sstblock:get_topandtail(B5, BlockMethod),
+                    OuterRightBlockFetchFun({StartKey, EndKey})
+            end;
         false ->
-            InnerRightBlockFetchFun()
+            InnerRightBlockFetchFun({StartKey, EndKey})
     end.
 
 filterby_midblock({not_present, not_present}, _RangeKeys) ->

--- a/src/leveled_sst.erl
+++ b/src/leveled_sst.erl
@@ -2764,7 +2764,7 @@ get_lefthand_blocks(B1, B2, BlockMethod, StartKey, EndKey) ->
                         leveled_sstblock:get_all(B1, BlockMethod),
                         InnerLeftBlockFetchFun(all)
                     );
-                _ ->
+                false ->
                     {_, _, OuterLeftBlockFetchFun} =
                         leveled_sstblock:get_topandtail(B1, BlockMethod),
                     OuterLeftBlockFetchFun({StartKey, EndKey})
@@ -2784,7 +2784,7 @@ get_righthand_blocks(B4, B5, BlockMethod, StartKey, EndKey) ->
                         InnerRightBlockFetchFun(all),
                         leveled_sstblock:get_all(B5, BlockMethod)
                     );
-                _ ->
+                false ->
                     {_, _, OuterRightBlockFetchFun} =
                         leveled_sstblock:get_topandtail(B5, BlockMethod),
                     OuterRightBlockFetchFun({StartKey, EndKey})

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -25,6 +25,12 @@
 -define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_FACTOR}]).
 
 -type block_type() :: ?BLOCK_TYPE0|?BLOCK_TYPE1|?BLOCK_TYPE2|?BLOCK_TYPE3.
+-type top_and_tail() ::
+    {
+        leveled_codec:ledger_key()|not_present,
+        leveled_codec:ledger_key()|not_present,
+        fun(() -> list(leveled_codec:ledger_kv()))
+    }.
 
 -export(
     [
@@ -173,12 +179,7 @@ get_all(Block, {0, PressMethod}) ->
     check_block(Block, [], ExtractFun).
 
 -spec get_topandtail(
-    binary(), leveled_sst:block_method()) ->
-        {
-            leveled_codec:ledger_key()|not_present,
-            leveled_codec:ledger_key()|not_present,
-            fun(() -> list(leveled_codec:ledger_kv()))
-        }.
+    binary(), leveled_sst:block_method()) -> top_and_tail().
 get_topandtail(Block, {0, PressMethod}) ->
     ExtractFun =
         fun(CheckedBlock) ->
@@ -267,9 +268,19 @@ decompress_block(BlockBin, lz4) ->
     {ok, Bin} = lz4:unpack(BlockBin),
     Bin;
 decompress_block(BlockBin, zstd) ->
-    zstd:decompress(BlockBin).
+    case zstd:decompress(BlockBin) of
+        DeflateBin when is_binary(DeflateBin) ->
+            DeflateBin
+    end.
 
--spec check_block(binary(), term(), fun((binary()) -> term())) -> term().
+-spec
+    check_block
+        (binary(), list(), fun((binary()) -> list(leveled_codec:ledger_kv())))
+            -> list(leveled_codec:ledger_kv());
+        (binary(), not_present, fun((binary()) -> leveled_codec:ledger_kv()))
+            -> leveled_codec:ledger_kv()|not_present;
+        (binary(), top_and_tail(), fun((binary()) -> top_and_tail()))
+            -> top_and_tail().
 check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
     BinS = byte_size(Block) - 4,
     <<TermBin:BinS/binary, CRC32:32/integer>> = Block,
@@ -283,16 +294,8 @@ check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
 check_block(_Block, Default, _ExtractFun) ->
     Default.
 
--type topandtail_response()
-    ::
-        {
-            leveled_codec:ledger_key(),
-            leveled_codec:ledger_key(),
-            fun(() -> list(leveled_codec:ledger_kv()))
-        }.
-
 -spec get_topandtail_block(
-    binary(), leveled_sst:press_method()) -> topandtail_response().
+    binary(), leveled_sst:press_method()) -> top_and_tail().
 get_topandtail_block(CheckedBlock, PressMethod) ->
     CheckedSize = byte_size(CheckedBlock),
     <<TypedBlock:(CheckedSize - 1)/binary, Type:8/integer>> = CheckedBlock,
@@ -301,7 +304,7 @@ get_topandtail_block(CheckedBlock, PressMethod) ->
 
 -spec get_topandtail_block(
     block_type(), binary(), leveled_sst:press_method()) ->
-        topandtail_response().
+        top_and_tail().
 get_topandtail_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
     <<TTSz:16/integer, TopTail:TTSz/binary, _/binary>> = TypedBlock,
     {Top, Tail} = binary_to_term(TopTail),
@@ -334,7 +337,9 @@ get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
     <<TTSz:16/integer, _TopTail:TTSz/binary, AllBin/binary>> = TypedBlock,
     get_nth_item(?BLOCK_TYPE0, N, AllBin, PM);
 get_nth_item(Type, N, TypedBlock, PressMethod)
-        when Type == ?BLOCK_TYPE1; Type == ?BLOCK_TYPE2 ->
+        when 
+            (Type == ?BLOCK_TYPE1 orelse Type == ?BLOCK_TYPE2 ) andalso
+            (PressMethod == lz4 orelse PressMethod == zstd) ->
     Width = case Type of ?BLOCK_TYPE1 -> 6; ?BLOCK_TYPE2 -> 8 end,
     <<
         ASz:16/integer,
@@ -457,7 +462,7 @@ v1_block_test() ->
     v1_block_tester(no_lookup, {1, zstd}, 24).
 
 v1_bigblock_test() ->
-    BigBlob = crypto:strong_rand_bytes(8192),
+    BigBlob = crypto:strong_rand_bytes(16384),
     {MegaSec, Sec, MicroSec} = os:timestamp(),
     MetaBin =
         <<
@@ -475,11 +480,32 @@ v1_bigblock_test() ->
             MetaBin/binary
         >>,
     v1_block_tester(lookup, {1, zstd}, 24, SibMetaBin),
+    v1_block_tester(lookup, {1, zstd}, 32, SibMetaBin),
     v1_block_tester(lookup, {1, zstd}, 25, SibMetaBin),
     v1_block_tester(lookup, {1, native}, 32, SibMetaBin),
     v1_block_tester(lookup, {1, native}, 31, SibMetaBin),
     v1_block_tester(no_lookup, {1, zstd}, 24, SibMetaBin).
 
+v1_nolookup_bigtail_test() ->
+    BigBlob = crypto:strong_rand_bytes(1024),
+    BigBucket = base64:encode(crypto:strong_rand_bytes(65536)),
+    {MegaSec, Sec, MicroSec} = os:timestamp(),
+    MetaBin =
+        <<
+            MegaSec:32/integer,
+            Sec:32/integer,
+            MicroSec:32/integer,
+            BigBlob/binary
+        >>,
+    MetaLen = byte_size(MetaBin),
+    SibMetaBin =
+        <<
+            1:32/integer,
+            0:32/integer,
+            MetaLen:32/integer,
+            MetaBin/binary
+        >>,
+    v1_block_tester(no_lookup, {1, zstd}, 24, SibMetaBin, BigBucket).
 
 v1_block_tester(Lookup, BlockMethod, BlockSize) ->
     v1_block_tester(
@@ -490,7 +516,9 @@ v1_block_tester(Lookup, BlockMethod, BlockSize) ->
     ).
 
 v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin) ->
-    B = <<"Bucket">>,
+    v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin, <<"Bucket">>).
+
+v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin, B) ->
     V =
         leveled_head:riak_metadata_to_binary(
             term_to_binary([{"actor1", 1}]),

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -542,11 +542,24 @@ get_all_block(Type, TypedBlock, PM)
         MBn:MSz/binary,
         RBn:RSz/binary
     >> = decompress_block(CompressedBin, PM),
-    leveled_sst:append(
-        binary_to_term(LBn),
-        binary_to_term(MBn),
-        binary_to_term(RBn)
-    );
+    [
+        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+    ] = binary_to_term(LBn),
+    [
+        M1, M2, M3, M4, M5, M6, M7, M8
+    ] = binary_to_term(MBn),
+    [
+        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+    ] = binary_to_term(RBn),
+    [
+        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+        M1, M2, M3, M4, M5, M6, M7, M8,
+        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+    ];
 get_all_block(_Type, TypedBlock, PM)
         when PM == lz4; PM == zstd ->
     <<

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -13,10 +13,19 @@
 -module(leveled_sstblock).
 
 -define(MAX_SUBBLOCK_SIZE, 1 bsl 16).
--define(BLOCK_TYPE0, 0). % Block is just a list of terms 
--define(BLOCK_TYPE1, 1). % Lookup block divided into 4 blocks of 6
--define(BLOCK_TYPE2, 2). % Lookup block divided into 4 blocks of 8
--define(BLOCK_TYPE3, 3). % Nolookup block with first/last terms at head
+-define(BLOCK_TYPE0, 0).
+    % Block is just a list of terms 
+-define(BLOCK_TYPE1, 1).
+    % Lookup block divided into 4 blocks of 6
+    % 24 KV blocks only
+-define(BLOCK_TYPE2, 2).
+    % Lookup block divided into 4 blocks of 8
+    % 32 KV blocks only
+-define(BLOCK_TYPE3, 3).
+    % Nolookup block with first/last terms at head
+-define(BLOCK_TYPE4, 4).
+    % Nolookup block with first/last terms at head, and block split into L/M/R
+    % 56 KV blocks only
 -define(COMPRESSION_FACTOR, 1).
     % When using native compression - how hard should the compression code
     % try to reduce the size of the compressed output. 1 Is to imply minimal
@@ -24,12 +33,15 @@
     % https://www.erlang.org/doc/man/erlang.html#term_to_binary-2
 -define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_FACTOR}]).
 
--type block_type() :: ?BLOCK_TYPE0|?BLOCK_TYPE1|?BLOCK_TYPE2|?BLOCK_TYPE3.
+-type block_type() ::
+    ?BLOCK_TYPE0|?BLOCK_TYPE1|?BLOCK_TYPE2|?BLOCK_TYPE3|?BLOCK_TYPE4.
+-type range_filter() ::
+    all|{leveled_codec:ledger_key(), leveled_codec:ledger_key()}.
 -type top_and_tail() ::
     {
         leveled_codec:ledger_key()|not_present,
         leveled_codec:ledger_key()|not_present,
-        fun(() -> list(leveled_codec:ledger_kv()))
+        fun((range_filter()) -> list(leveled_codec:ledger_kv()))
     }.
 
 -export(
@@ -132,6 +144,67 @@ serialise_block(
         _ ->
             serialise_block_aslist(PressMethod, TL)
     end;
+serialise_block(
+    no_lookup,
+    {1, PressMethod},
+    [
+        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+        M1, M2, M3, M4, M5, M6, M7, M8,
+        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+    ] = TermList
+)
+        when
+            PressMethod == zstd; PressMethod == lz4 ->
+    LBn =
+        term_to_binary(
+            [
+                L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+                L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+            ]
+        ),
+    MBn = term_to_binary([M1, M2, M3, M4, M5, M6, M7, M8]),
+    RBn =
+        term_to_binary(
+            [
+                R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+                R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+            ]
+        ),
+    TTBn = term_to_binary({element(1, L1), element(1, R24)}),
+    case {byte_size(LBn), byte_size(MBn), byte_size(RBn), byte_size(TTBn)} of
+        {LSz, MSz, RSz, TTSz}
+            when
+                LSz < ?MAX_SUBBLOCK_SIZE,
+                MSz < ?MAX_SUBBLOCK_SIZE,
+                RSz < ?MAX_SUBBLOCK_SIZE,
+                TTSz < ?MAX_SUBBLOCK_SIZE
+            ->
+                CompressedBin =
+                    compress_block(
+                        <<
+                            LSz:16/integer,
+                            MSz:16/integer,
+                            RSz:16/integer,
+                            LBn/binary,
+                            MBn/binary,
+                            RBn/binary
+                        >>,
+                        PressMethod
+                    ),
+
+                crc_validate_bin(
+                    <<
+                        TTSz:16/integer,
+                        TTBn/binary,
+                        CompressedBin/binary,
+                        (?BLOCK_TYPE4):8/integer
+                    >>
+                );
+        _ ->
+            serialise_block_aslist(PressMethod, TermList)
+    end;
 serialise_block(no_lookup, {1, PressMethod}, TermList)
         when
             length(TermList) > 2, 
@@ -187,12 +260,12 @@ get_topandtail(Block, {0, PressMethod}) ->
             {
                 element(1, hd(TL)),
                 element(1, lists:last(TL)),
-                fun() -> TL end
+                fun(_) -> TL end
             }
         end,
     check_block(
         Block,
-        {not_present, not_present, fun() -> [] end},
+        {not_present, not_present, fun(_) -> [] end},
         ExtractFun
     );
 get_topandtail(Block, {1, PressMethod}) ->
@@ -202,7 +275,7 @@ get_topandtail(Block, {1, PressMethod}) ->
         end,
     check_block(
         Block,
-        {not_present, not_present, fun() -> [] end},
+        {not_present, not_present, fun(_) -> [] end},
         ExtractFun
     ).
 
@@ -226,7 +299,7 @@ get_nth(N, Block, {0, PressMethod}) ->
     check_block(Block, not_present, ExtractFun).
 
 %%%============================================================================
-%%% Internal functions - v1
+%%% General internal functions - v1
 %%%============================================================================
 
 -spec crc_validate_bin(binary()) -> binary().
@@ -294,13 +367,16 @@ check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
 check_block(_Block, Default, _ExtractFun) ->
     Default.
 
+%%%============================================================================
+%%% Block-type specific cases - v1
+%%%============================================================================
+
 -spec get_topandtail_block(
     binary(), leveled_sst:press_method()) -> top_and_tail().
 get_topandtail_block(CheckedBlock, PressMethod) ->
     CheckedSize = byte_size(CheckedBlock),
     <<TypedBlock:(CheckedSize - 1)/binary, Type:8/integer>> = CheckedBlock,
     get_topandtail_block(Type, TypedBlock, PressMethod).
-
 
 -spec get_topandtail_block(
     block_type(), binary(), leveled_sst:press_method()) ->
@@ -311,11 +387,71 @@ get_topandtail_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
     {
         Top,
         Tail,
-        fun() -> get_all_block(?BLOCK_TYPE3, TypedBlock, PM) end
+        fun(_) -> get_all_block(?BLOCK_TYPE3, TypedBlock, PM) end
     };
+get_topandtail_block(Type, TypedBlock, PM)
+        when
+            Type == ?BLOCK_TYPE4 andalso
+            (PM == lz4 orelse PM == zstd) ->
+    <<
+        TTSz:16/integer,
+        TopTail:TTSz/binary,
+        CompressedBin/binary
+    >> = TypedBlock,
+    {Top, Tail} = binary_to_term(TopTail),
+    FetchFun =
+        fun(Range) ->
+            <<
+                LSz:16/integer,
+                MSz:16/integer,
+                RSz:16/integer,
+                LBn:LSz/binary,
+                MBn:MSz/binary,
+                RBn:RSz/binary
+            >> = decompress_block(CompressedBin, PM),
+            MidBlock = binary_to_term(MBn),
+            BlockNeeds =
+                case Range of
+                    all ->
+                        all_blocks;
+                    {SK, EK} ->
+                        leveled_sst:filterby_midblock(
+                            {
+                                element(1, hd(MidBlock)),
+                                element(1, lists:last(MidBlock))
+                            },
+                            {SK, EK}
+                        )
+                end,
+            case BlockNeeds of
+                lt_mid ->
+                    binary_to_term(LBn);
+                le_mid ->
+                    leveled_sst:append(
+                        binary_to_term(LBn),
+                        MidBlock
+                    );
+                mid_only ->
+                    MidBlock;
+                ge_mid ->
+                    leveled_sst:append(
+                        MidBlock,
+                        binary_to_term(RBn)
+                    );
+                gt_mid ->
+                    binary_to_term(RBn);
+                _ ->
+                    leveled_sst:append(
+                        binary_to_term(LBn),
+                        MidBlock,
+                        binary_to_term(RBn)
+                    )
+            end
+        end,
+    {Top, Tail, FetchFun};
 get_topandtail_block(Type, TypedBlock, PM) ->
     TL = get_all_block(Type, TypedBlock, PM),
-    {element(1, hd(TL)), element(1, lists:last(TL)), fun() -> TL end}.
+    {element(1, hd(TL)), element(1, lists:last(TL)), fun(_) -> TL end}.
 
 -spec get_nth_item(
     pos_integer(), binary(), leveled_sst:press_method()) ->
@@ -336,6 +472,10 @@ get_nth_item(Type, N, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
 get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
     <<TTSz:16/integer, _TopTail:TTSz/binary, AllBin/binary>> = TypedBlock,
     get_nth_item(?BLOCK_TYPE0, N, AllBin, PM);
+get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE4 ->
+    % No need to optimise - we don't expect to be asked for get_nth_item
+    % ona  no_lookup block
+    lists:nth(N, get_all_block(Type, TypedBlock, PM));
 get_nth_item(Type, N, TypedBlock, PressMethod)
         when 
             (Type == ?BLOCK_TYPE1 orelse Type == ?BLOCK_TYPE2 ) andalso
@@ -385,6 +525,28 @@ get_all_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
         AllBin/binary
     >> = TypedBlock,
     get_all_block(?BLOCK_TYPE0, AllBin, PM);
+get_all_block(Type, TypedBlock, PM)
+        when
+            Type == ?BLOCK_TYPE4 andalso
+            (PM == lz4 orelse PM == zstd) ->
+    <<
+        TTSz:16/integer,
+        _TopTail:TTSz/binary,
+        CompressedBin/binary
+    >> = TypedBlock,
+    <<
+        LSz:16/integer,
+        MSz:16/integer,
+        RSz:16/integer,
+        LBn:LSz/binary,
+        MBn:MSz/binary,
+        RBn:RSz/binary
+    >> = decompress_block(CompressedBin, PM),
+    leveled_sst:append(
+        binary_to_term(LBn),
+        binary_to_term(MBn),
+        binary_to_term(RBn)
+    );
 get_all_block(_Type, TypedBlock, PM)
         when PM == lz4; PM == zstd ->
     <<
@@ -505,7 +667,8 @@ v1_nolookup_bigtail_test() ->
             MetaLen:32/integer,
             MetaBin/binary
         >>,
-    v1_block_tester(no_lookup, {1, zstd}, 24, SibMetaBin, BigBucket).
+    v1_block_tester(no_lookup, {1, zstd}, 24, SibMetaBin, BigBucket),
+    v1_block_tester(no_lookup, {1, zstd}, 56, SibMetaBin, BigBucket).
 
 v1_block_tester(Lookup, BlockMethod, BlockSize) ->
     v1_block_tester(
@@ -550,7 +713,7 @@ v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin, B) ->
     {Top, Tail, AllFun} = get_topandtail(Block, BlockMethod),
     ?assertMatch(Top, element(1, hd(KVL))),
     ?assertMatch(Tail, element(1, lists:last(KVL))),
-    ?assertMatch(KVL, AllFun()),
+    ?assertMatch(KVL, AllFun(all)),
     ?assertMatch(KVL, get_all(Block, BlockMethod)).
 
 

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -429,43 +429,59 @@ get_topandtail_block(Type, TypedBlock, PM)
                     binary_to_term(LBn);
                 le_mid ->
                     [
-                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
-                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+                        L1, L2, L3, L4, L5, L6,
+                        L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18,
+                        L19, L20, L21, L22, L23, L24
                     ] = binary_to_term(LBn),
                     [
-                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
-                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+                        L1, L2, L3, L4, L5, L6,
+                        L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18,
+                        L19, L20, L21, L22, L23, L24,
                         M1, M2, M3, M4,M5, M6, M7, M8 
                     ];
                 mid_only ->
                     [M1, M2, M3, M4,M5, M6, M7, M8];
                 ge_mid ->
                     [
-                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
-                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                        R1, R2, R3, R4, R5, R6,
+                        R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18,
+                        R19, R20, R21, R22, R23, R24
                     ] = binary_to_term(RBn),
                     [
                         M1, M2, M3, M4,M5, M6, M7, M8,
-                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
-                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                        R1, R2, R3, R4, R5, R6,
+                        R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18,
+                        R19, R20, R21, R22, R23, R24
                     ];
                 gt_mid ->
                     binary_to_term(RBn);
                 _ ->
                     [
-                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
-                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+                        L1, L2, L3, L4, L5, L6,
+                        L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18,
+                        L19, L20, L21, L22, L23, L24
                     ] = binary_to_term(LBn),
                     [
-                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
-                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                        R1, R2, R3, R4, R5, R6,
+                        R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18,
+                        R19, R20, R21, R22, R23, R24
                     ] = binary_to_term(RBn),
                     [
-                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
-                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+                        L1, L2, L3, L4, L5, L6,
+                        L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18,
+                        L19, L20, L21, L22, L23, L24,
                         M1, M2, M3, M4,M5, M6, M7, M8,
-                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
-                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                        R1, R2, R3, R4, R5, R6,
+                        R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18,
+                        R19, R20, R21, R22, R23, R24
                     ]
             end
         end,

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -1,7 +1,16 @@
 %% -------- SST Block Functions ---------
 %%
-%% Functions to serialise and deserialise blocks in leveled_sst 
+%% Functions to serialise and then fetch from those serialised blocks, i.e.
+%% - serialise_block/3
+%% - get_all/2 deserialise returning all
+%% - get_topandtail/2 return only the first and last elements, as well as a 
+%% function to return the remainder, so that deserialisation of the remainder
+%% may be avoided on inspection of top and tail
+%% - get_nth/3 deserialise enough of the block to return just the nth item
 %%
+%% The fetch functions may be optimised for the block type to minimise the
+%% work required to fetch the required amount of deserialised data.
+%% 
 %% Standard block sizes are
 %% -define(LOOK_BLOCKSIZE, {24, 32}).
 %% -define(NOLOOK_BLOCKSIZE, {56, 32}).
@@ -60,7 +69,7 @@
 
 -spec serialise_block(
     lookup|no_lookup,
-    {0|1, leveled_sst:press_method()},
+    {leveled_sst:block_version(), leveled_sst:press_method()},
     list(leveled_codec:ledger_kv())) ->
         binary().
 serialise_block(
@@ -410,7 +419,7 @@ get_topandtail_block(Type, TypedBlock, PM)
                 MBn:MSz/binary,
                 RBn:RSz/binary
             >> = decompress_block(CompressedBin, PM),
-            [M1, M2, M3, M4,M5, M6, M7, M8] = binary_to_term(MBn),
+            [M1, M2, M3, M4, M5, M6, M7, M8] = binary_to_term(MBn),
             BlockNeeds =
                 case Range of
                     all ->
@@ -439,10 +448,10 @@ get_topandtail_block(Type, TypedBlock, PM)
                         L7, L8, L9, L10, L11, L12,
                         L13, L14, L15, L16, L17, L18,
                         L19, L20, L21, L22, L23, L24,
-                        M1, M2, M3, M4,M5, M6, M7, M8 
+                        M1, M2, M3, M4, M5, M6, M7, M8 
                     ];
                 mid_only ->
-                    [M1, M2, M3, M4,M5, M6, M7, M8];
+                    [M1, M2, M3, M4, M5, M6, M7, M8];
                 ge_mid ->
                     [
                         R1, R2, R3, R4, R5, R6,
@@ -451,7 +460,7 @@ get_topandtail_block(Type, TypedBlock, PM)
                         R19, R20, R21, R22, R23, R24
                     ] = binary_to_term(RBn),
                     [
-                        M1, M2, M3, M4,M5, M6, M7, M8,
+                        M1, M2, M3, M4, M5, M6, M7, M8,
                         R1, R2, R3, R4, R5, R6,
                         R7, R8, R9, R10, R11, R12,
                         R13, R14, R15, R16, R17, R18,
@@ -477,7 +486,7 @@ get_topandtail_block(Type, TypedBlock, PM)
                         L7, L8, L9, L10, L11, L12,
                         L13, L14, L15, L16, L17, L18,
                         L19, L20, L21, L22, L23, L24,
-                        M1, M2, M3, M4,M5, M6, M7, M8,
+                        M1, M2, M3, M4, M5, M6, M7, M8,
                         R1, R2, R3, R4, R5, R6,
                         R7, R8, R9, R10, R11, R12,
                         R13, R14, R15, R16, R17, R18,
@@ -503,7 +512,7 @@ get_nth_item(N, CheckedBlock, PressMethod) ->
         leveled_codec:ledger_kv().
 get_nth_item(Type, N, TypedBlock, PM)
         when Type == ?BLOCK_TYPE0, (PM == zstd orelse PM == lz4) ->
-    lists:nth(N, binary_to_term(decompress_block(TypedBlock, PM)));
+    lists:nth(N, deserialise_checkedblock(TypedBlock, PM));
 get_nth_item(Type, N, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
     lists:nth(N, binary_to_term(TypedBlock));
 get_nth_item(Type, N, TypedBlock, PressMethod)
@@ -545,7 +554,7 @@ get_all_block(CheckedBlock, PressMethod) ->
             list(leveled_codec:ledger_kv()).
 get_all_block(Type, TypedBlock, PM)
         when Type == ?BLOCK_TYPE0, (PM == zstd orelse PM == lz4) ->
-    binary_to_term(decompress_block(TypedBlock, PM));
+    deserialise_checkedblock(TypedBlock, PM);
 get_all_block(Type, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
     binary_to_term(TypedBlock);
 get_all_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -409,7 +409,7 @@ get_topandtail_block(Type, TypedBlock, PM)
                 MBn:MSz/binary,
                 RBn:RSz/binary
             >> = decompress_block(CompressedBin, PM),
-            MidBlock = binary_to_term(MBn),
+            [M1, M2, M3, M4,M5, M6, M7, M8] = binary_to_term(MBn),
             BlockNeeds =
                 case Range of
                     all ->
@@ -417,8 +417,8 @@ get_topandtail_block(Type, TypedBlock, PM)
                     {SK, EK} ->
                         leveled_sst:filterby_midblock(
                             {
-                                element(1, hd(MidBlock)),
-                                element(1, lists:last(MidBlock))
+                                element(1, M1),
+                                element(1, M8)
                             },
                             {SK, EK}
                         )
@@ -427,25 +427,45 @@ get_topandtail_block(Type, TypedBlock, PM)
                 lt_mid ->
                     binary_to_term(LBn);
                 le_mid ->
-                    leveled_sst:append(
-                        binary_to_term(LBn),
-                        MidBlock
-                    );
+                    [
+                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+                    ] = binary_to_term(LBn),
+                    [
+                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+                        M1, M2, M3, M4,M5, M6, M7, M8 
+                    ];
                 mid_only ->
-                    MidBlock;
+                    [M1, M2, M3, M4,M5, M6, M7, M8];
                 ge_mid ->
-                    leveled_sst:append(
-                        MidBlock,
-                        binary_to_term(RBn)
-                    );
+                    [
+                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                    ] = binary_to_term(RBn),
+                    [
+                        M1, M2, M3, M4,M5, M6, M7, M8,
+                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                    ];
                 gt_mid ->
                     binary_to_term(RBn);
                 _ ->
-                    leveled_sst:append(
-                        binary_to_term(LBn),
-                        MidBlock,
-                        binary_to_term(RBn)
-                    )
+                    [
+                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24
+                    ] = binary_to_term(LBn),
+                    [
+                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                    ] = binary_to_term(RBn),
+                    [
+                        L1, L2, L3, L4, L5, L6, L7, L8, L9, L10, L11, L12,
+                        L13, L14, L15, L16, L17, L18, L19, L20, L21, L22, L23, L24,
+                        M1, M2, M3, M4,M5, M6, M7, M8,
+                        R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
+                        R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
+                    ]
             end
         end,
     {Top, Tail, FetchFun};
@@ -561,7 +581,8 @@ get_all_block(Type, TypedBlock, PM)
         R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
     ];
 get_all_block(_Type, TypedBlock, PM)
-        when PM == lz4; PM == zstd ->
+        when
+            (PM == lz4 orelse PM == zstd) ->
     <<
         ASz:16/integer,
         BSz:16/integer,

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -1,0 +1,530 @@
+%% -------- SST Block Functions ---------
+%%
+%% Functions to serialise and deserialise blocks in leveled_sst 
+%%
+%% Standard block sizes are
+%% -define(LOOK_BLOCKSIZE, {24, 32}).
+%% -define(NOLOOK_BLOCKSIZE, {56, 32}).
+%% 
+%% Requirement to serialise LOOK_BLOCKS to optimise for picking the nth value
+%% Requirement to serialise NOLOOK_BLOCKS to optimise for picking the first and
+%% last values
+
+-module(leveled_sstblock).
+
+-define(MAX_SUBBLOCK_SIZE, 1 bsl 16).
+-define(BLOCK_TYPE0, 0). % Block is just a list of terms 
+-define(BLOCK_TYPE1, 1). % Lookup block divided into 4 blocks of 6
+-define(BLOCK_TYPE2, 2). % Lookup block divided into 4 blocks of 8
+-define(BLOCK_TYPE3, 3). % Nolookup block with first/last terms at head
+-define(COMPRESSION_FACTOR, 1).
+    % When using native compression - how hard should the compression code
+    % try to reduce the size of the compressed output. 1 Is to imply minimal
+    % effort, 6 is default in OTP:
+    % https://www.erlang.org/doc/man/erlang.html#term_to_binary-2
+-define(BINARY_SETTINGS, [{compressed, ?COMPRESSION_FACTOR}]).
+
+-type block_type() :: ?BLOCK_TYPE0|?BLOCK_TYPE1|?BLOCK_TYPE2|?BLOCK_TYPE3.
+
+-export(
+    [
+        serialise_block/3,
+        get_all/2,
+        get_topandtail/2,
+        get_nth/3
+    ]
+).
+
+%%%============================================================================
+%%% API
+%%%============================================================================
+
+
+-spec serialise_block(
+    lookup|no_lookup,
+    {0|1, leveled_sst:press_method()},
+    list(leveled_codec:ledger_kv())) ->
+        binary().
+serialise_block(
+    lookup,
+    {1, PressMethod},
+    [   A1, A2, A3, A4, A5, A6,
+        B1, B2, B3, B4, B5, B6,
+        C1, C2, C3, C4, C5, C6,
+        D1, D2, D3, D4, D5, D6
+    ] = TL
+) when PressMethod == lz4; PressMethod == zstd ->
+    ABn = term_to_binary([A1, A2, A3, A4, A5, A6]),
+    BBn = term_to_binary([B1, B2, B3, B4, B5, B6]),
+    CBn = term_to_binary([C1, C2, C3, C4, C5, C6]),
+    DBn = term_to_binary([D1, D2, D3, D4, D5, D6]),
+    case {byte_size(ABn), byte_size(BBn), byte_size(CBn), byte_size(DBn)} of
+        {ASz, BSz, CSz, DSz}
+            when
+                ASz < ?MAX_SUBBLOCK_SIZE,
+                BSz < ?MAX_SUBBLOCK_SIZE,
+                CSz < ?MAX_SUBBLOCK_SIZE,
+                DSz < ?MAX_SUBBLOCK_SIZE ->
+            BlockBin =
+                <<
+                    ASz:16/integer,
+                    BSz:16/integer,
+                    CSz:16/integer,
+                    DSz:16/integer,
+                    ABn/binary,
+                    BBn/binary,
+                    CBn/binary,
+                    DBn/binary
+                    >>,
+            crc_validate_bin(
+                <<
+                    (compress_block(BlockBin, PressMethod))/binary,
+                    (?BLOCK_TYPE1):8/integer
+                >>
+            );
+        _ ->
+            serialise_block_aslist(PressMethod, TL)
+    end;
+serialise_block(
+    lookup,
+    {1, PressMethod},
+    [
+        A1, A2, A3, A4, A5, A6, A7, A8,
+        B1, B2, B3, B4, B5, B6, B7, B8,
+        C1, C2, C3, C4, C5, C6, C7, C8,
+        D1, D2, D3, D4, D5, D6, D7, D8
+    ] = TL
+) when PressMethod == lz4; PressMethod == zstd ->
+    ABn = term_to_binary([A1, A2, A3, A4, A5, A6, A7, A8]),
+    BBn = term_to_binary([B1, B2, B3, B4, B5, B6, B7, B8]),
+    CBn = term_to_binary([C1, C2, C3, C4, C5, C6, C7, C8]),
+    DBn = term_to_binary([D1, D2, D3, D4, D5, D6, D7, D8]),
+    case {byte_size(ABn), byte_size(BBn), byte_size(CBn), byte_size(DBn)} of
+        {ASz, BSz, CSz, DSz}
+            when
+                ASz < ?MAX_SUBBLOCK_SIZE,
+                BSz < ?MAX_SUBBLOCK_SIZE,
+                CSz < ?MAX_SUBBLOCK_SIZE,
+                DSz < ?MAX_SUBBLOCK_SIZE ->
+            BlockBin =
+                <<
+                    ASz:16/integer,
+                    BSz:16/integer,
+                    CSz:16/integer,
+                    DSz:16/integer,
+                    ABn/binary,
+                    BBn/binary,
+                    CBn/binary,
+                    DBn/binary
+                    >>,
+            crc_validate_bin(
+                <<
+                    (compress_block(BlockBin, PressMethod))/binary,
+                    (?BLOCK_TYPE2):8/integer
+                >>
+            );
+        _ ->
+            serialise_block_aslist(PressMethod, TL)
+    end;
+serialise_block(no_lookup, {1, PressMethod}, TermList)
+        when
+            length(TermList) > 2, 
+            PressMethod == zstd; PressMethod == lz4 ->
+    TopTail =
+        term_to_binary(
+            {
+                element(1, hd(TermList)),
+                element(1, lists:last(TermList))
+            }
+        ),
+    AllBin = compress_block(term_to_binary(TermList), PressMethod),
+    case byte_size(TopTail) of
+        TTSz when TTSz < ?MAX_SUBBLOCK_SIZE ->
+            crc_validate_bin(
+                <<
+                    TTSz:16/integer,
+                    TopTail/binary,
+                    AllBin/binary,
+                    (?BLOCK_TYPE3):8/integer
+                >>
+            );
+        _ ->
+            serialise_block_aslist(PressMethod, TermList)
+    end;
+serialise_block(_, {1, PressMethod}, TermList) ->
+    serialise_block_aslist(PressMethod, TermList);
+serialise_block(_, {0, PressMethod}, TermList) ->
+    serialise_block(TermList, PressMethod).
+
+-spec get_all(
+    binary(), leveled_sst:block_method()) ->
+        list(leveled_codec:ledger_kv()).
+get_all(Block, {1, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            get_all_block(CheckedBlock, PressMethod)
+        end,
+    check_block(Block, [], ExtractFun);
+get_all(Block, {0, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            deserialise_checkedblock(CheckedBlock, PressMethod)
+        end,
+    check_block(Block, [], ExtractFun).
+
+-spec get_topandtail(
+    binary(), leveled_sst:block_method()) ->
+        {
+            leveled_codec:ledger_key()|not_present,
+            leveled_codec:ledger_key()|not_present,
+            fun(() -> list(leveled_codec:ledger_kv()))
+        }.
+get_topandtail(Block, {0, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            TL = deserialise_checkedblock(CheckedBlock, PressMethod),
+            {
+                element(1, hd(TL)),
+                element(1, lists:last(TL)),
+                fun() -> TL end
+            }
+        end,
+    check_block(
+        Block,
+        {not_present, not_present, fun() -> [] end},
+        ExtractFun
+    );
+get_topandtail(Block, {1, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            get_topandtail_block(CheckedBlock, PressMethod)
+        end,
+    check_block(
+        Block,
+        {not_present, not_present, fun() -> [] end},
+        ExtractFun
+    ).
+
+-spec get_nth(
+    pos_integer(), binary(), leveled_sst:block_method()) ->
+        leveled_codec:ledger_kv()|not_present.
+get_nth(N, Block, {1, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            get_nth_item(N, CheckedBlock, PressMethod)
+        end,
+    check_block(Block, not_present, ExtractFun);
+get_nth(N, Block, {0, PressMethod}) ->
+    ExtractFun =
+        fun(CheckedBlock) ->
+            lists:nth(
+                N,
+                deserialise_checkedblock(CheckedBlock, PressMethod)
+            )
+        end,
+    check_block(Block, not_present, ExtractFun).
+
+%%%============================================================================
+%%% Internal functions - v1
+%%%============================================================================
+
+-spec crc_validate_bin(binary()) -> binary().
+crc_validate_bin(Bin) ->
+    CRC32 = leveled_sst:hmac(Bin),
+    <<Bin/binary, CRC32:32/integer>>.
+
+-spec serialise_block_aslist(
+    leveled_sst:press_method(), list(leveled_codec:ledger_kv()))
+        -> binary().
+serialise_block_aslist(PM, TermList) when PM == lz4; PM == zstd ->
+    CompressedBin =
+        <<
+            (compress_block(term_to_binary(TermList), PM))/binary,
+            (?BLOCK_TYPE0):8/integer
+        >>,
+    crc_validate_bin(CompressedBin);
+serialise_block_aslist(native, TermList) ->
+    CompressedBin =
+        <<
+            (term_to_binary(TermList, ?BINARY_SETTINGS))/binary,
+            ?BLOCK_TYPE0:8/integer
+        >>,
+    crc_validate_bin(CompressedBin);
+serialise_block_aslist(none, TermList) ->
+    UncompressedBin =
+        <<(term_to_binary(TermList))/binary, ?BLOCK_TYPE0:8/integer >>,
+    crc_validate_bin(UncompressedBin).
+
+-spec compress_block(binary(), lz4|zstd) -> binary().
+compress_block(BlockBin, lz4) ->
+    {ok, Bin} = lz4:pack(BlockBin),
+    Bin;
+compress_block(BlockBin, zstd) ->
+    zstd:compress(BlockBin).
+    
+-spec decompress_block(binary(), lz4|zstd) -> binary().
+decompress_block(BlockBin, lz4) ->
+    {ok, Bin} = lz4:unpack(BlockBin),
+    Bin;
+decompress_block(BlockBin, zstd) ->
+    zstd:decompress(BlockBin).
+
+-spec check_block(binary(), term(), fun((binary()) -> term())) -> term().
+check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
+    BinS = byte_size(Block) - 4,
+    <<TermBin:BinS/binary, CRC32:32/integer>> = Block,
+    try
+        CRC32 = leveled_sst:hmac(TermBin),
+        ExtractFun(TermBin)
+    catch
+        _Exception:_Reason ->
+            Default
+    end;
+check_block(_Block, Default, _ExtractFun) ->
+    Default.
+
+-type topandtail_response()
+    ::
+        {
+            leveled_codec:ledger_key(),
+            leveled_codec:ledger_key(),
+            fun(() -> list(leveled_codec:ledger_kv()))
+        }.
+
+-spec get_topandtail_block(
+    binary(), leveled_sst:press_method()) -> topandtail_response().
+get_topandtail_block(CheckedBlock, PressMethod) ->
+    CheckedSize = byte_size(CheckedBlock),
+    <<TypedBlock:(CheckedSize - 1)/binary, Type:8/integer>> = CheckedBlock,
+    get_topandtail_block(Type, TypedBlock, PressMethod).
+
+
+-spec get_topandtail_block(
+    block_type(), binary(), leveled_sst:press_method()) ->
+        topandtail_response().
+get_topandtail_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
+    <<TTSz:16/integer, TopTail:TTSz/binary, _/binary>> = TypedBlock,
+    {Top, Tail} = binary_to_term(TopTail),
+    {
+        Top,
+        Tail,
+        fun() -> get_all_block(?BLOCK_TYPE3, TypedBlock, PM) end
+    };
+get_topandtail_block(Type, TypedBlock, PM) ->
+    TL = get_all_block(Type, TypedBlock, PM),
+    {element(1, hd(TL)), element(1, lists:last(TL)), fun() -> TL end}.
+
+-spec get_nth_item(
+    pos_integer(), binary(), leveled_sst:press_method()) ->
+        leveled_codec:ledger_kv().
+get_nth_item(N, CheckedBlock, PressMethod) ->
+    CheckedSize = byte_size(CheckedBlock),
+    <<TypedBlock:(CheckedSize - 1)/binary, Type:8/integer>> = CheckedBlock,
+    get_nth_item(Type, N, TypedBlock, PressMethod).
+
+-spec get_nth_item(
+    block_type(), pos_integer(), binary(), leveled_sst:press_method()) ->
+        leveled_codec:ledger_kv().
+get_nth_item(Type, N, TypedBlock, PM)
+        when Type == ?BLOCK_TYPE0, (PM == zstd orelse PM == lz4) ->
+    lists:nth(N, binary_to_term(decompress_block(TypedBlock, PM)));
+get_nth_item(Type, N, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
+    lists:nth(N, binary_to_term(TypedBlock));
+get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
+    <<TTSz:16/integer, _TopTail:TTSz/binary, AllBin/binary>> = TypedBlock,
+    get_nth_item(?BLOCK_TYPE0, N, AllBin, PM);
+get_nth_item(Type, N, TypedBlock, PressMethod)
+        when Type == ?BLOCK_TYPE1; Type == ?BLOCK_TYPE2 ->
+    Width = case Type of ?BLOCK_TYPE1 -> 6; ?BLOCK_TYPE2 -> 8 end,
+    <<
+        ASz:16/integer,
+        BSz:16/integer,
+        CSz:16/integer,
+        DSz:16/integer,
+        ABn:ASz/binary,
+        BBn:BSz/binary,
+        CBn:CSz/binary,
+        DBn:DSz/binary
+    >> = decompress_block(TypedBlock, PressMethod),
+    case N of 
+        N when N =< Width ->
+            lists:nth(N, binary_to_term(ABn));
+        N when N =< (2 * Width) ->
+            lists:nth(N - Width, binary_to_term(BBn));
+        N when N =< (3 * Width) ->
+            lists:nth(N - (2 * Width), binary_to_term(CBn));
+        N ->
+            lists:nth(N - (3 * Width), binary_to_term(DBn))
+    end.
+
+-spec get_all_block(
+    binary(), leveled_sst:press_method()) ->
+        list(leveled_codec:ledger_kv()).
+get_all_block(CheckedBlock, PressMethod) ->
+    CheckedSize = byte_size(CheckedBlock),
+    <<TypedBlock:(CheckedSize - 1)/binary, Type:8/integer>> = CheckedBlock,
+    get_all_block(Type, TypedBlock, PressMethod).
+
+-spec get_all_block(
+        block_type(), binary(), leveled_sst:press_method()) ->
+            list(leveled_codec:ledger_kv()).
+get_all_block(Type, TypedBlock, PM)
+        when Type == ?BLOCK_TYPE0, (PM == zstd orelse PM == lz4) ->
+    binary_to_term(decompress_block(TypedBlock, PM));
+get_all_block(Type, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
+    binary_to_term(TypedBlock);
+get_all_block(Type, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
+    <<
+        TTSz:16/integer,
+        _TopTail:TTSz/binary,
+        AllBin/binary
+    >> = TypedBlock,
+    get_all_block(?BLOCK_TYPE0, AllBin, PM);
+get_all_block(_Type, TypedBlock, PM)
+        when PM == lz4; PM == zstd ->
+    <<
+        ASz:16/integer,
+        BSz:16/integer,
+        CSz:16/integer,
+        DSz:16/integer,
+        ABn:ASz/binary,
+        BBn:BSz/binary,
+        CBn:CSz/binary,
+        DBn:DSz/binary
+    >> = decompress_block(TypedBlock, PM),
+    leveled_sst:append(
+        binary_to_term(ABn),
+        binary_to_term(BBn),
+        binary_to_term(CBn),
+        binary_to_term(DBn)
+    ).
+
+%%%============================================================================
+%%% Internal functions - v0
+%%%============================================================================
+
+deserialise_checkedblock(Bin, lz4) when is_binary(Bin) ->
+    case lz4:unpack(Bin) of
+        {ok, Bin0} when is_binary(Bin0) ->
+            binary_to_term(Bin0)
+    end;
+deserialise_checkedblock(Bin, zstd) when is_binary(Bin) ->
+    case zstd:decompress(Bin) of
+        Bin0 when is_binary(Bin0) ->
+            binary_to_term(Bin0)
+    end;
+deserialise_checkedblock(Bin, _Other) when is_binary(Bin) ->
+    % native or none can be treated the same
+    binary_to_term(Bin).
+
+-spec serialise_block(any(), leveled_sst:press_method()) -> binary().
+%% @doc
+%% Convert term to binary
+%% Function split out to make it easier to experiment with different
+%% compression methods.  Also, perhaps standardise applictaion of CRC
+%% checks
+serialise_block(Term, lz4) ->
+    {ok, Bin} = lz4:pack(term_to_binary(Term)),
+    CRC32 = leveled_sst:hmac(Bin),
+    <<Bin/binary, CRC32:32/integer>>;
+serialise_block(Term, native) ->
+    Bin = term_to_binary(Term, ?BINARY_SETTINGS),
+    CRC32 = leveled_sst:hmac(Bin),
+    <<Bin/binary, CRC32:32/integer>>;
+serialise_block(Term, zstd) ->
+    Bin = zstd:compress(term_to_binary(Term)),
+    CRC32 = leveled_sst:hmac(Bin),
+    <<Bin/binary, CRC32:32/integer>>;
+serialise_block(Term, none) ->
+    Bin = term_to_binary(Term),
+    CRC32 = leveled_sst:hmac(Bin),
+    <<Bin/binary, CRC32:32/integer>>.
+
+%%%============================================================================
+%%% eunit tests
+%%%============================================================================
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("leveled.hrl").
+
+v1_block_test() ->
+    v1_block_tester(lookup, {1, zstd}, 24),
+    v1_block_tester(lookup, {1, zstd}, 25),
+    v1_block_tester(lookup, {1, native}, 32),
+    v1_block_tester(lookup, {1, native}, 31),
+    v1_block_tester(no_lookup, {1, zstd}, 24).
+
+v1_bigblock_test() ->
+    BigBlob = crypto:strong_rand_bytes(8192),
+    {MegaSec, Sec, MicroSec} = os:timestamp(),
+    MetaBin =
+        <<
+            MegaSec:32/integer,
+            Sec:32/integer,
+            MicroSec:32/integer,
+            BigBlob/binary
+        >>,
+    MetaLen = byte_size(MetaBin),
+    SibMetaBin =
+        <<
+            1:32/integer,
+            0:32/integer,
+            MetaLen:32/integer,
+            MetaBin/binary
+        >>,
+    v1_block_tester(lookup, {1, zstd}, 24, SibMetaBin),
+    v1_block_tester(lookup, {1, zstd}, 25, SibMetaBin),
+    v1_block_tester(lookup, {1, native}, 32, SibMetaBin),
+    v1_block_tester(lookup, {1, native}, 31, SibMetaBin),
+    v1_block_tester(no_lookup, {1, zstd}, 24, SibMetaBin).
+
+
+v1_block_tester(Lookup, BlockMethod, BlockSize) ->
+    v1_block_tester(
+        Lookup,
+        BlockMethod,
+        BlockSize,
+        <<1:32/integer, 0:32/integer, 0:32/integer>>
+    ).
+
+v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin) ->
+    B = <<"Bucket">>,
+    V =
+        leveled_head:riak_metadata_to_binary(
+            term_to_binary([{"actor1", 1}]),
+            SibMetaBin
+        ),
+    GenKeyFun =
+        fun(X) ->
+            LK =
+                {?RIAK_TAG,
+                    B,
+                    list_to_binary("Key" ++ integer_to_list(X)),
+                    null},
+            LKV =
+                leveled_codec:generate_ledgerkv(
+                    LK, X, V, byte_size(V), infinity),
+            {_Bucket, _Key, MetaValue, _Hashes, _LastMods} = LKV,
+            {LK, MetaValue}
+        end,
+    KVL = lists:map(GenKeyFun, lists:seq(1, BlockSize)),
+    Block = serialise_block(Lookup, BlockMethod, KVL),
+    LKV1 = get_nth(1, Block, BlockMethod),
+    ?assertMatch(LKV1, hd(KVL)),
+    LKV6 = get_nth(6, Block, BlockMethod),
+    ?assertMatch(LKV6, lists:nth(6, KVL)),
+    LKV7 = get_nth(7, Block, BlockMethod),
+    ?assertMatch(LKV7, lists:nth(7, KVL)),
+    LKV24 = get_nth(24, Block, BlockMethod),
+    ?assertMatch(LKV24, lists:nth(24, KVL)),
+    {Top, Tail, AllFun} = get_topandtail(Block, BlockMethod),
+    ?assertMatch(Top, element(1, hd(KVL))),
+    ?assertMatch(Tail, element(1, lists:last(KVL))),
+    ?assertMatch(KVL, AllFun()),
+    ?assertMatch(KVL, get_all(Block, BlockMethod)).
+
+
+
+-endif.

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -361,8 +361,8 @@ check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
         CRC32 = leveled_sst:hmac(TermBin),
         ExtractFun(TermBin)
     catch
-        _Exception:Reason:Trace ->
-            leveled_log:log(sst15, [Reason, Trace]),
+        _Exception:Reason ->
+            leveled_log:log(sst15, [Reason]),
             Default
     end;
 check_block(_Block, Default, _ExtractFun) ->

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -361,7 +361,8 @@ check_block(Block, Default, ExtractFun) when byte_size(Block) > 4 ->
         CRC32 = leveled_sst:hmac(TermBin),
         ExtractFun(TermBin)
     catch
-        _Exception:_Reason ->
+        _Exception:Reason:Trace ->
+            leveled_log:log(sst15, [Reason, Trace]),
             Default
     end;
 check_block(_Block, Default, _ExtractFun) ->
@@ -489,13 +490,6 @@ get_nth_item(Type, N, TypedBlock, PM)
     lists:nth(N, binary_to_term(decompress_block(TypedBlock, PM)));
 get_nth_item(Type, N, TypedBlock, _PM) when Type == ?BLOCK_TYPE0 ->
     lists:nth(N, binary_to_term(TypedBlock));
-get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE3 ->
-    <<TTSz:16/integer, _TopTail:TTSz/binary, AllBin/binary>> = TypedBlock,
-    get_nth_item(?BLOCK_TYPE0, N, AllBin, PM);
-get_nth_item(Type, N, TypedBlock, PM) when Type == ?BLOCK_TYPE4 ->
-    % No need to optimise - we don't expect to be asked for get_nth_item
-    % ona  no_lookup block
-    lists:nth(N, get_all_block(Type, TypedBlock, PM));
 get_nth_item(Type, N, TypedBlock, PressMethod)
         when 
             (Type == ?BLOCK_TYPE1 orelse Type == ?BLOCK_TYPE2 ) andalso
@@ -765,14 +759,19 @@ v1_block_tester(Lookup, BlockMethod, BlockSize, SibMetaBin, B) ->
         end,
     KVL = lists:map(GenKeyFun, lists:seq(1, BlockSize)),
     Block = serialise_block(Lookup, BlockMethod, KVL),
-    LKV1 = get_nth(1, Block, BlockMethod),
-    ?assertMatch(LKV1, hd(KVL)),
-    LKV6 = get_nth(6, Block, BlockMethod),
-    ?assertMatch(LKV6, lists:nth(6, KVL)),
-    LKV7 = get_nth(7, Block, BlockMethod),
-    ?assertMatch(LKV7, lists:nth(7, KVL)),
-    LKV24 = get_nth(24, Block, BlockMethod),
-    ?assertMatch(LKV24, lists:nth(24, KVL)),
+    case Lookup of
+        lookup ->
+            LKV1 = get_nth(1, Block, BlockMethod),
+            ?assertMatch(LKV1, hd(KVL)),
+            LKV6 = get_nth(6, Block, BlockMethod),
+            ?assertMatch(LKV6, lists:nth(6, KVL)),
+            LKV7 = get_nth(7, Block, BlockMethod),
+            ?assertMatch(LKV7, lists:nth(7, KVL)),
+            LKV24 = get_nth(24, Block, BlockMethod),
+            ?assertMatch(LKV24, lists:nth(24, KVL));
+        no_lookup ->
+            ok
+    end,
     {Top, Tail, AllFun} = get_topandtail(Block, BlockMethod),
     ?assertMatch(Top, element(1, hd(KVL))),
     ?assertMatch(Tail, element(1, lists:last(KVL))),

--- a/src/leveled_sstblock.erl
+++ b/src/leveled_sstblock.erl
@@ -580,8 +580,9 @@ get_all_block(Type, TypedBlock, PM)
         R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12,
         R13, R14, R15, R16, R17, R18, R19, R20, R21, R22, R23, R24
     ];
-get_all_block(_Type, TypedBlock, PM)
+get_all_block(Type, TypedBlock, PM)
         when
+            Type == ?BLOCK_TYPE1,
             (PM == lz4 orelse PM == zstd) ->
     <<
         ASz:16/integer,
@@ -593,12 +594,40 @@ get_all_block(_Type, TypedBlock, PM)
         CBn:CSz/binary,
         DBn:DSz/binary
     >> = decompress_block(TypedBlock, PM),
-    leveled_sst:append(
-        binary_to_term(ABn),
-        binary_to_term(BBn),
-        binary_to_term(CBn),
-        binary_to_term(DBn)
-    ).
+    [A1, A2, A3, A4, A5, A6] = binary_to_term(ABn),
+    [B1, B2, B3, B4, B5, B6] = binary_to_term(BBn),
+    [C1, C2, C3, C4, C5, C6] = binary_to_term(CBn),
+    [D1, D2, D3, D4, D5, D6] = binary_to_term(DBn),
+    [
+        A1, A2, A3, A4, A5, A6,
+        B1, B2, B3, B4, B5, B6,
+        C1, C2, C3, C4, C5, C6,
+        D1, D2, D3, D4, D5, D6
+    ];
+get_all_block(Type, TypedBlock, PM)
+        when
+            Type == ?BLOCK_TYPE2,
+            (PM == lz4 orelse PM == zstd) ->
+    <<
+        ASz:16/integer,
+        BSz:16/integer,
+        CSz:16/integer,
+        DSz:16/integer,
+        ABn:ASz/binary,
+        BBn:BSz/binary,
+        CBn:CSz/binary,
+        DBn:DSz/binary
+    >> = decompress_block(TypedBlock, PM),
+    [A1, A2, A3, A4, A5, A6, A7, A8] = binary_to_term(ABn),
+    [B1, B2, B3, B4, B5, B6, B7, B8] = binary_to_term(BBn),
+    [C1, C2, C3, C4, C5, C6, C7, C8] = binary_to_term(CBn),
+    [D1, D2, D3, D4, D5, D6, D7, D8] = binary_to_term(DBn),
+    [
+        A1, A2, A3, A4, A5, A6, A7, A8,
+        B1, B2, B3, B4, B5, B6, B7, B8,
+        C1, C2, C3, C4, C5, C6, C7, C8,
+        D1, D2, D3, D4, D5, D6, D7, D8
+    ].
 
 %%%============================================================================
 %%% Internal functions - v0

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -45,8 +45,8 @@
 from_orderedset(Table, Type) ->
     from_orderedlist(ets:tab2list(Table), Type, ?SKIP_WIDTH).
 
--spec from_orderedset(ets:tab(), tree_type(), integer()|auto)
-                                                            -> leveled_tree().
+-spec from_orderedset(
+    ets:tab(), tree_type(), integer()|auto) -> leveled_tree().
 %% @doc
 %% Convert an ETS table of Keys and Values (of table type ordered_set) into a
 %% leveled_tree of the given type.  The SkipWidth is an integer representing
@@ -63,8 +63,8 @@ from_orderedset(Table, Type, SkipWidth) ->
 from_orderedlist(OrderedList, Type) ->
     from_orderedlist(OrderedList, Type, ?SKIP_WIDTH).
 
--spec from_orderedlist(list(tuple()), tree_type(), integer()|auto)
-                                                            -> leveled_tree().
+-spec from_orderedlist(
+    list(tuple()), tree_type(), integer()|auto) -> leveled_tree().
 %% @doc
 %% Convert a list of Keys and Values (of table type ordered_set) into a
 %% leveled_tree of the given type.  The SkipWidth is an integer representing
@@ -114,7 +114,11 @@ match(Key, {skpl, _L, SkipList}) ->
     SL0 = skpl_getsublist(Key, SkipList),
     lookup_match(Key, SL0).
 
--spec search(tuple()|integer(), leveled_tree(), fun()) -> none|tuple().
+-spec search(
+    tuple()|integer(),
+    leveled_tree(),
+    fun((leveled_pmanifest:manifest_entry()) -> leveled_codec:object_key()))
+        -> none|tuple().
 %% @doc
 %% Search is used when the tree is a manifest of key ranges and it is necessary
 %% to find a rnage which may contain the key.  The StartKeyFun is used if the
@@ -162,10 +166,10 @@ search(Key, {skpl, _L, SkipList}, StartKeyFun) ->
             none
     end.
 
--spec match_range(tuple()|integer()|all,
-                    tuple()|integer()|all,
-                    leveled_tree())
-                                 -> list().
+-spec match_range(
+    tuple()|integer()|all,
+    tuple()|integer()|all,
+    leveled_tree()) -> list().
 %% @doc
 %% Return a range of value between trees from a tree associated with an
 %% exact match for the given key.  This assumes the tree contains the actual
@@ -181,11 +185,11 @@ match_range(StartRange, EndRange, Tree) ->
         end,
     match_range(StartRange, EndRange, Tree, EndRangeFun).
 
--spec match_range(tuple()|integer()|all,
-                    tuple()|integer()|all,
-                    leveled_tree(),
-                    fun())
-                                 -> list().
+-spec match_range(
+    tuple()|integer()|all,
+    tuple()|integer()|all,
+    leveled_tree(),
+    fun((term(), term(), term()) -> boolean())) -> list().
 %% @doc
 %% As match_range/3 but a function can be passed to be used when comparing the
 %5 EndKey with a key in the tree (such as leveled_codec:endkey_passed), where
@@ -197,11 +201,12 @@ match_range(StartRange, EndRange, {idxt, _L, Tree}, EndRangeFun) ->
 match_range(StartRange, EndRange, {skpl, _L, SkipList}, EndRangeFun) ->
     skpllookup_to_range(StartRange, EndRange, SkipList, EndRangeFun).
 
--spec search_range(tuple()|integer()|all,
-                    tuple()|integer()|all,
-                    leveled_tree(),
-                    fun())
-                                -> list().
+-spec search_range(
+    tuple()|integer()|all,
+    tuple()|integer()|all,
+    leveled_tree(),
+    fun((leveled_pmanifest:manifest_entry()) -> leveled_codec:object_key()))
+        -> list().
 %% @doc
 %% Extract a range from a tree, with search used when the tree is a manifest
 %% of key ranges and it is necessary to find a rnage which may encapsulate the

--- a/src/leveled_tree.erl
+++ b/src/leveled_tree.erl
@@ -429,42 +429,29 @@ idxtlookup_range_end(EndRange, {TLI, NK0, SL0}, Iter0, Output, EndRangeFun) ->
             end 
     end.
 
+skplfold_range([], _StartRange, _EndRange, Acc) ->
+    Acc;
+skplfold_range([{K, _SL}|Rest], StartRange, EndRange, Acc) when StartRange > K ->
+    skplfold_range(Rest, StartRange, EndRange, Acc);
+skplfold_range([{K, SL}|Rest], StartRange, EndRange, Acc) ->
+    case leveled_codec:endkey_passed(EndRange, K) of
+        true ->
+            [SL|Acc];
+        false ->
+            skplfold_range(Rest, StartRange, EndRange, [SL|Acc])
+    end.
+    
 
 skpllookup_to_range(StartRange, EndRange, SkipList, EndRangeFun) ->
-    FoldFun =
-        fun({K, SL}, {PassedStart, PassedEnd, Acc}) ->
-            case {PassedStart, PassedEnd} of
-                {false, false} ->
-                    case StartRange > K of
-                        true ->
-                            {PassedStart, PassedEnd, Acc};
-                        false ->
-                            case leveled_codec:endkey_passed(EndRange, K) of
-                                true ->
-                                    {true, true, [SL|Acc]};
-                                false ->
-                                    {true, false, [SL|Acc]}
-                            end
-                    end;
-                {true, false} ->
-                    case leveled_codec:endkey_passed(EndRange, K) of
-                        true ->
-                            {true, true, [SL|Acc]};
-                        false ->
-                            {true, false, [SL|Acc]}
-                    end;
-                {true, true} ->
-                    {PassedStart, PassedEnd, Acc}
-            end
-        end,
-    Lv1List = lists:reverse(element(3,
-                                    lists:foldl(FoldFun,
-                                                {false, false, []},
-                                                SkipList))),
-    Lv0List = lists:reverse(element(3,
-                                    lists:foldl(FoldFun,
-                                                {false, false, []},
-                                                lists:append(Lv1List)))),
+    Lv1List =
+        lists:reverse(
+            skplfold_range(SkipList, StartRange, EndRange, [])
+        ),
+    Lv0List =
+        lists:reverse(
+            skplfold_range(
+                lists:append(Lv1List), StartRange, EndRange, [])
+        ),
     BeforeFun =
         fun({K, _V}) ->
             K < StartRange
@@ -479,20 +466,20 @@ skpllookup_to_range(StartRange, EndRange, SkipList, EndRangeFun) ->
             end
         end,
     
-    case length(Lv0List) of
-        0 ->
+    case Lv0List of
+        [] ->
             [];
-        1 ->
-            RHS = lists:dropwhile(BeforeFun, lists:nth(1, Lv0List)),
+        [SingleList] ->
+            RHS = lists:dropwhile(BeforeFun, SingleList),
             lists:takewhile(AfterFun, RHS);
-        2 ->
-            RHSofLHL = lists:dropwhile(BeforeFun, lists:nth(1, Lv0List)),
-            LHSofRHL = lists:takewhile(AfterFun, lists:last(Lv0List)),
+        [LHList, RHList] ->
+            RHSofLHL = lists:dropwhile(BeforeFun, LHList),
+            LHSofRHL = lists:takewhile(AfterFun, RHList),
             RHSofLHL ++ LHSofRHL;
-        L ->
-            RHSofLHL = lists:dropwhile(BeforeFun, lists:nth(1, Lv0List)),
-            LHSofRHL = lists:takewhile(AfterFun, lists:last(Lv0List)),
-            MidLists = lists:sublist(Lv0List, 2, L - 2),
+        [LHL|Rest] ->
+            RHSofLHL = lists:dropwhile(BeforeFun, LHL),
+            LHSofRHL = lists:takewhile(AfterFun, lists:last(Rest)),
+            MidLists = lists:sublist(Rest, length(Rest) - 1),
             lists:append([RHSofLHL] ++ MidLists ++ [LHSofRHL])
     end.
 

--- a/src/leveled_util.erl
+++ b/src/leveled_util.erl
@@ -1,6 +1,6 @@
 %% -------- Utility Functions ---------
 %%
-%% Generally helpful funtions within leveled
+%% Generally helpful functions within leveled
 %%
 
 -module(leveled_util).

--- a/test/end_to_end/iterator_SUITE.erl
+++ b/test/end_to_end/iterator_SUITE.erl
@@ -637,6 +637,47 @@ query_count(_Config) ->
     Index1Count =
         count_termsonindex(
             BucketBin, <<"idx1_bin">>, Book1, ?KEY_ONLY),
+
+    TermCountFun = 
+        fun(_B, {T, _K}, Acc) ->
+            Cnt = maps:get(T, Acc, 0),
+            maps:put(T, Cnt, Acc)
+        end,
+
+    {async, TermRunner} = 
+        leveled_bookie:book_returnfolder(
+            Book1,
+            {
+                index_query,
+                BucketBin,
+                {TermCountFun, maps:new()},
+                {<<"idx1_bin">>, <<"0">>, <<"|">>},
+                {true, undefined}
+            }
+        ),
+
+    TermCounts = TermRunner(),
+    io:format("TermCounts ~0p", [TermCounts]),
+    lists:foreach(
+        fun(T) ->
+            {async, TR0} = 
+                leveled_bookie:book_returnfolder(
+                    Book1,
+                    {
+                        index_query,
+                        BucketBin,
+                        {fun testutil:foldkeysfun/3, []},
+                        {<<"idx1_bin">>, T, <<T/binary, "|">>},
+                        ?KEY_ONLY
+                    }
+                ),
+            ResultsForTerm = length(TR0()),
+            io:format("Results for term ~w ~w", [T, ResultsForTerm]),
+            maps:get(T, TermCounts) == ResultsForTerm
+        end,
+        maps:keys(TermCounts)
+    ),
+
     ok = leveled_bookie:book_close(Book1),
     {ok, Book2} =
         leveled_bookie:book_start(

--- a/test/end_to_end/perf_SUITE.erl
+++ b/test/end_to_end/perf_SUITE.erl
@@ -363,6 +363,16 @@ memory_usage() ->
 
 profile_app(Pids, ProfiledFun, P) ->
 
+    MinTime =
+        case P of
+            P when P == query; P == mini_query ->
+                100000;
+            P when P == head; P == load ->
+                200000;
+            _ ->
+                150000
+        end,
+
     eprof:start(),
     eprof:start_profiling(Pids),
 
@@ -370,7 +380,7 @@ profile_app(Pids, ProfiledFun, P) ->
 
     eprof:stop_profiling(),
     eprof:log(atom_to_list(P) ++ ".log"),
-    eprof:analyze(total, [{filter, [{time, 160000}]}]),
+    eprof:analyze(total, [{filter, [{time, MinTime}]}]),
     eprof:stop(),
     {ok, Analysis} = file:read_file(atom_to_list(P) ++ ".log"),
     io:format(user, "~n~s~n", [Analysis])

--- a/test/end_to_end/recovery_SUITE.erl
+++ b/test/end_to_end/recovery_SUITE.erl
@@ -48,10 +48,11 @@ end_per_suite(Config) ->
 
 replace_everything(_Config) ->
     % See https://github.com/martinsumner/leveled/issues/389
-    % Also replaces previous test which was checking the comapction process
+    % Also replaces previous test which was checking the compaction process
     % respects the journal object count passed at startup
     RootPath = testutil:reset_filestructure(),
     BackupPath = testutil:reset_filestructure("backupRE"),
+    JournalPath = filename:join(RootPath, "journal/journal_files"),
     CompPath = filename:join(RootPath, "journal/journal_files/post_compact"),
     SmallJournalCount = 7000,
     StdJournalCount = 20000,
@@ -74,13 +75,13 @@ replace_everything(_Config) ->
     {KSpcL2, V2} = 
         testutil:put_altered_indexed_objects(Book1, BKT, KSpcL1),
     ok = testutil:check_indexed_objects(Book1, BKT, KSpcL2, V2),
-    compact_and_wait(Book1, 1000),
-    compact_and_wait(Book1, 1000),
+    {ok, FileList0} =  file:list_dir(JournalPath),
+    io:format(
+        "Number of journal files before compaction ~w~n", 
+        [length(FileList0)]
+    ),
     {ok, FileList1} =  file:list_dir(CompPath),
-    io:format("Number of files after compaction ~w~n", [length(FileList1)]),
-    compact_and_wait(Book1, 1000),
-    {ok, FileList2} =  file:list_dir(CompPath),
-    io:format("Number of files after compaction ~w~n", [length(FileList2)]),
+    FileList2 = check_compaction(Book1, CompPath),
     true = FileList1 =< FileList2,
         %% There will normally be 5 journal files after 50K write then alter
         %% That may be two files with entirely altered objects - which will be
@@ -92,10 +93,14 @@ replace_everything(_Config) ->
         %% is randomisation in both the scoring and the journal size (due to
         %% jittering of parameters).
     compact_and_wait(Book1, 1000),
-    {ok, FileList3} =  file:list_dir(CompPath),
-    io:format("Number of files after compaction ~w~n", [length(FileList3)]),
-        %% By the third compaction there should be no further changes
-    true = FileList2 == FileList3,
+    {ok, FileList3a} =  file:list_dir(CompPath),
+    io:format("Number of files after compaction ~w~n", [length(FileList3a)]),
+    compact_and_wait(Book1, 1000),
+    {ok, FileList3b} =  file:list_dir(CompPath),
+    io:format("Number of files after compaction ~w~n", [length(FileList3b)]),
+        %% By the fourth compaction there should be no further changes
+    true = FileList3a == FileList3b,
+    true = 0 < FileList3b,
     {async, BackupFun} = leveled_bookie:book_hotbackup(Book1),
     ok = BackupFun(BackupPath),
 
@@ -301,6 +306,17 @@ recovery_with_samekeyupdates(_Config) ->
     ok = leveled_bookie:book_close(Book2),
     testutil:reset_filestructure(BackupPath),
     testutil:reset_filestructure().
+
+check_compaction(Book, CompPath) ->
+    compact_and_wait(Book, 1000),
+    {ok, FileList} =  file:list_dir(CompPath),
+    io:format("Number of files after compaction ~w~n", [length(FileList)]),
+    case FileList > 0 of
+        true ->
+            FileList;
+        _ ->
+            check_compaction(Book, CompPath)
+    end.
 
 same_key_rotation_withindexes(_Config) ->
     % If we have the same key - but the indexes change.  Do we consistently

--- a/test/end_to_end/riak_SUITE.erl
+++ b/test/end_to_end/riak_SUITE.erl
@@ -6,6 +6,7 @@
 -export([
         test_large_lsm_merge/1,
         basic_riak/1,
+        block_version_change/1,
         fetchclocks_modifiedbetween/1,
         crossbucket_aae/1,
         handoff/1,
@@ -21,6 +22,7 @@ suite() -> [{timetrap, {hours, 2}}].
 
 all() -> [
             basic_riak,
+            block_version_change,
             fetchclocks_modifiedbetween,
             crossbucket_aae,
             handoff,
@@ -192,14 +194,188 @@ lsm_merge_tester(LoopsPerBucket) ->
 
     ok = leveled_bookie:book_destroy(Bookie2).
 
+block_version_change(_Config) ->
+    KeyCount = 40000,
+    Bucket = {<<"Type0">>, <<"B0">>},
+    IndexCount = 8,
+
+    RootPath = testutil:reset_filestructure("blockVerion"),
+    StartOpts1 =
+        [
+            {root_path, RootPath},
+            {max_pencillercachesize, 12000},
+            {block_version, 0},
+            {sync_strategy, testutil:sync_strategy()},
+            {database_id, 32},
+            {stats_logfrequency, 5},
+            {stats_probability, 80}
+        ],
+    {ok, Bookie1} = leveled_bookie:book_start(StartOpts1),
+
+    IndexGenFun =
+        fun(ListID) ->
+            fun() ->
+                RandInt = rand:uniform(IndexCount),
+                ID = integer_to_list(ListID),
+                [
+                    {
+                        add, 
+                        list_to_binary("integer" ++ ID ++ "_int"),
+                        RandInt
+                    },
+                    {
+                        add, 
+                        list_to_binary("binary" ++ ID ++ "_bin"),
+                        <<RandInt:32/integer>>
+                    }
+                ]
+            end
+        end,
+
+    ObjList1 = 
+        testutil:generate_objects(
+            KeyCount, 
+            {fixed_binary, 1}, [],
+            crypto:strong_rand_bytes(512),
+            IndexGenFun(1),
+            Bucket
+        ),
+    testutil:riakload(Bookie1, ObjList1),
+
+    SubList1 = lists:sublist(lists:ukeysort(1, ObjList1), 1000),
+    ok = testutil:check_forlist(Bookie1, SubList1),
+
+    FoldKeysFun =  fun(_B, K, Acc) -> [K|Acc] end,
+    IntIndexFold =
+        fun(Idx, Book) ->
+            fun(IC, CountAcc) ->
+                ID = integer_to_list(Idx),
+                Index = list_to_binary("integer" ++ ID ++ "_int"),
+                {async, R} = 
+                    leveled_bookie:book_indexfold(
+                        Book,
+                        {Bucket, <<>>},
+                        {FoldKeysFun, []},
+                        {Index, IC, IC},
+                        {true, undefined}
+                    ),
+                KTL = R(),
+                CountAcc + length(KTL)
+            end
+        end,
+    BinIndexFold =
+        fun(Idx, Book) ->
+            fun(IC, CountAcc) ->
+                ID = integer_to_list(Idx),
+                Index = list_to_binary("binary" ++ ID ++ "_bin"),
+                {async, R} = 
+                    leveled_bookie:book_indexfold(
+                        Book,
+                        {Bucket, <<>>},
+                        {FoldKeysFun, []},
+                        {Index, <<IC:32/integer>>, <<IC:32/integer>>},
+                        {true, undefined}
+                    ),
+                KTL = R(),
+                CountAcc + length(KTL)
+            end
+        end,
+
+    CheckIndices =
+        fun(Bookie, ObjList, Idx) ->
+            SWA = os:timestamp(),
+            TotalIntIndexEntries =
+                lists:foldl(
+                    IntIndexFold(Idx, Bookie),
+                    0,
+                    lists:seq(1, IndexCount)
+                ),
+            io:format(
+                "~w queries returned count=~w in ~w ms~n",
+                [
+                    IndexCount, 
+                    TotalIntIndexEntries,
+                    timer:now_diff(os:timestamp(), SWA) div 1000
+                ]
+            ),
+            true = TotalIntIndexEntries == length(ObjList1),
+            SWB = os:timestamp(),
+            TotalBinIndexEntries =
+                lists:foldl(
+                    BinIndexFold(Idx, Bookie),
+                    0,
+                    lists:seq(1, IndexCount)
+                ),
+            io:format(
+                "~w queries returned count=~w in ~w ms~n",
+                [
+                    IndexCount, 
+                    TotalBinIndexEntries,
+                    timer:now_diff(os:timestamp(), SWB) div 1000
+                ]
+            ),
+            true = TotalBinIndexEntries == length(ObjList)
+        end,
+    
+    CheckIndices(Bookie1, ObjList1, 1),
+    
+    ok = leveled_bookie:book_close(Bookie1),
+
+    StartOpts2 = lists:ukeysort(1, [{block_version, 1}|StartOpts1]),
+    {ok, Bookie2} = leveled_bookie:book_start(StartOpts2),
+
+    ObjList2 = 
+        testutil:generate_objects(
+            KeyCount, 
+            {fixed_binary, KeyCount + 1}, [],
+            crypto:strong_rand_bytes(512),
+            IndexGenFun(2),
+            Bucket
+        ),
+    testutil:riakload(Bookie2, ObjList2),
+
+    SubList2 = lists:sublist(lists:ukeysort(1, ObjList2), 1000),
+    ok = testutil:check_forlist(Bookie2, SubList1),
+    ok = testutil:check_forlist(Bookie2, SubList2),
+
+    CheckIndices(Bookie2, ObjList1, 1),
+    CheckIndices(Bookie2, ObjList2, 2),
+
+    ok = leveled_bookie:book_close(Bookie2),
+    
+    {ok, Bookie3} = leveled_bookie:book_start(StartOpts1),
+
+    ObjList3 = 
+        testutil:generate_objects(
+            KeyCount, 
+            {fixed_binary, KeyCount + KeyCount + 1}, [],
+            crypto:strong_rand_bytes(512),
+            IndexGenFun(3),
+            Bucket
+        ),
+    testutil:riakload(Bookie3, ObjList3),
+
+    SubList3 = lists:sublist(lists:ukeysort(1, ObjList3), 1000),
+    ok = testutil:check_forlist(Bookie3, SubList1),
+    ok = testutil:check_forlist(Bookie3, SubList2),
+    ok = testutil:check_forlist(Bookie3, SubList3),
+
+    CheckIndices(Bookie3, ObjList1, 1),
+    CheckIndices(Bookie3, ObjList2, 2),
+    CheckIndices(Bookie3, ObjList3, 3),
+    
+    ok = leveled_bookie:book_destroy(Bookie3).
+
 basic_riak(_Config) ->
     basic_riak_tester(<<"B0">>, 640000),
     basic_riak_tester({<<"Type0">>, <<"B0">>}, 80000).
 
 basic_riak_tester(Bucket, KeyCount) ->
     % Key Count should be > 10K and divisible by 5
-    io:format("Basic riak test with Bucket ~w KeyCount ~w~n",
-                [Bucket, KeyCount]),
+    io:format(
+        "Basic riak test with Bucket ~w KeyCount ~w~n",
+        [Bucket, KeyCount]
+    ),
     IndexCount = 20,
 
     RootPath = testutil:reset_filestructure("basicRiak"),


### PR DESCRIPTION
The profile test for most different run-types has `binary_to_term/1` as a significant user of CPU time.

Within `leveled_sst`, each file is made up of slots (normally 256 of them), and each slot is divided into blocks.  The slot normally has five blocks - OuterLeft, InnerLeft, Mid, InnerRight, OuterRight.  There are two types of slots `lookup` and `no_lookup`.  In a `lookup` slot, at least one of the key/values in the slot has a hash as it is expected to be looked up directly.  With `no_lookup` slots, all KV pairs are un-hashed i.e. they are only to be fetched through range queries.

Normally, there are three access requests for information in a slot:

- `get_nth` - i.e. get the KV pair in position N, with N having been found via a hash lookup.
- `get_all` - i.e. get all KVs in the slot - such as in large range folds, bit also to fetch for merge during compaction.
- `get_range` - i.e. get only the KVs within a given range.

The larger the blocks, the more efficient the creation and storage of blocks (due to better compression), and the easier it is to `get_all` (i.e. the more that is fetched within a dingle operation.  The smaller the blocks - the less work to find the nth or a range - as fewer unneeded KV pairs are de-serialised as part of the process.

The aim is to find a way of using smaller blocks, but without paying the penalty at compaction/write time.

The proposed solution is to use multiple block types, with a format tailored for the expected use of the block.  These types of blocks should have minimal changes to enhance efficiency of access.

The block types are:

- Block Type 0 - single block, term_to_binary/1 list of KV pairs, compressed.
- Block Type 1 - a block of 24 KV pairs of type `lookup`, split into four sub-blocks of 6 KV pairs each.
- Block Type 2 - a block of 32 KV pairs of type `lookup`, split into four sub-blocks of 8 KV pairs each.
- Block Type 3 - a block of any length, of type `no_lookup`, which outside of the compressed part has the first and last keys in a mini sub-block appended as a short `term_to_binary/1` object.
- Block Type 4 - as above, but where there are 56 KV pairs in the block, and the block is split into a 24 pair LHS sub-block, an 8 pair mid sub-block and a 24 pair RHS sub-block.

Sub-blocks are all compressed together, they can only be accessed post decompression.  The block includes 2-byte sub-block lengths of every block.  Any block that does not match the requirements of Block Types 1 - 4 (including sub-blocks with length  > 64KB), will use Block Type 0.

For get_nth requests to Block Type 1 & 2, have to decompress the whole block, but only need to deserialise (i.e. `binary_to_term/1`) the relevant block.

For range requests with Block Type 3, the first and last keys can be accessed to determine whether this block and/or neighbouring blocks are required to be deserialised (without having to deserialise the block).  With Block Type 4, the same is true, but when the range is entirely within the block, by deserialising the mid sub-block first it may be possible to avoid deserialising either the left or right sub-blocks.

The Block Types were added in stages, with each stage subjected to perf_SUITE testing in turn, and compared to a control (the current develop-3.4 branch).

- v1 - introduced Block Types 0, 1 and 2;
- v2 - added Block Type 3;
- v3 - added Block Type 4.

![perfSUITE-i474](https://github.com/user-attachments/assets/4d4c660f-310b-48f3-9739-2522b313a05d)

There is a small cost at data load time from the more complex blocks, but this is counter-balanced by significant gains in other operations.

The advantages of block types are largely limited to LZ4 and ZSTD compression, as in native compression the decompression operation is coupled to the deserialisation.
